### PR TITLE
Add Groq and Anthropic integrations with global settings

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,5 @@
+anthropic>=0.36.0
+openai>=1.52.0
+groq>=0.5.0
+python-dotenv>=1.0.1
+requests>=2.32.3

--- a/src/types/globalSettings.ts
+++ b/src/types/globalSettings.ts
@@ -1,0 +1,7 @@
+export type SupportedProvider = 'openai' | 'anthropic' | 'groq';
+
+export type ApiKeySettings = Record<SupportedProvider, string>;
+
+export interface GlobalSettings {
+  apiKeys: ApiKeySettings;
+}

--- a/src/utils/aiProviders.ts
+++ b/src/utils/aiProviders.ts
@@ -1,0 +1,180 @@
+export interface ChatProviderRequest {
+  apiKey: string;
+  model: string;
+  prompt: string;
+  systemPrompt?: string;
+  maxTokens?: number;
+  temperature?: number;
+}
+
+const DEFAULT_MAX_TOKENS = 1024;
+const DEFAULT_TEMPERATURE = 0.7;
+
+const resolveMessage = (value: unknown): string => {
+  if (!value) {
+    return '';
+  }
+  if (typeof value === 'string') {
+    return value;
+  }
+  if (Array.isArray(value)) {
+    return value
+      .map(entry => {
+        if (!entry) {
+          return '';
+        }
+        if (typeof entry === 'string') {
+          return entry;
+        }
+        if (typeof entry === 'object' && 'text' in entry) {
+          const text = (entry as { text?: string }).text;
+          return typeof text === 'string' ? text : '';
+        }
+        return '';
+      })
+      .filter(Boolean)
+      .join('\n');
+  }
+  if (typeof value === 'object' && 'content' in (value as Record<string, unknown>)) {
+    return resolveMessage((value as Record<string, unknown>).content);
+  }
+  return '';
+};
+
+const ensureContent = (raw: string, provider: string): string => {
+  const content = raw.trim();
+  if (!content) {
+    throw new Error(`${provider} devolvió una respuesta vacía`);
+  }
+  return content;
+};
+
+export const callOpenAIChat = async ({
+  apiKey,
+  model,
+  prompt,
+  systemPrompt,
+  maxTokens = DEFAULT_MAX_TOKENS,
+  temperature = DEFAULT_TEMPERATURE,
+}: ChatProviderRequest): Promise<string> => {
+  const response = await fetch('https://api.openai.com/v1/chat/completions', {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json',
+      Authorization: `Bearer ${apiKey}`,
+    },
+    body: JSON.stringify({
+      model,
+      max_tokens: maxTokens,
+      temperature,
+      messages: [
+        ...(systemPrompt
+          ? [
+              {
+                role: 'system',
+                content: systemPrompt,
+              },
+            ]
+          : []),
+        {
+          role: 'user',
+          content: prompt,
+        },
+      ],
+    }),
+  });
+
+  if (!response.ok) {
+    const error = await response.json().catch(() => ({}));
+    throw new Error(error?.error?.message || `OpenAI respondió con ${response.status}`);
+  }
+
+  const payload = await response.json();
+  const choice = payload?.choices?.[0]?.message?.content;
+  return ensureContent(resolveMessage(choice), 'OpenAI');
+};
+
+export const callGroqChat = async ({
+  apiKey,
+  model,
+  prompt,
+  systemPrompt,
+  maxTokens = DEFAULT_MAX_TOKENS,
+  temperature = DEFAULT_TEMPERATURE,
+}: ChatProviderRequest): Promise<string> => {
+  const response = await fetch('https://api.groq.com/openai/v1/chat/completions', {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json',
+      Authorization: `Bearer ${apiKey}`,
+    },
+    body: JSON.stringify({
+      model,
+      max_tokens: maxTokens,
+      temperature,
+      messages: [
+        ...(systemPrompt
+          ? [
+              {
+                role: 'system',
+                content: systemPrompt,
+              },
+            ]
+          : []),
+        {
+          role: 'user',
+          content: prompt,
+        },
+      ],
+    }),
+  });
+
+  if (!response.ok) {
+    const error = await response.json().catch(() => ({}));
+    throw new Error(error?.error?.message || `Groq respondió con ${response.status}`);
+  }
+
+  const payload = await response.json();
+  const choice = payload?.choices?.[0]?.message?.content;
+  return ensureContent(resolveMessage(choice), 'Groq');
+};
+
+export const callAnthropicChat = async ({
+  apiKey,
+  model,
+  prompt,
+  systemPrompt,
+  maxTokens = DEFAULT_MAX_TOKENS,
+  temperature = DEFAULT_TEMPERATURE,
+}: ChatProviderRequest): Promise<string> => {
+  const response = await fetch('https://api.anthropic.com/v1/messages', {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json',
+      'x-api-key': apiKey,
+      'anthropic-version': '2023-06-01',
+    },
+    body: JSON.stringify({
+      model,
+      max_tokens: maxTokens,
+      temperature,
+      ...(systemPrompt ? { system: systemPrompt } : {}),
+      messages: [
+        {
+          role: 'user',
+          content: prompt,
+        },
+      ],
+    }),
+  });
+
+  if (!response.ok) {
+    const error = await response.json().catch(() => ({}));
+    const message = error?.error?.message || error?.error || error?.message;
+    throw new Error(message || `Anthropic respondió con ${response.status}`);
+  }
+
+  const payload = await response.json();
+  const content = payload?.content;
+  return ensureContent(resolveMessage(content), 'Anthropic');
+};

