### PR TITLE
feat: create multi-agent chat ui

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,1654 +1,523 @@
-// App.tsx - Completo con todas las mejoras del presets gallery
-
-import React, {
-  useEffect,
-  useRef,
-  useState,
-  useCallback,
-  Suspense,
-  lazy,
-} from 'react';
-import { AudioVisualizerEngine } from './core/AudioVisualizerEngine';
-import { StatusBar } from './components/StatusBar';
-import { TopBar } from './components/TopBar';
-// Lazy loaded heavy components
-const LayerGrid = lazy(() => import('./components/LayerGrid'));
-const PresetControls = lazy(() => import('./components/PresetControls'));
-const ResourcesModal = lazy(() => import('./components/ResourcesModal'));
-const GlobalSettingsModal = lazy(() => import('./components/GlobalSettingsModal'));
-import { LoadedPreset } from './core/PresetLoader';
-import { setNestedValue } from './utils/objectPath';
-import { AVAILABLE_EFFECTS } from './utils/effects';
-import { gridIndexToNote, LAUNCHPAD_PRESETS } from './utils/launchpad';
-import { useAudio } from './hooks/useAudio';
-import { useMidi } from './hooks/useMidi';
-import { useLaunchpad } from './hooks/useLaunchpad';
+import React, { useEffect, useMemo, useRef, useState } from 'react';
 import './App.css';
 import './AppLayout.css';
-import VideoControls from './components/VideoControls';
-import ResourceExplorer from './components/ResourceExplorer';
-import {
-  VideoResource,
-  VideoPlaybackSettings,
-  DEFAULT_VIDEO_PLAYBACK_SETTINGS,
-} from './types/video';
-import {
-  loadVideoGallery,
-  clearVideoGalleryCache,
-  VideoProviderSettings,
-  VideoProviderId,
-} from './utils/videoProviders';
-import { clearVideoCache } from './utils/videoCache';
+import './components/chat/ChatInterface.css';
+import { ChatTopBar } from './components/chat/ChatTopBar';
+import { ChatStatusBar } from './components/chat/ChatStatusBar';
 
-interface MonitorInfo {
+type AgentKind = 'cloud' | 'local';
+
+type AgentStatus = 'Disponible' | 'Sin clave' | 'Cargando' | 'Inactivo';
+
+type AgentDefinition = {
   id: string;
-  label: string;
-  position: { x: number; y: number };
-  size: { width: number; height: number };
-  isPrimary: boolean;
-  scaleFactor: number;
-}
+  name: string;
+  provider: string;
+  description: string;
+  kind: AgentKind;
+  accent: string;
+  active: boolean;
+  status: AgentStatus;
+  apiKey?: string;
+};
 
-const RESOURCE_EXPLORER_WIDTH = 320;
+type ChatAuthor = 'system' | 'user' | 'agent';
+
+type ChatMessage = {
+  id: string;
+  author: ChatAuthor;
+  content: string;
+  timestamp: string;
+  agentId?: string;
+  status?: 'pending' | 'sent';
+  sourcePrompt?: string;
+};
+
+type ApiKeyState = {
+  openai: string;
+  anthropic: string;
+  groq: string;
+};
+
+const INITIAL_AGENTS: AgentDefinition[] = [
+  {
+    id: 'gpt-4o-mini',
+    name: 'GPT-4o mini',
+    provider: 'OpenAI',
+    description: 'Modelo ligero ideal para brainstorming visual y prototipos rápidos.',
+    kind: 'cloud',
+    accent: '#8E8DFF',
+    active: true,
+    status: 'Disponible',
+  },
+  {
+    id: 'claude-35-sonnet',
+    name: 'Claude 3.5 Sonnet',
+    provider: 'Anthropic',
+    description: 'Especialista en refinamiento, redacción y coherencia narrativa.',
+    kind: 'cloud',
+    accent: '#FFB347',
+    active: true,
+    status: 'Disponible',
+  },
+  {
+    id: 'groq-llama3-70b',
+    name: 'LLaMA3 70B',
+    provider: 'Groq',
+    description: 'Respuesta ultrarrápida para tareas analíticas y técnicas.',
+    kind: 'cloud',
+    accent: '#7FDBFF',
+    active: true,
+    status: 'Disponible',
+  },
+  {
+    id: 'local-phi3',
+    name: 'Phi-3 Mini',
+    provider: 'Local',
+    description: 'Modelo local optimizado para dispositivos ligeros.',
+    kind: 'local',
+    accent: '#4DD0E1',
+    active: false,
+    status: 'Inactivo',
+  },
+  {
+    id: 'local-mistral',
+    name: 'Mistral 7B',
+    provider: 'Local',
+    description: 'Gran equilibrio entre velocidad y creatividad en local.',
+    kind: 'local',
+    accent: '#FF8A65',
+    active: false,
+    status: 'Cargando',
+  },
+];
+
+const DEFAULT_API_KEYS: ApiKeyState = {
+  openai: '',
+  anthropic: '',
+  groq: '',
+};
+
+const QUICK_COMMANDS: string[] = [
+  'gpt, analiza este briefing y propón un storyboard.',
+  'claude, revisa el copy y hazlo más humano.',
+  'groq, genera casos de prueba para esta API.',
+  'equipo, proponed variantes de UI para el panel lateral.',
+];
+
+const formatTime = (isoString: string): string => {
+  try {
+    return new Date(isoString).toLocaleTimeString([], { hour: '2-digit', minute: '2-digit' });
+  } catch {
+    return '';
+  }
+};
+
+const buildMessageId = (prefix: string): string => `${prefix}-${Date.now()}-${Math.random().toString(16).slice(2, 8)}`;
+
+const mockAgentReply = (agent: AgentDefinition, prompt?: string): string => {
+  const safePrompt = prompt?.replace(/\s+/g, ' ').trim() ?? '';
+  const truncatedPrompt = safePrompt.length > 120 ? `${safePrompt.slice(0, 117)}…` : safePrompt;
+
+  if (agent.id.startsWith('gpt')) {
+    return `He generado una propuesta inicial basándome en «${truncatedPrompt || 'la última instrucción'}». Puedo preparar estilos CSS y componentes listos para copiar.`;
+  }
+
+  if (agent.id.startsWith('claude')) {
+    return `He revisado la entrega de los otros modelos y propongo mejoras editoriales y de tono para «${truncatedPrompt || 'el contexto actual'}».`;
+  }
+
+  if (agent.id.startsWith('groq')) {
+    return `Aquí tienes un desglose técnico rápido y una lista de validaciones clave a partir de «${truncatedPrompt || 'tu solicitud'}».`;
+  }
+
+  if (agent.kind === 'local') {
+    return `El modelo local ${agent.name} sugiere una variante optimizada trabajando con «${truncatedPrompt || 'los parámetros indicados'}».`;
+  }
+
+  return `Respuesta generada por ${agent.name}.`;
+};
 
 const App: React.FC = () => {
-  const playgroundRef = useRef<HTMLDivElement>(null);
-  const canvasRef = useRef<HTMLCanvasElement>(null);
-  const engineRef = useRef<AudioVisualizerEngine | null>(null);
-  const broadcastRef = useRef<BroadcastChannel | null>(null);
-  const [isInitialized, setIsInitialized] = useState(false);
-  const [availablePresets, setAvailablePresets] = useState<LoadedPreset[]>([]);
-  const [fps, setFps] = useState(60);
-  const [status, setStatus] = useState('Initializing...');
-  const [activeLayers, setActiveLayers] = useState<Record<string, string>>({});
-  const [selectedPreset, setSelectedPreset] = useState<LoadedPreset | null>(null);
-  const [selectedLayer, setSelectedLayer] = useState<string | null>(null);
-  const [layerPresetConfigs, setLayerPresetConfigs] = useState<Record<string, Record<string, any>>>(() => {
-    try {
-      const stored = localStorage.getItem('layerPresetConfigs');
-      return stored ? JSON.parse(stored) : {};
-    } catch {
-      return {};
-    }
-  });
-
-  const [genLabPresets, setGenLabPresets] = useState<{ name: string; config: any }[]>(() => {
-    try {
-      return JSON.parse(localStorage.getItem('genLabPresets') || '[]');
-    } catch {
-      return [];
-    }
-  });
-  const [genLabBasePreset, setGenLabBasePreset] = useState<LoadedPreset | null>(null);
-  const [fractalLabPresets, setFractalLabPresets] = useState<{ name: string; config: any }[]>(() => {
-    try {
-      return JSON.parse(localStorage.getItem('fractalLabPresets') || '[]');
-    } catch {
-      return [];
-    }
-  });
-  const [fractalLabBasePreset, setFractalLabBasePreset] = useState<LoadedPreset | null>(null);
-
-  const defaultVideoProviderSettings: VideoProviderSettings = {
-    provider: 'pexels',
-    apiKey: '',
-    refreshMinutes: 30,
-    query: 'vj loop',
-  };
-
-  const [videoProviderSettings, setVideoProviderSettings] = useState<VideoProviderSettings>(() => {
-    try {
-      const stored = localStorage.getItem('videoProviderSettings');
-      if (stored) {
-        const parsed = JSON.parse(stored);
-        return {
-          provider: (parsed.provider as VideoProviderId) || 'pexels',
-          apiKey: parsed.apiKey || '',
-          refreshMinutes: parsed.refreshMinutes || 30,
-          query: parsed.query || 'vj loop',
-        };
-      }
-    } catch (err) {
-      console.warn('Unable to restore video provider settings', err);
-    }
-    return defaultVideoProviderSettings;
-  });
-
-  const [videoGallery, setVideoGallery] = useState<VideoResource[]>(() => {
-    try {
-      const cached = localStorage.getItem('videoGalleryCache');
-      if (cached) {
-        const parsed = JSON.parse(cached);
-        return Array.isArray(parsed.items) ? parsed.items : [];
-      }
-    } catch {
-      /* ignore */
-    }
-    return [];
-  });
-  const [isRefreshingVideos, setIsRefreshingVideos] = useState(false);
-  const [selectedVideo, setSelectedVideo] = useState<VideoResource | null>(null);
-  const [selectedVideoLayer, setSelectedVideoLayer] = useState<string | null>(null);
-  const [layerVideoSettings, setLayerVideoSettings] = useState<Record<string, VideoPlaybackSettings>>(() => {
-    try {
-      const stored = localStorage.getItem('layerVideoSettings');
-      if (stored) {
-        const parsed = JSON.parse(stored);
-        return {
-          A: { ...DEFAULT_VIDEO_PLAYBACK_SETTINGS, ...(parsed.A || {}) },
-          B: { ...DEFAULT_VIDEO_PLAYBACK_SETTINGS, ...(parsed.B || {}) },
-          C: { ...DEFAULT_VIDEO_PLAYBACK_SETTINGS, ...(parsed.C || {}) },
-        };
-      }
-    } catch {
-      /* ignore */
-    }
-    return {
-      A: { ...DEFAULT_VIDEO_PLAYBACK_SETTINGS },
-      B: { ...DEFAULT_VIDEO_PLAYBACK_SETTINGS },
-      C: { ...DEFAULT_VIDEO_PLAYBACK_SETTINGS },
-    };
-  });
-
-  const layerVideoSettingsRef = useRef(layerVideoSettings);
-  const videoGalleryRef = useRef(videoGallery);
-
-  // Top bar & settings state
-  const [layerChannels, setLayerChannels] = useState<Record<string, number>>(() => {
-    const saved = localStorage.getItem('layerMidiChannels');
-    return saved ? JSON.parse(saved) : { A: 14, B: 15, C: 16 };
-  });
-  const [effectMidiNotes, setEffectMidiNotes] = useState<Record<string, number>>(() => {
-    try {
-      const stored = localStorage.getItem('effectMidiNotes');
-      if (stored) return JSON.parse(stored);
-    } catch {}
-    const defaults: Record<string, number> = {};
-    AVAILABLE_EFFECTS.forEach((eff, idx) => {
-      if (eff !== 'none') defaults[eff] = 80 + idx;
-    });
-    return defaults;
-  });
-  const [layerEffects, setLayerEffects] = useState<Record<string, { effect: string; alwaysOn: boolean; active: boolean }>>(() => {
-    try {
-      const stored = localStorage.getItem('layerEffects');
-      if (stored) {
-        const parsed = JSON.parse(stored);
-        const ensure = (layer: any) => ({
-          effect: layer?.effect || 'none',
-          alwaysOn: layer?.alwaysOn || false,
-          active: layer?.alwaysOn || false,
-        });
-        return {
-          A: ensure(parsed.A),
-          B: ensure(parsed.B),
-          C: ensure(parsed.C),
-        };
-      }
-    } catch {}
-    return {
-      A: { effect: 'none', alwaysOn: false, active: false },
-      B: { effect: 'none', alwaysOn: false, active: false },
-      C: { effect: 'none', alwaysOn: false, active: false },
-    };
-  });
-
-  const [layerVFX, setLayerVFX] = useState<Record<string, Record<string, string[]>>>(() => {
-    try {
-      const stored = localStorage.getItem('layerVFX');
-      if (stored) return JSON.parse(stored);
-    } catch {}
-    return { A: {}, B: {}, C: {} };
-  });
-
-  const [isFullscreenMode, setIsFullscreenMode] = useState(
-    () => new URLSearchParams(window.location.search).get('fullscreen') === 'true'
-  );
-
-  useEffect(() => {
-    layerVideoSettingsRef.current = layerVideoSettings;
-  }, [layerVideoSettings]);
-
-  useEffect(() => {
-    videoGalleryRef.current = videoGallery;
-  }, [videoGallery]);
-
-  const {
-    audioData,
-    audioDevices,
-    audioDeviceId,
-    setAudioDeviceId,
-    audioGain,
-    setAudioGain,
-  } = useAudio(engineRef, isInitialized);
-
-  const {
-    launchpadOutputs,
-    launchpadId,
-    setLaunchpadId,
-    launchpadOutput,
-    launchpadRunning,
-    setLaunchpadRunning,
-    launchpadPreset,
-    setLaunchpadPreset,
-    launchpadChannel,
-    setLaunchpadChannel,
-    launchpadNote,
-    setLaunchpadNote,
-    launchpadSmoothness,
-    setLaunchpadSmoothness,
-    launchpadText,
-    setLaunchpadText,
-  } = useLaunchpad(audioData, canvasRef);
-
-  const updateVideoProviderSettings = useCallback(
-    (updates: Partial<VideoProviderSettings>) => {
-      setVideoProviderSettings(prev => ({ ...prev, ...updates }));
+  const [agents, setAgents] = useState<AgentDefinition[]>(INITIAL_AGENTS);
+  const [apiKeys, setApiKeys] = useState<ApiKeyState>(DEFAULT_API_KEYS);
+  const [messages, setMessages] = useState<ChatMessage[]>([
+    {
+      id: buildMessageId('system'),
+      author: 'system',
+      content: 'Bienvenido a JungleMonk.AI Control Hub. Activa tus modelos y coordina la conversación multimodal desde un solo lugar.',
+      timestamp: new Date().toISOString(),
     },
-    []
+  ]);
+  const [draft, setDraft] = useState('');
+  const scheduledResponsesRef = useRef<Set<string>>(new Set());
+
+  const activeAgents = useMemo(() => agents.filter(agent => agent.active), [agents]);
+  const agentMap = useMemo(() => {
+    const map = new Map<string, AgentDefinition>();
+    agents.forEach(agent => map.set(agent.id, agent));
+    return map;
+  }, [agents]);
+
+  const pendingResponses = useMemo(
+    () => messages.filter(message => message.author === 'agent' && message.status === 'pending').length,
+    [messages],
   );
 
-  const refreshVideoGallery = useCallback(
-    async (force = false) => {
-      setIsRefreshingVideos(true);
-      try {
-        const videos = await loadVideoGallery(videoProviderSettings, force);
-        setVideoGallery(videos);
-        engineRef.current?.setVideoRegistry(videos);
-        setStatus(`Video gallery updated (${videos.length} items)`);
-      } catch (error) {
-        console.error('Failed to refresh video gallery', error);
-        setStatus('Error loading video gallery');
-      } finally {
-        setIsRefreshingVideos(false);
-      }
-    },
-    [videoProviderSettings]
-  );
+  useEffect(() => {
+    const timeouts: Array<ReturnType<typeof setTimeout>> = [];
 
-  const handleClearVideoCache = useCallback(async () => {
-    try {
-      clearVideoGalleryCache();
-      await clearVideoCache();
-      setVideoGallery([]);
-      setStatus('Video cache cleared');
-      await refreshVideoGallery(true);
-    } catch (error) {
-      console.error('Failed to clear video cache', error);
-      setStatus('Error clearing video cache');
-    }
-  }, [refreshVideoGallery]);
+    messages
+      .filter(message => message.author === 'agent' && message.status === 'pending' && !scheduledResponsesRef.current.has(message.id))
+      .forEach(message => {
+        scheduledResponsesRef.current.add(message.id);
+        const agent = message.agentId ? agentMap.get(message.agentId) : undefined;
 
-  const handleVideoSettingsChange = useCallback(
-    (updates: Partial<VideoPlaybackSettings>) => {
-      if (!selectedVideoLayer) return;
-      setLayerVideoSettings(prev => {
-        const current = prev[selectedVideoLayer] || DEFAULT_VIDEO_PLAYBACK_SETTINGS;
-        return {
-          ...prev,
-          [selectedVideoLayer]: { ...current, ...updates },
-        };
+        timeouts.push(
+          setTimeout(() => {
+            if (!agent) {
+              return;
+            }
+
+            setMessages(prev =>
+              prev.map(item =>
+                item.id === message.id
+                  ? {
+                      ...item,
+                      status: 'sent',
+                      content: mockAgentReply(agent, message.sourcePrompt),
+                    }
+                  : item,
+              ),
+            );
+
+            scheduledResponsesRef.current.delete(message.id);
+          }, 700 + Math.random() * 1200),
+        );
       });
-      engineRef.current?.updateLayerVideoSettings(selectedVideoLayer, updates);
-    },
-    [selectedVideoLayer]
-  );
-
-  const handleAddVideoToLayer = useCallback(
-    (videoId: string, layerId: string) => {
-      const video = videoGalleryRef.current.find(item => item.id === videoId);
-      if (video) {
-        setStatus(`${video.title} assigned to Layer ${layerId}`);
-      }
-    },
-    []
-  );
-
-  const handleRemoveVideoFromLayer = useCallback((videoId: string, layerId: string) => {
-    const video = videoGalleryRef.current.find(item => item.id === videoId);
-    if (video) {
-      setStatus(`${video.title} removed from Layer ${layerId}`);
-    }
-  }, []);
-
-  const handleLaunchpadToggle = useCallback(() => {
-    console.log('🎯 LaunchPad toggle requested');
-
-    // Validar que hay un dispositivo disponible
-    if (!launchpadOutput) {
-      console.warn('⚠️ No LaunchPad device available for toggle');
-      return;
-    }
-
-    // Validar que el dispositivo está conectado
-    if (launchpadOutput.state !== 'connected') {
-      console.warn('⚠️ LaunchPad device not connected:', launchpadOutput.state);
-      return;
-    }
-
-    console.log('✅ LaunchPad toggle válido, ejecutando...');
-    setLaunchpadRunning(prev => {
-      const newState = !prev;
-      console.log(`🔄 LaunchPad state: ${prev} → ${newState}`);
-      return newState;
-    });
-  }, [launchpadOutput, setLaunchpadRunning]);
-
-  const {
-    midiDevices,
-    midiDeviceId,
-    setMidiDeviceId,
-    midiActive,
-    bpm,
-    beatActive,
-    midiTrigger,
-    setMidiTrigger,
-    midiClockSettings,
-    updateClockSettings,
-    setInternalBpm,
-    internalBpm,
-    clockStable,
-    currentMeasure,
-    currentBeat,
-  } = useMidi({
-    isFullscreenMode,
-    availablePresets,
-    layerChannels,
-    layerEffects,
-    setLayerEffects,
-    effectMidiNotes,
-    engineRef,
-  });
-  const [isSettingsOpen, setIsSettingsOpen] = useState(false);
-  const [isResourcesOpen, setResourcesOpen] = useState(false);
-  const [monitors, setMonitors] = useState<MonitorInfo[]>([]);
-  const [monitorRoles, setMonitorRoles] = useState<Record<string, 'main' | 'secondary' | 'none'>>(() => {
-    try {
-      return JSON.parse(localStorage.getItem('monitorRoles') || '{}');
-    } catch {
-      return {} as Record<string, 'main' | 'secondary' | 'none'>;
-    }
-  });
-  const storedTemplate = (() => {
-    try {
-      return JSON.parse(localStorage.getItem('customTextTemplate') || '{}');
-    } catch {
-      return {};
-    }
-  })();
-  const [glitchTextPads, setGlitchTextPads] = useState<number>(storedTemplate.count || parseInt(localStorage.getItem('glitchTextPads') || '1'));
-  const [customTextContents, setCustomTextContents] = useState<string[]>(storedTemplate.texts || []);
-  const [emptyPads, setEmptyPads] = useState<number>(() => parseInt(localStorage.getItem('emptyPads') || '1'));
-  const [clearSignal, setClearSignal] = useState(0);
-  const [hideUiHotkey, setHideUiHotkey] = useState(() => localStorage.getItem('hideUiHotkey') || 'F10');
-  const [isUiHidden, setIsUiHidden] = useState(false);
-  const [fullscreenHotkey, setFullscreenHotkey] = useState(() => localStorage.getItem('fullscreenHotkey') || 'F9');
-  const [exitFullscreenHotkey, setExitFullscreenHotkey] = useState(() => localStorage.getItem('exitFullscreenHotkey') || 'F11');
-  const [fullscreenByDefault, setFullscreenByDefault] = useState(() => localStorage.getItem('fullscreenByDefault') !== 'false');
-  const [startMaximized, setStartMaximized] = useState(() => localStorage.getItem('startMaximized') !== 'false');
-  const [startMonitor, setStartMonitor] = useState<string | null>(() => localStorage.getItem('startMonitor'));
-  const [canvasBrightness, setCanvasBrightness] = useState(() => parseFloat(localStorage.getItem('canvasBrightness') || '1'));
-  const [canvasVibrance, setCanvasVibrance] = useState(() => parseFloat(localStorage.getItem('canvasVibrance') || '1'));
-  const [canvasBackground, setCanvasBackground] = useState(() => localStorage.getItem('canvasBackground') || '#000000');
-  const [visualsPath, setVisualsPath] = useState(
-    () => localStorage.getItem('visualsPath') || './src/presets/'
-  );
-
-  useEffect(() => {
-    const channel = new BroadcastChannel('av-sync');
-    broadcastRef.current = channel;
-    return () => channel.close();
-  }, []);
-
-  // Persist selected devices across sessions
-  useEffect(() => {
-    const savedAudio = localStorage.getItem('selectedAudioDevice');
-    const savedMidi = localStorage.getItem('selectedMidiDevice');
-    const savedMonitorRoles = localStorage.getItem('monitorRoles');
-    
-    if (savedAudio) setAudioDeviceId(savedAudio);
-    if (savedMidi) setMidiDeviceId(savedMidi);
-    if (savedMonitorRoles) {
-      try {
-        setMonitorRoles(JSON.parse(savedMonitorRoles));
-      } catch (e) {
-        console.warn('Error parsing saved monitor roles:', e);
-      }
-    }
-  }, []);
-
-  // Persist monitor roles
-  useEffect(() => {
-    localStorage.setItem('monitorRoles', JSON.stringify(monitorRoles));
-  }, [monitorRoles]);
-
-  useEffect(() => {
-    localStorage.setItem('startMaximized', startMaximized.toString());
-  }, [startMaximized]);
-
-  useEffect(() => {
-    localStorage.setItem('fullscreenHotkey', fullscreenHotkey);
-  }, [fullscreenHotkey]);
-
-  useEffect(() => {
-    localStorage.setItem('exitFullscreenHotkey', exitFullscreenHotkey);
-  }, [exitFullscreenHotkey]);
-
-  useEffect(() => {
-    localStorage.setItem('fullscreenByDefault', fullscreenByDefault.toString());
-  }, [fullscreenByDefault]);
-
-  useEffect(() => {
-    localStorage.setItem('canvasBrightness', canvasBrightness.toString());
-  }, [canvasBrightness]);
-
-  useEffect(() => {
-    localStorage.setItem('canvasVibrance', canvasVibrance.toString());
-  }, [canvasVibrance]);
-
-  useEffect(() => {
-    localStorage.setItem('canvasBackground', canvasBackground);
-  }, [canvasBackground]);
-
-  useEffect(() => {
-    localStorage.setItem('visualsPath', visualsPath);
-  }, [visualsPath]);
-
-  useEffect(() => {
-    try {
-      localStorage.setItem('videoProviderSettings', JSON.stringify(videoProviderSettings));
-    } catch (err) {
-      console.warn('Failed to persist video provider settings:', err);
-    }
-  }, [videoProviderSettings]);
-
-  useEffect(() => {
-    try {
-      localStorage.setItem('layerVideoSettings', JSON.stringify(layerVideoSettings));
-    } catch (err) {
-      console.warn('Failed to persist layer video settings:', err);
-    }
-    if (engineRef.current) {
-      Object.entries(layerVideoSettings).forEach(([layerId, settings]) => {
-        engineRef.current?.updateLayerVideoSettings(layerId, settings);
-      });
-    }
-  }, [layerVideoSettings]);
-
-  useEffect(() => {
-    if (!isFullscreenMode && midiTrigger) {
-      broadcastRef.current?.postMessage({ type: 'midiTrigger', data: midiTrigger });
-    }
-  }, [midiTrigger, isFullscreenMode]);
-
-  useEffect(() => {
-    if (startMonitor) {
-      localStorage.setItem('startMonitor', startMonitor);
-    } else {
-      localStorage.removeItem('startMonitor');
-    }
-  }, [startMonitor]);
-
-  useEffect(() => {
-    (window as any).electronAPI?.applySettings({
-      maximize: startMaximized,
-      monitorId: startMonitor || undefined
-    });
-  }, [startMaximized, startMonitor]);
-
-  useEffect(() => {
-    refreshVideoGallery();
-  }, [refreshVideoGallery]);
-
-  useEffect(() => {
-    if (!videoProviderSettings.refreshMinutes) return;
-    const interval = window.setInterval(() => {
-      refreshVideoGallery();
-    }, videoProviderSettings.refreshMinutes * 60_000);
-    return () => window.clearInterval(interval);
-  }, [videoProviderSettings.refreshMinutes, refreshVideoGallery]);
-
-  useEffect(() => {
-    if (engineRef.current) {
-      engineRef.current.setVideoRegistry(videoGallery);
-    }
-  }, [videoGallery]);
-
-  // Persist preset configs per layer/visual automatically
-  useEffect(() => {
-    try {
-      localStorage.setItem('layerPresetConfigs', JSON.stringify(layerPresetConfigs));
-      broadcastRef.current?.postMessage({ type: 'layerPresetConfigs', data: layerPresetConfigs });
-    } catch (e) {
-      console.warn('Failed to persist layer preset configs:', e);
-    }
-  }, [layerPresetConfigs]);
-
-  useEffect(() => {
-    try {
-      localStorage.setItem('layerEffects', JSON.stringify(layerEffects));
-    } catch (e) {
-      console.warn('Failed to persist layer effects:', e);
-    }
-  }, [layerEffects]);
-
-  useEffect(() => {
-    try {
-      localStorage.setItem('layerVFX', JSON.stringify(layerVFX));
-    } catch (e) {
-      console.warn('Failed to persist layer VFX:', e);
-    }
-  }, [layerVFX]);
-
-  const activeEffectClasses = Object.entries(layerEffects)
-    .filter(([, cfg]) => cfg.active && cfg.effect !== 'none')
-    .map(([, cfg]) => `effect-${cfg.effect}`)
-    .join(' ');
-
-  useEffect(() => {
-    try {
-      localStorage.setItem('effectMidiNotes', JSON.stringify(effectMidiNotes));
-    } catch (e) {
-      console.warn('Failed to persist effect MIDI notes:', e);
-    }
-  }, [effectMidiNotes]);
-
-
-  // Enumerar monitores disponibles usando Electron o Tauri
-  const refreshMonitors = useCallback(async () => {
-    try {
-      let mapped: MonitorInfo[] = [];
-
-      if ((window as any).electronAPI?.getDisplays) {
-        const displays = await (window as any).electronAPI.getDisplays();
-        mapped = displays.map((d: any) => {
-          const scale = d.scaleFactor || 1;
-          const width = d.bounds.width * scale;
-          const height = d.bounds.height * scale;
-          return {
-            id: d.id.toString(),
-            label: `${d.label} (${width}x${height})`,
-            position: { x: d.bounds.x, y: d.bounds.y },
-            size: { width, height },
-            isPrimary: d.primary,
-            scaleFactor: scale
-          };
-        });
-      } else if ((window as any).__TAURI__) {
-        const { availableMonitors, primaryMonitor } = await import('@tauri-apps/api/window');
-        const [displays, primary] = await Promise.all([
-          availableMonitors(),
-          primaryMonitor()
-        ]);
-        mapped = displays.map((d: any, index: number) => {
-          const width = d.size.width;
-          const height = d.size.height;
-          const id = `${d.name || 'monitor'}-${index}`;
-          return {
-            id,
-            label: `${d.name || `Monitor ${index + 1}`} (${width}x${height})`,
-            position: { x: d.position.x, y: d.position.y },
-            size: { width, height },
-            isPrimary: primary ? d.name === primary.name : index === 0,
-            scaleFactor: d.scaleFactor || 1
-          };
-        });
-      } else {
-        const width = window.screen.width;
-        const height = window.screen.height;
-        mapped = [{
-          id: 'screen',
-          label: `Screen (${width}x${height})`,
-          position: { x: 0, y: 0 },
-          size: { width, height },
-          isPrimary: true,
-          scaleFactor: window.devicePixelRatio || 1
-        }];
-      }
-
-      mapped.sort((a, b) => {
-        if (a.isPrimary !== b.isPrimary) return a.isPrimary ? -1 : 1;
-        return a.position.x - b.position.x;
-      });
-
-      setMonitors(mapped);
-      setMonitorRoles(prev => {
-        const roles: Record<string, 'main' | 'secondary' | 'none'> = {};
-        mapped.forEach(m => {
-          roles[m.id] = prev[m.id] || 'none';
-        });
-        if (!Object.values(roles).some(r => r === 'main')) {
-          const primary = mapped.find(m => m.isPrimary) || mapped[0];
-          if (primary) roles[primary.id] = 'main';
-        }
-        const newMain = Object.entries(roles).find(([, r]) => r === 'main')?.[0];
-        if (newMain) setStartMonitor(newMain);
-        return roles;
-      });
-    } catch (e) {
-      console.warn('Error loading monitors:', e);
-    }
-  }, []);
-
-  useEffect(() => {
-    refreshMonitors();
-  }, [refreshMonitors]);
-
-  useEffect(() => {
-    if (isSettingsOpen) refreshMonitors();
-  }, [isSettingsOpen, refreshMonitors]);
-
-  useEffect(() => {
-    const handler = () => {
-      const param = new URLSearchParams(window.location.search).get('fullscreen') === 'true';
-      setIsFullscreenMode(param || !!document.fullscreenElement);
-      window.dispatchEvent(new Event('resize'));
-    };
-    document.addEventListener('fullscreenchange', handler);
-    return () => document.removeEventListener('fullscreenchange', handler);
-  }, []);
-
-  useEffect(() => {
-    window.dispatchEvent(new Event('resize'));
-  }, [isFullscreenMode]);
-
-  useEffect(() => {
-    if (isFullscreenMode) {
-      setIsUiHidden(true);
-    } else {
-      setIsUiHidden(false);
-    }
-  }, [isFullscreenMode]);
-
-  useEffect(() => {
-    const api = (window as any).electronAPI;
-    if (!api?.onMainLeaveFullscreen) return;
-    const handler = () => {
-      setIsFullscreenMode(false);
-      engineRef.current?.setMultiMonitorMode(false);
-      localStorage.setItem('multiMonitorMode', 'false');
-    };
-    api.onMainLeaveFullscreen(handler);
-    return () => {
-      api.removeMainLeaveFullscreenListener?.();
-    };
-  }, []);
-
-  // Inicializar el engine
-  useEffect(() => {
-    const initEngine = async () => {
-      if (!playgroundRef.current) {
-        console.error('❌ Playground ref is null');
-        return;
-      }
-
-      console.log('🔧 Playground found, initializing engine...');
-      try {
-        setStatus('Loading presets...');
-        const engine = new AudioVisualizerEngine(playgroundRef.current, { glitchTextPads, visualsPath });
-        await engine.initialize();
-        engineRef.current = engine;
-        canvasRef.current = engine.getLayerCanvas('A') || null;
-        setGenLabBasePreset(engine.getGenLabBasePreset());
-        setFractalLabBasePreset(engine.getFractalLabBasePreset());
-
-        engine.setVideoRegistry(videoGalleryRef.current);
-        Object.entries(layerVideoSettingsRef.current).forEach(([layerId, settings]) => {
-          engine.updateLayerVideoSettings(layerId, settings);
-        });
-
-        const multiMonitor = localStorage.getItem('multiMonitorMode') === 'true';
-        engine.setMultiMonitorMode(multiMonitor);
-
-        let presets = engine.getAvailablePresets();
-        if (emptyPads !== 1) {
-          presets = await engine.updateEmptyTemplates(emptyPads);
-        }
-        if (customTextContents.length > 0) {
-          presets = await engine.updateCustomTextTemplates(glitchTextPads, customTextContents);
-        }
-        if (genLabPresets.length > 0) {
-          presets = await engine.updateGenLabPresets(genLabPresets);
-        }
-        if (fractalLabPresets.length > 0) {
-          presets = await engine.updateFractalLabPresets(fractalLabPresets);
-        }
-        setAvailablePresets(presets);
-        setIsInitialized(true);
-        setStatus('Ready');
-        console.log(`✅ Engine initialized with ${presets.length} presets`);
-      } catch (error) {
-        console.error('❌ Failed to initialize engine:', error);
-        setStatus('Error during initialization');
-      }
-    };
-
-    console.log('🚀 Starting app initialization...');
-    initEngine();
 
     return () => {
-      if (engineRef.current) {
-        engineRef.current.dispose();
-      }
+      timeouts.forEach(clearTimeout);
     };
-  }, [glitchTextPads, visualsPath]);
+  }, [messages, agentMap]);
 
+  const handleToggleAgent = (agentId: string) => {
+    setAgents(prev =>
+      prev.map(agent =>
+        agent.id === agentId
+          ? {
+              ...agent,
+              active: !agent.active,
+              status: !agent.active ? 'Disponible' : agent.status,
+            }
+          : agent,
+      ),
+    );
+  };
 
-  // Activar capas almacenadas en modo fullscreen
-  useEffect(() => {
-    if (isFullscreenMode && isInitialized && engineRef.current) {
-      const stored = localStorage.getItem('activeLayers');
-      if (stored) {
-        const layers = JSON.parse(stored) as Record<string, string>;
-        Promise.all(
-          Object.entries(layers).map(([layerId, presetId]) =>
-            engineRef.current!.activateLayerPreset(layerId, presetId)
-          )
-        ).catch(err => {
-          console.error('Failed to activate stored layers', err);
-        });
-      }
-    }
-  }, [isFullscreenMode, isInitialized]);
+  const handleApiKeyChange = (provider: keyof ApiKeyState, value: string) => {
+    setApiKeys(prev => ({ ...prev, [provider]: value }));
+    setAgents(prev =>
+      prev.map(agent =>
+        agent.provider.toLowerCase() === provider
+          ? {
+              ...agent,
+              apiKey: value,
+              status: value ? 'Disponible' : 'Sin clave',
+            }
+          : agent,
+      ),
+    );
+  };
 
-  // Cerrar ventana fullscreen con ESC o hotkey configurable
-  useEffect(() => {
-    if (isFullscreenMode) {
-      const handler = (e: KeyboardEvent) => {
-        if (
-          e.key === 'Escape' ||
-          e.key.toUpperCase() === exitFullscreenHotkey.toUpperCase()
-        ) {
-          if ((window as any).__TAURI__) {
-            window.close();
-          } else if (document.fullscreenElement) {
-            document.exitFullscreen();
-          }
-        }
-      };
-      window.addEventListener('keydown', handler);
-      return () => window.removeEventListener('keydown', handler);
-    }
-  }, [isFullscreenMode, exitFullscreenHotkey]);
+  const handleCommandInsert = (command: string) => {
+    setDraft(prev => (prev ? `${prev}\n${command}` : command));
+  };
 
-  // Monitor FPS
-  useEffect(() => {
-    let frameCount = 0;
-    let lastTime = Date.now();
-    
-    const updateFPS = () => {
-      frameCount++;
-      const currentTime = Date.now();
-      if (currentTime - lastTime >= 1000) {
-        setFps(frameCount);
-        frameCount = 0;
-        lastTime = currentTime;
-      }
-      requestAnimationFrame(updateFPS);
-    };
-
-    if (isInitialized) {
-      updateFPS();
-    }
-  }, [isInitialized]);
-
-  // Persistir capas activas para modo fullscreen
-  useEffect(() => {
-    localStorage.setItem('activeLayers', JSON.stringify(activeLayers));
-    broadcastRef.current?.postMessage({ type: 'activeLayers', data: activeLayers });
-  }, [activeLayers]);
-
-  // Toggle UI visibility with configurable hotkey
-  useEffect(() => {
-    const handler = (e: KeyboardEvent) => {
-      if (e.key.toUpperCase() === hideUiHotkey.toUpperCase()) {
-        e.preventDefault();
-        setIsUiHidden(prev => !prev);
-      }
-    };
-    window.addEventListener('keydown', handler);
-    return () => window.removeEventListener('keydown', handler);
-  }, [hideUiHotkey]);
-
-  // Recalcular el tamano del canvas al mostrar/ocultar la UI
-  useEffect(() => {
-    window.dispatchEvent(new Event('resize'));
-  }, [isUiHidden]);
-
-  // Funcion de debug para verificar el grid completo
-  const debugLaunchpadGrid = () => {
-    if (!launchpadOutput) {
-      console.log('No hay Launchpad conectado');
+  const handleSend = () => {
+    const trimmed = draft.trim();
+    if (!trimmed) {
       return;
     }
 
-    console.log('🔍 Test de debug del grid completo 8x8...');
-
-    // Test secuencial de todos los pads
-    for (let i = 0; i < 64; i++) {
-      setTimeout(() => {
-        const row = Math.floor(i / 8);
-        const col = i % 8;
-        const note = gridIndexToNote(i);
-        console.log(`Encendiendo pad ${i} (fila ${row}, columna ${col}, nota ${note})`);
-
-        launchpadOutput.send([0x90, note, 60 + (i % 64)]);
-
-        setTimeout(() => {
-          launchpadOutput.send([0x90, note, 0]);
-        }, 100);
-
-      }, i * 50);
-    }
-  };
-
-  // Exponer funcion de debug globalmente
-  (window as any).debugLaunchpadGrid = debugLaunchpadGrid;
-
-  // Handlers
-  const handleFullScreen = useCallback(async () => {
-    if ((window as any).electronAPI) {
-      localStorage.setItem('activeLayers', JSON.stringify(activeLayers));
-      const mainId = Object.entries(monitorRoles).find(([, role]) => role === 'main')?.[0];
-      const secondaryIds = Object.entries(monitorRoles)
-        .filter(([, role]) => role === 'secondary')
-        .map(([id]) => id);
-      const ids = [
-        ...(mainId ? [mainId] : []),
-        ...secondaryIds
-      ];
-      if (ids.length === 0) {
-        setStatus('Error: No monitors selected');
-        return;
-      }
-      if (isFullscreenMode) {
-        engineRef.current?.setMultiMonitorMode(false);
-        localStorage.setItem('multiMonitorMode', 'false');
-      } else {
-        const multi = ids.length > 1;
-        engineRef.current?.setMultiMonitorMode(multi);
-        localStorage.setItem('multiMonitorMode', multi ? 'true' : 'false');
-      }
-      try {
-        await (window as any).electronAPI.toggleFullscreen(ids);
-        setStatus(`Fullscreen toggled en ${ids.length} monitor(es)`);
-        setIsFullscreenMode(!isFullscreenMode);
-      } catch (err) {
-        console.error('Fullscreen error:', err);
-        setStatus('Error: Fullscreen could not be enabled');
-      }
-    } else if ((window as any).__TAURI__) {
-      localStorage.setItem('activeLayers', JSON.stringify(activeLayers));
-
-      try {
-        const { WebviewWindow } = await import(
-          /* @vite-ignore */ '@tauri-apps/api/window'
-        );
-
-        let activeMonitors = monitors.filter(
-          m => monitorRoles[m.id] === 'main' || monitorRoles[m.id] === 'secondary'
-        );
-        const mainId = Object.entries(monitorRoles).find(([, role]) => role === 'main')?.[0];
-        if (mainId) {
-          const idx = activeMonitors.findIndex(m => m.id === mainId);
-          if (idx > 0) {
-            const [main] = activeMonitors.splice(idx, 1);
-            activeMonitors.unshift(main);
-          }
-        }
-
-        if (activeMonitors.length === 0) {
-          setStatus('Error: No monitors selected');
-          return;
-        }
-        if (isFullscreenMode) {
-          engineRef.current?.setMultiMonitorMode(false);
-          localStorage.setItem('multiMonitorMode', 'false');
-        } else {
-          const multi = activeMonitors.length > 1;
-          engineRef.current?.setMultiMonitorMode(multi);
-          localStorage.setItem('multiMonitorMode', multi ? 'true' : 'false');
-        }
-
-        console.log(`🎯 Abriendo fullscreen en ${activeMonitors.length} monitores`);
-
-        activeMonitors.forEach((monitor, index) => {
-          const label = `fullscreen-${monitor.id}-${Date.now()}-${index}`;
-
-          const windowOptions = {
-            url: `index.html?fullscreen=true&monitor=${monitor.id}`,
-            x: monitor.position.x,
-            y: monitor.position.y,
-            width: monitor.size.width,
-            height: monitor.size.height,
-            decorations: false,
-            fullscreen: fullscreenByDefault,
-            skipTaskbar: true,
-            resizable: false,
-            title: `Visual Output - ${monitor.label}`,
-            alwaysOnTop: false
-          };
-
-          console.log(`🖥️ Creando ventana en ${monitor.label}:`, windowOptions);
-
-          try {
-            new WebviewWindow(label, windowOptions);
-          } catch (windowError) {
-            console.error(`Error creating window for ${monitor.label}:`, windowError);
-            setStatus(`Error: Could not create window on ${monitor.label}`);
-          }
-        });
-
-        setStatus(`Fullscreen activo en ${activeMonitors.length} monitor(es)`);
-        setIsFullscreenMode(!isFullscreenMode);
-      } catch (err) {
-        console.error('Fullscreen error:', err);
-        setStatus('Error: Fullscreen could not be enabled');
-      }
-    } else {
-      const elem: any = document.documentElement;
-      if (elem.requestFullscreen) {
-        await elem.requestFullscreen();
-        setIsFullscreenMode(true);
-        setStatus('Fullscreen activado (navegador)');
-      } else {
-        setStatus('Error: Fullscreen not available');
-      }
-    }
-  }, [activeLayers, monitorRoles, monitors, isFullscreenMode]);
-
-  useEffect(() => {
-    if (isFullscreenMode) return;
-    const handler = (e: KeyboardEvent) => {
-      if (e.key.toUpperCase() === fullscreenHotkey.toUpperCase()) {
-        e.preventDefault();
-        handleFullScreen();
-      }
-    };
-    window.addEventListener('keydown', handler);
-    return () => window.removeEventListener('keydown', handler);
-  }, [handleFullScreen, fullscreenHotkey, isFullscreenMode]);
-
-  const handleClearAll = () => {
-    if (!engineRef.current) return;
-    ['A', 'B', 'C'].forEach(layerId => engineRef.current?.deactivateLayerPreset(layerId));
-    engineRef.current.clearRenderer();
-    setActiveLayers({});
-    setSelectedPreset(null);
-    setSelectedLayer(null);
-    setSelectedVideo(null);
-    setSelectedVideoLayer(null);
-    setClearSignal(prev => prev + 1);
-    setStatus('Capas limpiadas');
-    setLayerEffects(prev => ({
-      A: { ...prev.A, active: prev.A.alwaysOn },
-      B: { ...prev.B, active: prev.B.alwaysOn },
-      C: { ...prev.C, active: prev.C.alwaysOn }
-    }));
-  };
-
-  const handleToggleUi = () => {
-    setIsUiHidden(prev => !prev);
-  };
-
-  const handleLayerEffectChange = (layerId: string, effect: string) => {
-    setLayerEffects(prev => ({
-      ...prev,
-      [layerId]: { ...prev[layerId], effect, active: prev[layerId].alwaysOn }
-    }));
-  };
-
-  const handleLayerEffectToggle = (layerId: string, alwaysOn: boolean) => {
-    setLayerEffects(prev => ({
-      ...prev,
-      [layerId]: { ...prev[layerId], alwaysOn, active: alwaysOn }
-    }));
-  };
-
-  const handleEffectMidiNoteChange = (effect: string, note: number) => {
-    setEffectMidiNotes(prev => ({ ...prev, [effect]: note }));
-  };
-
-  const applyPresetConfig = (
-    engine: AudioVisualizerEngine,
-    layerId: string,
-    cfg: Record<string, any>,
-    prefix = ''
-  ) => {
-    Object.entries(cfg).forEach(([key, value]) => {
-      const path = prefix ? `${prefix}.${key}` : key;
-      if (value && typeof value === 'object' && !Array.isArray(value)) {
-        applyPresetConfig(engine, layerId, value as Record<string, any>, path);
-      } else {
-        engine.updateLayerPresetConfig(layerId, path, value);
-      }
-    });
-  };
-
-  useEffect(() => {
-    if (!isFullscreenMode) return;
-    const channel = broadcastRef.current;
-    if (!channel) return;
-
-    const handler = (event: MessageEvent) => {
-      const msg = event.data;
-      if (!engineRef.current) return;
-      switch (msg.type) {
-        case 'activeLayers': {
-          const newActive = msg.data as Record<string, string>;
-          Object.keys(activeLayers).forEach(layerId => {
-            if (!newActive[layerId]) {
-              engineRef.current!.deactivateLayerPreset(layerId);
-            }
-          });
-          Object.entries(newActive).forEach(([layerId, presetId]) => {
-            engineRef.current!.activateLayerPreset(layerId, presetId);
-            const cfg = layerPresetConfigs[layerId]?.[presetId];
-            if (cfg) applyPresetConfig(engineRef.current!, layerId, cfg);
-          });
-          setActiveLayers(newActive);
-          break;
-        }
-        case 'midiTrigger': {
-          const data = msg.data;
-          if (data.presetId) {
-            setMidiTrigger(data);
-          } else if (data.note !== undefined) {
-            const preset = availablePresets.find(p => p.config.note === data.note);
-            if (preset) {
-              setMidiTrigger({
-                layerId: data.layerId,
-                presetId: preset.id,
-                velocity: data.velocity
-              });
-            }
-          }
-          break;
-        }
-        case 'layerConfig': {
-          engineRef.current.updateLayerConfig(msg.layerId, msg.config);
-          break;
-        }
-        case 'layerPresetConfigs': {
-          const cfgs = msg.data as Record<string, Record<string, any>>;
-          setLayerPresetConfigs(cfgs);
-          Object.entries(activeLayers).forEach(([layerId, presetId]) => {
-            const cfg = cfgs[layerId]?.[presetId];
-            if (cfg) applyPresetConfig(engineRef.current!, layerId, cfg);
-          });
-          break;
-        }
-      }
+    const timestamp = new Date().toISOString();
+    const userMessage: ChatMessage = {
+      id: buildMessageId('user'),
+      author: 'user',
+      content: trimmed,
+      timestamp,
     };
 
-    channel.addEventListener('message', handler);
-    return () => channel.removeEventListener('message', handler);
-  }, [isFullscreenMode, activeLayers, layerPresetConfigs, availablePresets]);
+    const agentReplies: ChatMessage[] = activeAgents.map((agent, index) => ({
+      id: buildMessageId(`${agent.id}-${index}`),
+      author: 'agent',
+      agentId: agent.id,
+      content: `${agent.name} está preparando una respuesta…`,
+      timestamp,
+      status: 'pending',
+      sourcePrompt: trimmed,
+    }));
 
-  const handleMonitorRoleChange = (id: string, role: 'main' | 'secondary' | 'none') => {
-    setMonitorRoles(prev => {
-      const updated = { ...prev, [id]: role } as Record<string, 'main' | 'secondary' | 'none'>;
-      if (role === 'main') {
-        Object.keys(updated).forEach(otherId => {
-          if (otherId !== id && updated[otherId] === 'main') {
-            updated[otherId] = 'secondary';
-          }
-        });
-      }
-      if (!Object.values(updated).some(r => r === 'main')) {
-        const primaryMonitor = monitors.find(m => m.isPrimary) || monitors[0];
-        if (primaryMonitor) {
-          updated[primaryMonitor.id] = 'main';
-        }
-      }
-      const newMain = Object.entries(updated).find(([, r]) => r === 'main')?.[0];
-      if (newMain) {
-        setStartMonitor(newMain);
-      }
-      return updated;
-    });
+    setMessages(prev => [...prev, userMessage, ...agentReplies]);
+    setDraft('');
   };
 
-  // Handler para cambios en los templates de custom text
-  const handleCustomTextTemplateChange = async (count: number, texts: string[]) => {
-    setGlitchTextPads(count);
-    setCustomTextContents(texts);
-    localStorage.setItem('glitchTextPads', count.toString());
-    localStorage.setItem('customTextTemplate', JSON.stringify({ count, texts }));
+  const lastUserMessage = useMemo(
+    () =>
+      [...messages]
+        .reverse()
+        .find(message => message.author === 'user'),
+    [messages],
+  );
 
-    if (engineRef.current) {
-      try {
-        const updatedPresets = await engineRef.current.updateCustomTextTemplates(count, texts);
-        setAvailablePresets(updatedPresets);
-        setStatus(`Custom text actualizado: ${count} instancia${count > 1 ? 's' : ''}`);
-      } catch (error) {
-        console.error('Error updating custom text templates:', error);
-        setStatus('Error updating custom text');
-      }
-    }
-  };
-
-  const handleCustomTextCountChange = (count: number) => {
-    handleCustomTextTemplateChange(count, customTextContents);
-  };
-
-  const handleEmptyTemplateChange = async (count: number) => {
-    setEmptyPads(count);
-    localStorage.setItem('emptyPads', count.toString());
-    if (engineRef.current) {
-      try {
-        const updated = await engineRef.current.updateEmptyTemplates(count);
-        setAvailablePresets(updated);
-        setStatus(`Empty templates updated: ${count}`);
-      } catch (err) {
-        console.error('Error updating empty templates:', err);
-        setStatus('Error updating Empty templates');
-      }
-    }
-  };
-
-  const handleTriggerVFX = (layerId: string, effect: string) => {
-    engineRef.current?.triggerLayerVFX(layerId, effect);
-  };
-
-  const handleSetVFX = (
-    layerId: string,
-    presetId: string,
-    effect: string,
-    enabled: boolean
-  ) => {
-    engineRef.current?.setLayerVFX(layerId, effect, enabled);
-    setLayerVFX(prev => {
-      const layerMap = { ...(prev[layerId] || {}) };
-      const effects = new Set(layerMap[presetId] || []);
-      if (enabled) {
-        effects.add(effect);
-      } else {
-        effects.delete(effect);
-      }
-      return { ...prev, [layerId]: { ...layerMap, [presetId]: Array.from(effects) } };
-    });
-  };
-
-  const handleGenLabPresetsChange = async (presets: { name: string; config: any }[]) => {
-    setGenLabPresets(presets);
-    localStorage.setItem('genLabPresets', JSON.stringify(presets));
-    if (engineRef.current) {
-      try {
-        const updated = await engineRef.current.updateGenLabPresets(presets);
-        setAvailablePresets(updated);
-        setStatus(`Gen Lab actualizado: ${presets.length} preset${presets.length !== 1 ? 's' : ''}`);
-      } catch (err) {
-        console.error('Error updating Gen Lab presets:', err);
-        setStatus('Error updating Gen Lab');
-      }
-    }
-  };
-
-  const handleFractalLabPresetsChange = async (presets: { name: string; config: any }[]) => {
-    setFractalLabPresets(presets);
-    localStorage.setItem('fractalLabPresets', JSON.stringify(presets));
-    if (engineRef.current) {
-      try {
-        const updated = await engineRef.current.updateFractalLabPresets(presets);
-        setAvailablePresets(updated);
-        setStatus(`Fractal Lab actualizado: ${presets.length} preset${presets.length !== 1 ? 's' : ''}`);
-      } catch (err) {
-        console.error('Error updating Fractal Lab presets:', err);
-        setStatus('Error updating Fractal Lab');
-      }
-    }
-  };
-
-  // Handler para anadir preset a layer desde la galeria sin activarlo
-  const handleAddPresetToLayer = (presetId: string, layerId: string) => {
-    const addFn = (window as any).addPresetToLayer as
-      | ((layerId: string, presetId: string) => void)
-      | undefined;
-
-    if (typeof addFn !== 'function') return;
-
-    addFn(layerId, presetId);
-
-    if (presetId.startsWith('video:')) {
-      const video = videoGallery.find(v => `video:${v.id}` === presetId);
-      if (video) {
-        setStatus(`${video.title} added to Layer ${layerId}`);
-      }
-    } else {
-      const preset = availablePresets.find(p => p.id === presetId);
-      if (preset) {
-        setStatus(`${preset.config.name} added to Layer ${layerId}`);
-      }
-    }
-  };
-
-  const handleRemovePresetFromLayer = (presetId: string, layerId: string) => {
-    const removeFn = (window as any).removePresetFromLayer as
-      | ((layerId: string, presetId: string) => void)
-      | undefined;
-
-    if (typeof removeFn !== 'function') return;
-
-    removeFn(layerId, presetId);
-
-    if (presetId.startsWith('video:')) {
-      const video = videoGallery.find(v => `video:${v.id}` === presetId);
-      if (video) {
-        setStatus(`${video.title} removed from Layer ${layerId}`);
-      }
-    } else {
-      const preset = availablePresets.find(p => p.id === presetId);
-      if (preset) {
-        setStatus(`${preset.config.name} removed from Layer ${layerId}`);
-      }
-    }
-  };
-
-  const getCurrentPresetName = (): string => {
-    if (selectedVideo && selectedVideoLayer) {
-      return `${selectedVideo.title} (${selectedVideoLayer})`;
-    }
-    if (!selectedPreset) return 'None';
-    return `${selectedPreset.config.name} (${selectedLayer || 'N/A'})`;
-  };
-
-  const midiDeviceName = midiDeviceId ? midiDevices.find((d: any) => d.id === midiDeviceId)?.name || null : null;
-  const launchpadAvailable = launchpadOutputs.length > 0;
-  const audioDeviceName = audioDeviceId ? audioDevices.find(d => d.deviceId === audioDeviceId)?.label || null : null;
-  const audioLevel = Math.min((audioData.low + audioData.mid + audioData.high) / 3, 1);
+  const agentResponses = useMemo(
+    () => messages.filter(message => message.author === 'agent'),
+    [messages],
+  );
 
   return (
-    <div
-      className={`app-container audiovisualizer-app ${isUiHidden ? 'ui-hidden' : ''}`}
-    >
-      <TopBar
-        midiActive={midiActive}
-        midiDeviceName={midiDeviceName}
-        midiDeviceCount={midiDevices.length}
-        bpm={bpm}
-        beatActive={beatActive}
-        audioDeviceName={audioDeviceName}
-        audioDeviceCount={audioDevices.length}
-        audioGain={audioGain}
-        onAudioGainChange={setAudioGain}
-        audioLevel={audioLevel}
-        onFullScreen={handleFullScreen}
-        onToggleUi={handleToggleUi}
-        onClearAll={handleClearAll}
-        onOpenSettings={() => setIsSettingsOpen(true)}
-        onOpenResources={() => setResourcesOpen(true)}
-        launchpadAvailable={launchpadAvailable}
-        launchpadOutput={launchpadOutput}
-        launchpadRunning={launchpadRunning}
-        launchpadPreset={launchpadPreset}
-        onToggleLaunchpad={handleLaunchpadToggle}
-        launchpadText={launchpadText}
-        onLaunchpadTextChange={setLaunchpadText}
-        onLaunchpadPresetChange={setLaunchpadPreset}
+    <div className="app-container">
+      <ChatTopBar
+        activeAgents={activeAgents.length}
+        totalAgents={agents.length}
+        pendingResponses={pendingResponses}
       />
 
       <div className="workspace">
-        <ResourceExplorer
-          width={RESOURCE_EXPLORER_WIDTH}
-          presets={availablePresets}
-          videos={videoGallery}
-          onOpenLibrary={() => setResourcesOpen(true)}
-          onRefreshVideos={() => refreshVideoGallery(true)}
-          isRefreshingVideos={isRefreshingVideos}
-        />
         <div className="main-panel">
-          {/* Grid de capas */}
-          <div className="layer-grid-container">
-            <Suspense fallback={<div>Loading layers...</div>}>
-              <LayerGrid
-                presets={availablePresets}
-                videos={videoGallery}
-                externalTrigger={midiTrigger}
-                onPresetActivate={(layerId, presetId, velocity) => {
-              (async () => {
-                if (!engineRef.current) return;
-                const isVideo = presetId.startsWith('video:');
-                if (isVideo) {
-                  const videoId = presetId.replace(/^video:/, '');
-                  const video = videoGallery.find(v => v.id === videoId);
-                  if (!video) {
-                    setStatus(`Video ${videoId} unavailable`);
-                    return;
-                  }
-                  const success = await engineRef.current.activateLayerPreset(layerId, presetId);
-                  if (!success) return;
-                  setActiveLayers(prev => ({ ...prev, [layerId]: presetId }));
-
-                  const savedVfx = layerVFX[layerId]?.[presetId] || [];
-                  savedVfx.forEach(effect =>
-                    engineRef.current?.setLayerVFX(layerId, effect, true)
-                  );
-
-                  setSelectedVideo(video);
-                  setSelectedVideoLayer(layerId);
-                  setSelectedPreset(null);
-                  setSelectedLayer(layerId);
-                  const settings = layerVideoSettings[layerId] || DEFAULT_VIDEO_PLAYBACK_SETTINGS;
-                  engineRef.current.updateLayerVideoSettings(layerId, settings);
-                  setStatus(`${video.title} loaded on Layer ${layerId}`);
-                  return;
-                }
-
-                const success = await engineRef.current.activateLayerPreset(layerId, presetId);
-                if (!success) return;
-                setActiveLayers(prev => ({ ...prev, [layerId]: presetId }));
-
-                const savedVfx = layerVFX[layerId]?.[presetId] || [];
-                savedVfx.forEach(effect =>
-                  engineRef.current?.setLayerVFX(layerId, effect, true)
-                );
-
-                const preset = availablePresets.find(p => p.id === presetId);
-                if (preset) {
-                  const existing = layerPresetConfigs[layerId]?.[presetId];
-                  if (existing) {
-                    applyPresetConfig(engineRef.current, layerId, existing);
-                  } else {
-                    const cfg = await engineRef.current.getLayerPresetConfig(layerId, presetId);
-                    setLayerPresetConfigs(prev => ({
-                      ...prev,
-                      [layerId]: { ...(prev[layerId] || {}), [presetId]: cfg }
-                    }));
-                  }
-                  setSelectedPreset(preset);
-                  setSelectedLayer(layerId);
-                  if (selectedVideoLayer === layerId) {
-                    setSelectedVideo(null);
-                    setSelectedVideoLayer(null);
-                  }
-                }
-              })();
-            }}
-          onLayerClear={(layerId) => {
-            if (engineRef.current) {
-              engineRef.current.deactivateLayerPreset(layerId);
-              setActiveLayers(prev => {
-                const newLayers = { ...prev };
-                delete newLayers[layerId];
-                return newLayers;
-              });
-              if (selectedLayer === layerId) {
-                setSelectedPreset(null);
-                setSelectedLayer(null);
-              }
-              if (selectedVideoLayer === layerId) {
-                setSelectedVideo(null);
-                setSelectedVideoLayer(null);
-              }
-            }
-          }}
-          onLayerConfigChange={(layerId, config) => {
-            if (engineRef.current) {
-              engineRef.current.updateLayerConfig(layerId, config);
-            }
-            broadcastRef.current?.postMessage({ type: 'layerConfig', layerId, config });
-          }}
-          onPresetSelect={(layerId, presetId) => {
-            (async () => {
-              if (presetId) {
-                if (presetId.startsWith('video:')) {
-                  const videoId = presetId.replace(/^video:/, '');
-                  const video = videoGallery.find(v => v.id === videoId) || null;
-                  setSelectedVideo(video);
-                  setSelectedVideoLayer(layerId);
-                  setSelectedPreset(null);
-                  setSelectedLayer(layerId);
-                  return;
-                }
-                const preset = availablePresets.find(p => p.id === presetId);
-                if (preset) {
-                  const existing = layerPresetConfigs[layerId]?.[presetId];
-                  if (!existing) {
-                    const cfg = await engineRef.current?.getLayerPresetConfig(layerId, presetId);
-                    if (cfg) {
-                      setLayerPresetConfigs(prev => ({
-                        ...prev,
-                        [layerId]: { ...(prev[layerId] || {}), [presetId]: cfg }
-                      }));
-                    }
-                  }
-                  setSelectedPreset(preset);
-                  setSelectedLayer(layerId);
-                  if (selectedVideoLayer === layerId) {
-                    setSelectedVideo(null);
-                    setSelectedVideoLayer(null);
-                  }
-                }
-              } else {
-                if (selectedLayer === layerId) {
-                  setSelectedPreset(null);
-                  setSelectedLayer(null);
-                }
-                if (selectedVideoLayer === layerId) {
-                  setSelectedVideo(null);
-                  setSelectedVideoLayer(null);
-                }
-              }
-            })();
-          }}
-          clearAllSignal={clearSignal}
-          layerChannels={layerChannels}
-          layerEffects={layerEffects}
-                onLayerEffectChange={handleLayerEffectChange}
-                onLayerEffectToggle={handleLayerEffectToggle}
-                onOpenResources={() => setResourcesOpen(true)}
-                bpm={bpm}
-              />
-            </Suspense>
-          </div>
-
-          {/* Seccion inferior con visuales y controles */}
-          <div className="bottom-section">
-            <div className="visual-stage">
-              <div
-                className="visual-wrapper"
-                style={{ background: canvasBackground }}
-              >
-                <div
-                  ref={playgroundRef}
-                  className={`playground ${activeEffectClasses}`}
-                  style={{
-                    filter: `brightness(${canvasBrightness}) saturate(${canvasVibrance})`
-                  }}
-                />
+          <div className="layer-grid-container chat-layer-grid">
+            <div className="chat-header">
+              <div className="chat-header-text">
+                <h1 className="chat-title">JungleMonk.AI · Control Hub</h1>
+                <p className="chat-subtitle">
+                  Orquesta múltiples agentes en paralelo manteniendo la estética original del entorno.
+                </p>
               </div>
-            </div>
-            {!isResourcesOpen && (
-              <div className="controls-panel">
-                <div className="controls-panel-content">
-                  {selectedVideo && selectedVideoLayer && (
-                    <VideoControls
-                      video={selectedVideo}
-                      settings={layerVideoSettings[selectedVideoLayer] || DEFAULT_VIDEO_PLAYBACK_SETTINGS}
-                      onChange={handleVideoSettingsChange}
-                    />
-                  )}
-                  {!selectedVideo && selectedPreset && (
-                    <Suspense fallback={<div>Loading controls...</div>}>
-                      <PresetControls
-                        preset={selectedPreset}
-                        config={layerPresetConfigs[selectedLayer!]?.[selectedPreset.id]}
-                        onChange={(path, value) => {
-                          if (engineRef.current && selectedLayer && selectedPreset) {
-                            engineRef.current.updateLayerPresetConfig(selectedLayer, path, value);
-                            setLayerPresetConfigs(prev => {
-                              const layerMap = { ...(prev[selectedLayer] || {}) };
-                              const cfg = { ...(layerMap[selectedPreset.id] || {}) };
-                              setNestedValue(cfg, path, value);
-                              layerMap[selectedPreset.id] = cfg;
-                              return { ...prev, [selectedLayer]: layerMap };
-                            });
-                          }
-                        }}
-                      />
-                    </Suspense>
-                  )}
-                  {!selectedPreset && !selectedVideo && (
-                    <div className="no-preset-selected">Selecciona un preset</div>
-                  )}
+              <div className="chat-metrics">
+                <div className="metric-chip">
+                  <span className="metric-label">Agentes activos</span>
+                  <span className="metric-value">{activeAgents.length}</span>
+                </div>
+                <div className="metric-chip">
+                  <span className="metric-label">Mensajes totales</span>
+                  <span className="metric-value">{messages.length}</span>
+                </div>
+                <div className={`metric-chip ${pendingResponses ? 'metric-warning' : ''}`}>
+                  <span className="metric-label">Respuestas pendientes</span>
+                  <span className="metric-value">{pendingResponses}</span>
                 </div>
               </div>
-            )}
+            </div>
+          </div>
+
+          <div className="bottom-section">
+            <div className="visual-stage">
+              <div className="visual-wrapper chat-visual-wrapper">
+                <div className="chat-stage">
+                  <div className="message-feed">
+                    {messages.map(message => {
+                      const isUser = message.author === 'user';
+                      const isSystem = message.author === 'system';
+                      const agent = message.agentId ? agentMap.get(message.agentId) : undefined;
+                      const chipColor = agent?.accent || 'var(--accent-color)';
+
+                      return (
+                        <div
+                          key={message.id}
+                          className={`message-card ${isUser ? 'message-user' : ''} ${isSystem ? 'message-system' : ''}`}
+                        >
+                          <div className="message-card-header">
+                            <div className="message-card-author" style={{ borderColor: chipColor }}>
+                              {isUser && 'Tú'}
+                              {isSystem && 'Control Hub'}
+                              {!isUser && !isSystem && agent?.name}
+                            </div>
+                            <div className="message-card-meta">
+                              {!isUser && !isSystem && (
+                                <span className="message-card-tag" style={{ color: chipColor }}>
+                                  {agent?.provider}
+                                </span>
+                              )}
+                              <span className="message-card-time">{formatTime(message.timestamp)}</span>
+                              {message.status === 'pending' && <span className="message-card-status">orquestando…</span>}
+                            </div>
+                          </div>
+                          <p className="message-card-content">{message.content}</p>
+                        </div>
+                      );
+                    })}
+                  </div>
+
+                  <div className="chat-suggestions">
+                    <span className="suggestions-label">Sugerencias:</span>
+                    {QUICK_COMMANDS.slice(0, 3).map(command => (
+                      <button
+                        key={command}
+                        type="button"
+                        className="suggestion-chip"
+                        onClick={() => handleCommandInsert(command)}
+                      >
+                        {command}
+                      </button>
+                    ))}
+                  </div>
+
+                  <div className="chat-composer">
+                    <textarea
+                      value={draft}
+                      onChange={event => setDraft(event.target.value)}
+                      placeholder="Habla con varios agentes a la vez: por ejemplo “gpt, genera un esquema de estilos”"
+                      className="chat-input"
+                      rows={3}
+                    />
+                    <div className="composer-toolbar">
+                      <div className="composer-hints">
+                        <span>Usa @ para mencionar modelos concretos</span>
+                        {lastUserMessage && (
+                          <span className="composer-last">Último mensaje a las {formatTime(lastUserMessage.timestamp)}</span>
+                        )}
+                      </div>
+                      <div className="composer-actions">
+                        <button
+                          type="button"
+                          className="ghost-button"
+                          onClick={() => setDraft('')}
+                          disabled={!draft.trim()}
+                        >
+                          Limpiar
+                        </button>
+                        <button type="button" className="primary-button" onClick={handleSend}>
+                          Enviar a {activeAgents.length || 'ningún'} agente{activeAgents.length === 1 ? '' : 's'}
+                        </button>
+                      </div>
+                    </div>
+                  </div>
+                </div>
+              </div>
+            </div>
+
+            <aside className="controls-panel">
+              <div className="controls-panel-content">
+                <section className="panel-section">
+                  <header className="panel-section-header">
+                    <h2>Credenciales</h2>
+                    <p>Conecta tus proveedores en caliente.</p>
+                  </header>
+                  <div className="key-field">
+                    <label htmlFor="openai-key">OpenAI</label>
+                    <input
+                      id="openai-key"
+                      type="password"
+                      value={apiKeys.openai}
+                      onChange={event => handleApiKeyChange('openai', event.target.value)}
+                      placeholder="sk-..."
+                      className={!apiKeys.openai ? 'is-empty' : ''}
+                    />
+                  </div>
+                  <div className="key-field">
+                    <label htmlFor="anthropic-key">Anthropic</label>
+                    <input
+                      id="anthropic-key"
+                      type="password"
+                      value={apiKeys.anthropic}
+                      onChange={event => handleApiKeyChange('anthropic', event.target.value)}
+                      placeholder="anthropic-..."
+                      className={!apiKeys.anthropic ? 'is-empty' : ''}
+                    />
+                  </div>
+                  <div className="key-field">
+                    <label htmlFor="groq-key">Groq</label>
+                    <input
+                      id="groq-key"
+                      type="password"
+                      value={apiKeys.groq}
+                      onChange={event => handleApiKeyChange('groq', event.target.value)}
+                      placeholder="groq-..."
+                      className={!apiKeys.groq ? 'is-empty' : ''}
+                    />
+                  </div>
+                </section>
+
+                <section className="panel-section">
+                  <header className="panel-section-header">
+                    <h2>Modelos activos</h2>
+                    <p>Activa y desactiva agentes al instante.</p>
+                  </header>
+                  <div className="agent-grid">
+                    {agents.map(agent => (
+                      <button
+                        key={agent.id}
+                        type="button"
+                        className={`agent-chip ${agent.active ? 'is-active' : ''}`}
+                        style={{ '--agent-accent': agent.accent } as React.CSSProperties}
+                        onClick={() => handleToggleAgent(agent.id)}
+                      >
+                        <span className="agent-chip-name">{agent.name}</span>
+                        <span className="agent-chip-provider">{agent.provider}</span>
+                        <span className="agent-chip-status">{agent.status}</span>
+                      </button>
+                    ))}
+                  </div>
+                </section>
+
+                <section className="panel-section">
+                  <header className="panel-section-header">
+                    <h2>Comandos frecuentes</h2>
+                    <p>Guarda instrucciones recurrentes para dispararlas en el chat.</p>
+                  </header>
+                  <div className="command-list">
+                    {QUICK_COMMANDS.map(command => (
+                      <button
+                        key={command}
+                        type="button"
+                        className="command-item"
+                        onClick={() => handleCommandInsert(command)}
+                      >
+                        <span>{command}</span>
+                      </button>
+                    ))}
+                  </div>
+                </section>
+
+                <section className="panel-section">
+                  <header className="panel-section-header">
+                    <h2>Actividad reciente</h2>
+                    <p>Monitoriza cómo responden los agentes.</p>
+                  </header>
+                  <ul className="activity-feed">
+                    {agentResponses.slice(-6).reverse().map(message => {
+                      const agent = message.agentId ? agentMap.get(message.agentId) : undefined;
+                      if (!agent) {
+                        return null;
+                      }
+
+                      return (
+                        <li key={message.id} className="activity-item">
+                          <span className="activity-dot" style={{ background: agent.accent }} />
+                          <div className="activity-content">
+                            <div className="activity-title">
+                              <strong>{agent.name}</strong>
+                              <span>{formatTime(message.timestamp)}</span>
+                            </div>
+                            <p>{message.content}</p>
+                          </div>
+                        </li>
+                      );
+                    })}
+                    {!agentResponses.length && <li className="activity-empty">Todavía no hay actividad de los agentes.</li>}
+                  </ul>
+                </section>
+              </div>
+            </aside>
           </div>
         </div>
       </div>
 
-      {/* Barra de estado */}
-      <StatusBar
-        status={status}
-        fps={fps}
-        currentPreset={getCurrentPresetName()}
-        audioData={audioData}
+      <ChatStatusBar
+        activeAgents={activeAgents.length}
+        totalMessages={messages.length}
+        pendingResponses={pendingResponses}
       />
-
-      {/* Modal de configuracion global */}
-      <Suspense fallback={null}>
-        <GlobalSettingsModal
-          isOpen={isSettingsOpen}
-          onClose={() => setIsSettingsOpen(false)}
-          audioDevices={audioDevices.map(d => ({ id: d.deviceId, label: d.label || d.deviceId }))}
-          midiDevices={midiDevices.map((d: any) => ({ id: d.id, label: d.name || d.id }))}
-          launchpadDevices={launchpadOutputs.map((d: any) => ({ id: d.id, label: d.name || d.id }))}
-          selectedAudioId={audioDeviceId}
-          selectedMidiId={midiDeviceId}
-          selectedLaunchpadId={launchpadId}
-          onSelectAudio={(id) => {
-            setAudioDeviceId(id || null);
-            if (id) {
-              localStorage.setItem('selectedAudioDevice', id);
-            } else {
-              localStorage.removeItem('selectedAudioDevice');
-            }
-          }}
-          onSelectMidi={(id) => {
-            setMidiDeviceId(id || null);
-            if (id) {
-              localStorage.setItem('selectedMidiDevice', id);
-            } else {
-              localStorage.removeItem('selectedMidiDevice');
-            }
-          }}
-          onSelectLaunchpad={(id) => {
-            setLaunchpadId(id);
-            if (id) {
-              localStorage.setItem('launchpadId', id);
-            } else {
-              localStorage.removeItem('launchpadId');
-            }
-          }}
-        audioGain={audioGain}
-        onAudioGainChange={setAudioGain}
-        midiClockSettings={midiClockSettings}
-        onUpdateClockSettings={updateClockSettings}
-        internalBpm={internalBpm}
-        onSetInternalBpm={setInternalBpm}
-        clockStable={clockStable}
-        currentMeasure={currentMeasure}
-        currentBeat={currentBeat}
-        layerChannels={layerChannels}
-        onLayerChannelChange={(layerId, channel) => {
-          const updated = { ...layerChannels, [layerId]: channel };
-          setLayerChannels(updated);
-          localStorage.setItem('layerMidiChannels', JSON.stringify(updated));
-        }}
-        effectMidiNotes={effectMidiNotes}
-        onEffectMidiNoteChange={handleEffectMidiNoteChange}
-        launchpadChannel={launchpadChannel}
-        onLaunchpadChannelChange={setLaunchpadChannel}
-        launchpadNote={launchpadNote}
-        onLaunchpadNoteChange={setLaunchpadNote}
-        launchpadSmoothness={launchpadSmoothness}
-        onLaunchpadSmoothnessChange={setLaunchpadSmoothness}
-        monitors={monitors}
-        monitorRoles={monitorRoles}
-        onMonitorRoleChange={handleMonitorRoleChange}
-        startMonitor={startMonitor}
-        onStartMonitorChange={setStartMonitor}
-        glitchTextPads={glitchTextPads}
-        onGlitchPadChange={handleCustomTextCountChange}
-        startMaximized={startMaximized}
-        onStartMaximizedChange={setStartMaximized}
-        hideUiHotkey={hideUiHotkey}
-        onHideUiHotkeyChange={(key) => {
-          setHideUiHotkey(key);
-          localStorage.setItem('hideUiHotkey', key);
-        }}
-        fullscreenHotkey={fullscreenHotkey}
-        onFullscreenHotkeyChange={(key) => {
-          setFullscreenHotkey(key);
-          localStorage.setItem('fullscreenHotkey', key);
-        }}
-        exitFullscreenHotkey={exitFullscreenHotkey}
-        onExitFullscreenHotkeyChange={(key) => {
-          setExitFullscreenHotkey(key);
-          localStorage.setItem('exitFullscreenHotkey', key);
-        }}
-        fullscreenByDefault={fullscreenByDefault}
-        onFullscreenByDefaultChange={(value) => {
-          setFullscreenByDefault(value);
-          localStorage.setItem('fullscreenByDefault', value.toString());
-        }}
-        canvasBrightness={canvasBrightness}
-        onCanvasBrightnessChange={setCanvasBrightness}
-        canvasVibrance={canvasVibrance}
-        onCanvasVibranceChange={setCanvasVibrance}
-        canvasBackground={canvasBackground}
-        onCanvasBackgroundChange={setCanvasBackground}
-        visualsPath={visualsPath}
-        onVisualsPathChange={setVisualsPath}
-        videoProvider={videoProviderSettings.provider}
-        videoApiKey={videoProviderSettings.apiKey || ''}
-        videoQuery={videoProviderSettings.query}
-        videoRefreshMinutes={videoProviderSettings.refreshMinutes}
-        onVideoProviderChange={(provider) => updateVideoProviderSettings({ provider })}
-        onVideoApiKeyChange={(value) => updateVideoProviderSettings({ apiKey: value })}
-        onVideoQueryChange={(value) => updateVideoProviderSettings({ query: value })}
-        onVideoRefreshMinutesChange={(value) => updateVideoProviderSettings({ refreshMinutes: value })}
-        onVideoCacheClear={handleClearVideoCache}
-        />
-      </Suspense>
-
-      {/* Modal de galeria de presets */}
-      <Suspense fallback={null}>
-        <ResourcesModal
-          isOpen={isResourcesOpen}
-          onClose={() => setResourcesOpen(false)}
-          presets={availablePresets}
-          onCustomTextTemplateChange={handleCustomTextTemplateChange}
-          customTextTemplate={{ count: glitchTextPads, texts: customTextContents }}
-          onEmptyTemplateChange={handleEmptyTemplateChange}
-          emptyTemplateCount={emptyPads}
-          genLabPresets={genLabPresets}
-          genLabBasePreset={genLabBasePreset}
-          onGenLabPresetsChange={handleGenLabPresetsChange}
-          fractalLabPresets={fractalLabPresets}
-          fractalLabBasePreset={fractalLabBasePreset}
-          onFractalLabPresetsChange={handleFractalLabPresetsChange}
-          onAddPresetToLayer={handleAddPresetToLayer}
-          onRemovePresetFromLayer={handleRemovePresetFromLayer}
-          launchpadPresets={LAUNCHPAD_PRESETS}
-          launchpadPreset={launchpadPreset}
-          onLaunchpadPresetChange={setLaunchpadPreset}
-          launchpadRunning={launchpadRunning}
-          onToggleLaunchpad={() => setLaunchpadRunning(r => !r)}
-          launchpadText={launchpadText}
-          onLaunchpadTextChange={setLaunchpadText}
-          onTriggerVFX={handleTriggerVFX}
-          onSetVFX={handleSetVFX}
-          layerVFX={layerVFX}
-          videos={videoGallery}
-          onAddVideoToLayer={handleAddVideoToLayer}
-          onRemoveVideoFromLayer={handleRemoveVideoFromLayer}
-          onRefreshVideos={() => refreshVideoGallery(true)}
-          isRefreshingVideos={isRefreshingVideos}
-        />
-      </Suspense>
     </div>
   );
 };

--- a/src/components/chat/ChatInterface.css
+++ b/src/components/chat/ChatInterface.css
@@ -1,0 +1,693 @@
+.chat-top-bar {
+  width: 100%;
+  height: 60px;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 24px;
+  padding: 0 24px;
+  background: rgba(5, 5, 5, 0.85);
+  border-bottom: 1px solid rgba(255, 255, 255, 0.08);
+  box-shadow: 0 10px 30px rgba(0, 0, 0, 0.4);
+  z-index: 30;
+}
+
+.topbar-section {
+  display: flex;
+  align-items: center;
+  gap: 18px;
+}
+
+.topbar-branding .brand-icon {
+  width: 36px;
+  height: 36px;
+  display: grid;
+  place-items: center;
+  font-size: 18px;
+  border-radius: 12px;
+  background: linear-gradient(135deg, rgba(255, 183, 77, 0.6), rgba(142, 141, 255, 0.4));
+  box-shadow: 0 10px 20px rgba(255, 183, 77, 0.2);
+}
+
+.brand-copy {
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+}
+
+.brand-title {
+  font-size: 15px;
+  font-weight: 600;
+  letter-spacing: 0.5px;
+}
+
+.brand-subtitle {
+  font-size: 11px;
+  color: rgba(255, 255, 255, 0.6);
+  letter-spacing: 1px;
+  text-transform: uppercase;
+}
+
+.topbar-status {
+  gap: 20px;
+}
+
+.status-indicator {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  font-size: 13px;
+  letter-spacing: 0.3px;
+  color: rgba(255, 255, 255, 0.85);
+}
+
+.status-led {
+  width: 10px;
+  height: 10px;
+  border-radius: 50%;
+  background: #555;
+  box-shadow: 0 0 0 0 rgba(68, 255, 68, 0.4);
+  transition: background 0.3s ease, box-shadow 0.3s ease;
+}
+
+.status-led.online {
+  background: #66ff66;
+  box-shadow: 0 0 12px rgba(102, 255, 102, 0.6);
+}
+
+.status-led.offline {
+  background: #ff6666;
+  box-shadow: 0 0 12px rgba(255, 102, 102, 0.45);
+}
+
+.status-metric {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+  padding: 6px 14px;
+  border-radius: 10px;
+  background: rgba(255, 255, 255, 0.05);
+  border: 1px solid rgba(255, 255, 255, 0.08);
+}
+
+.status-metric.warning {
+  border-color: rgba(255, 148, 77, 0.6);
+  background: rgba(255, 148, 77, 0.14);
+}
+
+.metric-label {
+  font-size: 10px;
+  text-transform: uppercase;
+  letter-spacing: 1px;
+  color: rgba(255, 255, 255, 0.55);
+}
+
+.metric-value {
+  font-size: 14px;
+  font-weight: 600;
+}
+
+.topbar-actions {
+  margin-left: auto;
+}
+
+.topbar-button {
+  background: rgba(255, 255, 255, 0.06);
+  color: #fff;
+  border: 1px solid rgba(255, 255, 255, 0.08);
+  border-radius: 8px;
+  padding: 6px 14px;
+  font-size: 12px;
+  font-weight: 500;
+  letter-spacing: 0.2px;
+  cursor: pointer;
+  transition: background 0.2s ease, transform 0.2s ease, box-shadow 0.2s ease;
+}
+
+.topbar-button:hover {
+  background: rgba(255, 183, 77, 0.18);
+  border-color: rgba(255, 183, 77, 0.6);
+  box-shadow: 0 6px 18px rgba(255, 183, 77, 0.2);
+  transform: translateY(-1px);
+}
+
+.chat-layer-grid {
+  border-bottom: 1px solid rgba(255, 255, 255, 0.05);
+}
+
+.chat-header {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: 24px;
+  color: #fff;
+}
+
+.chat-header-text {
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+}
+
+.chat-title {
+  font-size: 26px;
+  letter-spacing: 1px;
+  font-weight: 600;
+}
+
+.chat-subtitle {
+  font-size: 14px;
+  color: rgba(255, 255, 255, 0.65);
+  max-width: 520px;
+}
+
+.chat-metrics {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+}
+
+.metric-chip {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+  padding: 10px 16px;
+  border-radius: 12px;
+  background: linear-gradient(135deg, rgba(255, 255, 255, 0.05), rgba(255, 255, 255, 0.02));
+  border: 1px solid rgba(255, 255, 255, 0.08);
+  min-width: 140px;
+}
+
+.metric-chip.metric-warning {
+  border-color: rgba(255, 148, 77, 0.55);
+  background: linear-gradient(135deg, rgba(255, 148, 77, 0.22), rgba(255, 255, 255, 0.04));
+}
+
+.chat-visual-wrapper {
+  padding: 32px;
+  display: flex;
+  flex-direction: column;
+}
+
+.chat-stage {
+  flex: 1;
+  display: flex;
+  flex-direction: column;
+  gap: 20px;
+  min-height: 0;
+}
+
+.message-feed {
+  flex: 1;
+  overflow-y: auto;
+  display: flex;
+  flex-direction: column;
+  gap: 14px;
+  padding-right: 12px;
+}
+
+.message-card {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+  padding: 16px 20px;
+  border-radius: 14px;
+  background: rgba(12, 12, 12, 0.75);
+  border: 1px solid rgba(255, 255, 255, 0.08);
+  box-shadow: 0 18px 30px rgba(0, 0, 0, 0.35);
+  backdrop-filter: blur(16px);
+  max-width: 85%;
+}
+
+.message-card.message-user {
+  align-self: flex-end;
+  background: linear-gradient(135deg, rgba(142, 141, 255, 0.35), rgba(77, 77, 255, 0.2));
+  border-color: rgba(142, 141, 255, 0.55);
+}
+
+.message-card.message-system {
+  align-self: center;
+  background: rgba(255, 255, 255, 0.05);
+  border-style: dashed;
+  border-color: rgba(255, 255, 255, 0.25);
+}
+
+.message-card-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 20px;
+}
+
+.message-card-author {
+  font-weight: 600;
+  font-size: 13px;
+  letter-spacing: 0.6px;
+  text-transform: uppercase;
+  padding: 6px 12px;
+  border-radius: 999px;
+  border: 1px solid rgba(255, 255, 255, 0.2);
+}
+
+.message-card-meta {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  font-size: 11px;
+  color: rgba(255, 255, 255, 0.6);
+}
+
+.message-card-tag {
+  font-weight: 600;
+  letter-spacing: 0.8px;
+  text-transform: uppercase;
+}
+
+.message-card-status {
+  color: #ffb347;
+  font-weight: 600;
+  letter-spacing: 0.6px;
+  text-transform: uppercase;
+}
+
+.message-card-content {
+  font-size: 14px;
+  line-height: 1.6;
+  color: rgba(255, 255, 255, 0.92);
+  white-space: pre-wrap;
+}
+
+.chat-suggestions {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  flex-wrap: wrap;
+}
+
+.suggestions-label {
+  font-size: 12px;
+  letter-spacing: 0.7px;
+  text-transform: uppercase;
+  color: rgba(255, 255, 255, 0.6);
+}
+
+.suggestion-chip {
+  border: 1px solid rgba(255, 255, 255, 0.12);
+  background: rgba(255, 255, 255, 0.04);
+  color: #fff;
+  padding: 6px 12px;
+  border-radius: 999px;
+  font-size: 12px;
+  cursor: pointer;
+  transition: background 0.2s ease, border-color 0.2s ease;
+}
+
+.suggestion-chip:hover {
+  background: rgba(255, 183, 77, 0.16);
+  border-color: rgba(255, 183, 77, 0.5);
+}
+
+.chat-composer {
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+  padding: 18px 20px;
+  border-radius: 16px;
+  background: rgba(12, 12, 12, 0.75);
+  border: 1px solid rgba(255, 255, 255, 0.06);
+  box-shadow: 0 18px 34px rgba(0, 0, 0, 0.45);
+}
+
+.chat-input {
+  width: 100%;
+  resize: vertical;
+  min-height: 90px;
+  max-height: 200px;
+  border-radius: 12px;
+  border: 1px solid rgba(255, 255, 255, 0.08);
+  background: rgba(0, 0, 0, 0.65);
+  color: #fff;
+  padding: 14px 16px;
+  font-size: 14px;
+  line-height: 1.6;
+  font-family: inherit;
+  outline: none;
+  transition: border 0.2s ease, box-shadow 0.2s ease;
+}
+
+.chat-input:focus {
+  border-color: rgba(255, 183, 77, 0.7);
+  box-shadow: 0 0 0 2px rgba(255, 183, 77, 0.15);
+}
+
+.composer-toolbar {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 16px;
+  flex-wrap: wrap;
+}
+
+.composer-hints {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+  font-size: 12px;
+  color: rgba(255, 255, 255, 0.6);
+}
+
+.composer-last {
+  color: rgba(142, 141, 255, 0.85);
+}
+
+.composer-actions {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+}
+
+.ghost-button,
+.primary-button {
+  border-radius: 10px;
+  padding: 10px 18px;
+  font-size: 13px;
+  font-weight: 600;
+  letter-spacing: 0.4px;
+  cursor: pointer;
+  border: 1px solid transparent;
+  transition: all 0.2s ease;
+}
+
+.ghost-button {
+  background: transparent;
+  border-color: rgba(255, 255, 255, 0.18);
+  color: rgba(255, 255, 255, 0.75);
+}
+
+.ghost-button:disabled {
+  opacity: 0.45;
+  cursor: not-allowed;
+}
+
+.ghost-button:not(:disabled):hover {
+  border-color: rgba(255, 255, 255, 0.4);
+}
+
+.primary-button {
+  background: linear-gradient(135deg, rgba(255, 183, 77, 0.9), rgba(255, 138, 101, 0.9));
+  color: #111;
+  border: none;
+  box-shadow: 0 14px 30px rgba(255, 183, 77, 0.35);
+}
+
+.primary-button:hover {
+  transform: translateY(-1px);
+  box-shadow: 0 18px 36px rgba(255, 183, 77, 0.45);
+}
+
+.controls-panel {
+  backdrop-filter: blur(14px);
+}
+
+.panel-section {
+  display: flex;
+  flex-direction: column;
+  gap: 14px;
+  margin-bottom: 32px;
+  padding-bottom: 24px;
+  border-bottom: 1px solid rgba(255, 255, 255, 0.04);
+}
+
+.panel-section:last-of-type {
+  border-bottom: none;
+  margin-bottom: 0;
+  padding-bottom: 0;
+}
+
+.panel-section-header h2 {
+  font-size: 15px;
+  letter-spacing: 0.6px;
+  text-transform: uppercase;
+}
+
+.panel-section-header p {
+  font-size: 12px;
+  color: rgba(255, 255, 255, 0.55);
+}
+
+.key-field {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+}
+
+.key-field label {
+  font-size: 12px;
+  text-transform: uppercase;
+  letter-spacing: 0.8px;
+  color: rgba(255, 255, 255, 0.6);
+}
+
+.key-field input {
+  height: 34px;
+  border-radius: 10px;
+  border: 1px solid rgba(255, 255, 255, 0.12);
+  background: rgba(0, 0, 0, 0.65);
+  color: #fff;
+  padding: 0 12px;
+  font-size: 13px;
+  outline: none;
+  transition: border 0.2s ease, box-shadow 0.2s ease;
+}
+
+.key-field input.is-empty {
+  border-style: dashed;
+  border-color: rgba(255, 255, 255, 0.18);
+}
+
+.key-field input:focus {
+  border-color: rgba(142, 141, 255, 0.7);
+  box-shadow: 0 0 0 2px rgba(142, 141, 255, 0.15);
+}
+
+.agent-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(140px, 1fr));
+  gap: 12px;
+}
+
+.agent-chip {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+  padding: 14px 12px;
+  border-radius: 12px;
+  border: 1px solid rgba(255, 255, 255, 0.08);
+  background: rgba(15, 15, 15, 0.7);
+  color: #fff;
+  text-align: left;
+  cursor: pointer;
+  transition: transform 0.2s ease, box-shadow 0.2s ease, border-color 0.2s ease;
+}
+
+.agent-chip.is-active {
+  border-color: var(--agent-accent);
+  box-shadow: 0 12px 26px color-mix(in srgb, var(--agent-accent) 40%, transparent);
+  transform: translateY(-2px);
+}
+
+.agent-chip-name {
+  font-size: 13px;
+  font-weight: 600;
+}
+
+.agent-chip-provider {
+  font-size: 11px;
+  text-transform: uppercase;
+  letter-spacing: 1px;
+  color: rgba(255, 255, 255, 0.55);
+}
+
+.agent-chip-status {
+  font-size: 12px;
+  color: rgba(255, 255, 255, 0.8);
+}
+
+.command-list {
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+}
+
+.command-item {
+  background: rgba(0, 0, 0, 0.55);
+  border: 1px solid rgba(255, 255, 255, 0.08);
+  border-radius: 10px;
+  padding: 10px 12px;
+  text-align: left;
+  color: rgba(255, 255, 255, 0.85);
+  font-size: 13px;
+  cursor: pointer;
+  transition: border 0.2s ease, background 0.2s ease;
+}
+
+.command-item:hover {
+  border-color: rgba(255, 183, 77, 0.6);
+  background: rgba(255, 183, 77, 0.12);
+}
+
+.activity-feed {
+  list-style: none;
+  display: flex;
+  flex-direction: column;
+  gap: 14px;
+  padding: 0;
+  margin: 0;
+}
+
+.activity-item {
+  display: flex;
+  gap: 12px;
+  align-items: flex-start;
+}
+
+.activity-dot {
+  width: 10px;
+  height: 10px;
+  border-radius: 50%;
+  margin-top: 6px;
+  box-shadow: 0 0 12px rgba(255, 255, 255, 0.35);
+}
+
+.activity-content {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+}
+
+.activity-title {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  font-size: 12px;
+  color: rgba(255, 255, 255, 0.65);
+}
+
+.activity-title strong {
+  font-size: 13px;
+  color: #fff;
+}
+
+.activity-content p {
+  font-size: 12px;
+  line-height: 1.5;
+  color: rgba(255, 255, 255, 0.75);
+}
+
+.activity-empty {
+  font-size: 12px;
+  color: rgba(255, 255, 255, 0.5);
+  font-style: italic;
+}
+
+.chat-status-bar {
+  position: absolute;
+  bottom: 24px;
+  left: 24px;
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  padding: 14px 18px;
+  border-radius: 14px;
+  background: rgba(0, 0, 0, 0.78);
+  border: 1px solid rgba(255, 255, 255, 0.08);
+  box-shadow: 0 18px 34px rgba(0, 0, 0, 0.45);
+  backdrop-filter: blur(18px);
+  max-width: 520px;
+}
+
+.status-pill {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+  padding: 8px 12px;
+  border-radius: 10px;
+  background: rgba(255, 255, 255, 0.04);
+  border: 1px solid rgba(255, 255, 255, 0.08);
+  min-width: 100px;
+}
+
+.status-pill.warning {
+  border-color: rgba(255, 148, 77, 0.55);
+  background: rgba(255, 148, 77, 0.16);
+}
+
+.pill-label {
+  font-size: 10px;
+  letter-spacing: 0.9px;
+  text-transform: uppercase;
+  color: rgba(255, 255, 255, 0.6);
+}
+
+.pill-value {
+  font-size: 14px;
+  font-weight: 600;
+  color: #fff;
+}
+
+.status-hint {
+  font-size: 11px;
+  color: rgba(255, 255, 255, 0.55);
+  max-width: 220px;
+  line-height: 1.4;
+}
+
+@media (max-width: 1280px) {
+  .bottom-section {
+    flex-direction: column;
+  }
+
+  .controls-panel {
+    width: 100%;
+    flex: none;
+    order: -1;
+  }
+
+  .chat-status-bar {
+    position: static;
+    margin: 20px;
+  }
+}
+
+@media (max-width: 960px) {
+  .chat-top-bar {
+    flex-direction: column;
+    height: auto;
+    padding: 16px;
+    align-items: flex-start;
+  }
+
+  .topbar-section {
+    width: 100%;
+    justify-content: space-between;
+  }
+
+  .topbar-actions {
+    width: 100%;
+    justify-content: flex-end;
+  }
+
+  .chat-header {
+    flex-direction: column;
+    align-items: flex-start;
+  }
+
+  .chat-metrics {
+    width: 100%;
+    flex-wrap: wrap;
+  }
+
+  .message-card {
+    max-width: 100%;
+  }
+}

--- a/src/components/chat/ChatStatusBar.tsx
+++ b/src/components/chat/ChatStatusBar.tsx
@@ -1,0 +1,33 @@
+import React from 'react';
+
+interface ChatStatusBarProps {
+  activeAgents: number;
+  totalMessages: number;
+  pendingResponses: number;
+}
+
+export const ChatStatusBar: React.FC<ChatStatusBarProps> = ({
+  activeAgents,
+  totalMessages,
+  pendingResponses,
+}) => {
+  return (
+    <div className="chat-status-bar">
+      <div className="status-pill">
+        <span className="pill-label">Agentes activos</span>
+        <span className="pill-value">{activeAgents}</span>
+      </div>
+      <div className="status-pill">
+        <span className="pill-label">Mensajes en sesión</span>
+        <span className="pill-value">{totalMessages}</span>
+      </div>
+      <div className={`status-pill ${pendingResponses ? 'warning' : ''}`}>
+        <span className="pill-label">Pendientes</span>
+        <span className="pill-value">{pendingResponses}</span>
+      </div>
+      <div className="status-hint">
+        Coordina instrucciones simultáneas: el hub distribuirá las tareas a cada modelo activo.
+      </div>
+    </div>
+  );
+};

--- a/src/components/chat/ChatTopBar.tsx
+++ b/src/components/chat/ChatTopBar.tsx
@@ -1,0 +1,54 @@
+import React from 'react';
+
+interface ChatTopBarProps {
+  activeAgents: number;
+  totalAgents: number;
+  pendingResponses: number;
+}
+
+export const ChatTopBar: React.FC<ChatTopBarProps> = ({
+  activeAgents,
+  totalAgents,
+  pendingResponses,
+}) => {
+  const hasPending = pendingResponses > 0;
+
+  return (
+    <header className="chat-top-bar">
+      <div className="topbar-section topbar-branding">
+        <div className="brand-icon" aria-hidden>🌀</div>
+        <div className="brand-copy">
+          <span className="brand-title">JungleMonk.AI</span>
+          <span className="brand-subtitle">Multi-Agent Studio</span>
+        </div>
+      </div>
+
+      <div className="topbar-section topbar-status">
+        <div className="status-indicator">
+          <span className={`status-led ${activeAgents ? 'online' : 'offline'}`} aria-hidden />
+          <span>{activeAgents ? 'Operativo' : 'En espera'}</span>
+        </div>
+        <div className="status-metric">
+          <span className="metric-label">Agentes activos</span>
+          <span className="metric-value">{activeAgents}/{totalAgents}</span>
+        </div>
+        <div className={`status-metric ${hasPending ? 'warning' : ''}`}>
+          <span className="metric-label">Pendientes</span>
+          <span className="metric-value">{pendingResponses}</span>
+        </div>
+      </div>
+
+      <div className="topbar-section topbar-actions">
+        <button type="button" className="topbar-button" onClick={() => console.log('Abrir comandos habituales')}>
+          ⚡ Comandos
+        </button>
+        <button type="button" className="topbar-button" onClick={() => console.log('Abrir actividad reciente')}>
+          📊 Actividad
+        </button>
+        <button type="button" className="topbar-button" onClick={() => console.log('Abrir ajustes globales')}>
+          ⚙️ Ajustes
+        </button>
+      </div>
+    </header>
+  );
+};


### PR DESCRIPTION
## Summary
- replace the audio-visualizer focused App shell with a multi-agent control hub that keeps the neon-glass look and introduces chat orchestration logic, dynamic agent toggles, and placeholder replies
- add dedicated chat top bar and status bar components plus a rich control panel for API keys, agent activation, quick commands, and activity feed visuals
- craft new styling rules that mirror the existing aesthetic for chat messages, composer, metrics, and side panels while remaining responsive

## Testing
- npm run test -- --run

------
https://chatgpt.com/codex/tasks/task_e_68ce73511430833386c78c513822bc1f