--- a/src/utils/globalSettings.ts
+++ b/src/utils/globalSettings.ts
@@ -1,0 +1,59 @@
+import { ApiKeySettings, GlobalSettings, SupportedProvider } from '../types/globalSettings';
+
+const STORAGE_KEY = 'global-settings';
+
+export const DEFAULT_GLOBAL_SETTINGS: GlobalSettings = {
+  apiKeys: {
+    openai: '',
+    anthropic: '',
+    groq: '',
+  },
+};
+
+const SUPPORTED_PROVIDERS: SupportedProvider[] = ['openai', 'anthropic', 'groq'];
+
+export const isSupportedProvider = (value: string): value is SupportedProvider =>
+  SUPPORTED_PROVIDERS.includes(value as SupportedProvider);
+
+const normalizeApiKeys = (input: Partial<ApiKeySettings> | undefined): ApiKeySettings => ({
+  openai: input?.openai ?? '',
+  anthropic: input?.anthropic ?? '',
+  groq: input?.groq ?? '',
+});
+
+export const loadGlobalSettings = (): GlobalSettings => {
+  if (typeof window === 'undefined' || typeof localStorage === 'undefined') {
+    return { ...DEFAULT_GLOBAL_SETTINGS };
+  }
+
+  try {
+    const raw = localStorage.getItem(STORAGE_KEY);
+    if (!raw) {
+      return { ...DEFAULT_GLOBAL_SETTINGS };
+    }
+
+    const parsed = JSON.parse(raw) as Partial<GlobalSettings>;
+    return {
+      apiKeys: normalizeApiKeys(parsed?.apiKeys),
+    };
+  } catch (error) {
+    console.warn('Unable to load global settings from storage', error);
+    return { ...DEFAULT_GLOBAL_SETTINGS };
+  }
+};
+
+export const saveGlobalSettings = (settings: GlobalSettings) => {
+  if (typeof window === 'undefined' || typeof localStorage === 'undefined') {
+    return;
+  }
+
+  try {
+    const payload: GlobalSettings = {
+      apiKeys: normalizeApiKeys(settings.apiKeys),
+    };
+    localStorage.setItem(STORAGE_KEY, JSON.stringify(payload));
+  } catch (error) {
+    console.warn('Unable to persist global settings', error);
+  }
+};
+


### PR DESCRIPTION
## Summary
- add a Python requirements file with the SDKs needed to call OpenAI, Groq and Anthropic APIs
- persist API keys through the global settings model and drive agent replies through the Groq/Anthropic HTTP APIs when keys are present
- introduce shared utilities for loading/saving global settings and for calling each provider's chat endpoint

## Testing
- npm test -- --run

------
https://chatgpt.com/codex/tasks/task_e_68ce7673dda48333b259ae02658caecd