### PR TITLE
feat: expand global settings schema and add diagnostics panel

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -8,12 +8,12 @@ import { ChatWorkspace } from './components/chat/ChatWorkspace';
 import { SidePanel } from './components/chat/SidePanel';
 import { AgentProvider, useAgents } from './core/agents/AgentContext';
 import { MessageProvider, useMessages } from './core/messages/MessageContext';
-import { ApiKeySettings, GlobalSettings, SupportedProvider } from './types/globalSettings';
+import { ApiKeySettings, GlobalSettings } from './types/globalSettings';
 import { DEFAULT_GLOBAL_SETTINGS, loadGlobalSettings, saveGlobalSettings } from './utils/globalSettings';
 
 interface AppContentProps {
   apiKeys: ApiKeySettings;
-  onApiKeyChange: (provider: SupportedProvider, value: string) => void;
+  onApiKeyChange: (provider: string, value: string) => void;
 }
 
 const AppContent: React.FC<AppContentProps> = ({ apiKeys, onApiKeyChange }) => {
@@ -53,7 +53,7 @@ const App: React.FC = () => {
     saveGlobalSettings(globalSettings);
   }, [globalSettings]);
 
-  const handleApiKeyChange = (provider: SupportedProvider, value: string) => {
+  const handleApiKeyChange = (provider: string, value: string) => {
     setGlobalSettings(prev => ({
       ...prev,
       apiKeys: {

--- a/src/components/chat/SidePanel.tsx
+++ b/src/components/chat/SidePanel.tsx
@@ -1,11 +1,11 @@
 import React, { useMemo } from 'react';
 import { useAgents } from '../../core/agents/AgentContext';
 import { useMessages } from '../../core/messages/MessageContext';
-import { ApiKeySettings, SupportedProvider } from '../../types/globalSettings';
+import { ApiKeySettings } from '../../types/globalSettings';
 
 interface SidePanelProps {
   apiKeys: ApiKeySettings;
-  onApiKeyChange: (provider: SupportedProvider, value: string) => void;
+  onApiKeyChange: (provider: string, value: string) => void;
 }
 
 export const SidePanel: React.FC<SidePanelProps> = ({ apiKeys, onApiKeyChange }) => {

--- a/src/components/settings/GlobalSettingsPanel.css
+++ b/src/components/settings/GlobalSettingsPanel.css
@@ -1,0 +1,154 @@
+.settings-modal-content.wide {
+  max-width: 960px;
+  width: 85vw;
+}
+
+.setting-button {
+  background: rgba(255, 255, 255, 0.12);
+  border: 1px solid rgba(255, 255, 255, 0.2);
+  border-radius: 8px;
+  color: #fff;
+  padding: 6px 12px;
+  font-size: 12px;
+  cursor: pointer;
+  transition: all 0.2s ease;
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+}
+
+.setting-button:hover:not(:disabled) {
+  background: rgba(255, 255, 255, 0.2);
+  transform: translateY(-1px);
+}
+
+.setting-button:disabled {
+  opacity: 0.6;
+  cursor: not-allowed;
+}
+
+.setting-button.primary {
+  background: var(--accent-color);
+  border-color: rgba(255, 255, 255, 0.25);
+  color: #1a1a1a;
+  font-weight: 600;
+}
+
+.setting-button.subtle {
+  background: transparent;
+  border-color: rgba(255, 255, 255, 0.15);
+  color: #bbb;
+}
+
+.setting-actions {
+  display: flex;
+  gap: 10px;
+  margin-top: 10px;
+}
+
+.setting-group.inline {
+  display: flex;
+  gap: 10px;
+  align-items: center;
+  margin-bottom: 24px;
+}
+
+.setting-group.inline .setting-input {
+  flex: 1;
+}
+
+.setting-success {
+  color: #72f1b8;
+  font-size: 12px;
+  margin-top: 6px;
+  display: inline-block;
+}
+
+.setting-error {
+  color: #ff7b7b;
+  font-size: 12px;
+  margin-top: 6px;
+  display: inline-block;
+}
+
+.setting-input,
+.setting-select {
+  background: rgba(255, 255, 255, 0.1);
+  border: 1px solid rgba(255, 255, 255, 0.2);
+  border-radius: 8px;
+  color: #fff;
+  padding: 8px 10px;
+  font-size: 12px;
+  transition: border 0.2s ease, box-shadow 0.2s ease;
+}
+
+.setting-input:focus,
+.setting-select:focus {
+  outline: none;
+  border-color: var(--accent-color);
+  box-shadow: 0 0 0 2px rgba(255, 183, 77, 0.2);
+}
+
+.setting-card {
+  background: rgba(0, 0, 0, 0.25);
+  border: 1px solid rgba(255, 255, 255, 0.1);
+  border-radius: 12px;
+  padding: 16px;
+  margin-bottom: 18px;
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+}
+
+.setting-card-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  gap: 12px;
+}
+
+.setting-row {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));
+  gap: 16px;
+}
+
+.setting-textarea {
+  background: rgba(255, 255, 255, 0.1);
+  border: 1px solid rgba(255, 255, 255, 0.2);
+  border-radius: 10px;
+  color: #fff;
+  padding: 10px;
+  font-size: 12px;
+  resize: vertical;
+  min-height: 120px;
+  transition: border 0.2s ease;
+}
+
+.setting-textarea:focus {
+  outline: none;
+  border-color: var(--accent-color);
+  box-shadow: 0 0 0 2px rgba(255, 183, 77, 0.2);
+}
+
+.setting-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  margin-bottom: 18px;
+}
+
+.settings-footer {
+  padding: 14px 16px;
+  border-top: 1px solid rgba(255, 255, 255, 0.1);
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  background: rgba(0, 0, 0, 0.25);
+  gap: 12px;
+}
+
+.settings-footer-actions {
+  display: flex;
+  gap: 10px;
+}

--- a/src/components/settings/GlobalSettingsPanel.tsx
+++ b/src/components/settings/GlobalSettingsPanel.tsx
@@ -1,0 +1,710 @@
+import React, { useCallback, useEffect, useMemo, useState } from 'react';
+import {
+  CommandPreset,
+  DefaultRoutingRules,
+  GlobalSettings,
+  RoutingRule,
+  SupportedProvider,
+} from '../../types/globalSettings';
+import { useProviderDiagnostics } from '../../hooks/useProviderDiagnostics';
+import '../GlobalSettingsModal.css';
+import './GlobalSettingsPanel.css';
+
+type ProviderTestState = {
+  status: 'idle' | 'loading' | 'success' | 'error';
+  message?: string;
+  latencyMs?: number;
+  modelUsed?: string;
+};
+
+interface GlobalSettingsPanelProps {
+  isOpen: boolean;
+  settings: GlobalSettings;
+  onClose: () => void;
+  onSave: (settings: GlobalSettings) => void;
+  onResetDefaults?: () => void;
+}
+
+const cloneSettings = (value: GlobalSettings): GlobalSettings => ({
+  version: value.version,
+  apiKeys: { ...value.apiKeys },
+  commandPresets: value.commandPresets.map((preset) => ({
+    ...preset,
+    settings: preset.settings ? { ...preset.settings } : undefined,
+  })),
+  defaultRoutingRules: Object.entries(value.defaultRoutingRules).reduce<DefaultRoutingRules>(
+    (acc, [key, rule]) => ({
+      ...acc,
+      [key]: { ...rule },
+    }),
+    {}
+  ),
+});
+
+const getPresetId = () => {
+  if (typeof crypto !== 'undefined' && 'randomUUID' in crypto) {
+    return crypto.randomUUID();
+  }
+  return `preset-${Date.now().toString(36)}-${Math.random().toString(36).slice(2, 8)}`;
+};
+
+const PROVIDER_LABELS: Record<string, string> = {
+  openai: 'OpenAI',
+  anthropic: 'Anthropic',
+  groq: 'Groq',
+};
+
+const toTitle = (value: string) => {
+  if (PROVIDER_LABELS[value]) {
+    return PROVIDER_LABELS[value];
+  }
+  const lower = value.toLowerCase();
+  return lower.charAt(0).toUpperCase() + lower.slice(1);
+};
+
+export const GlobalSettingsPanel: React.FC<GlobalSettingsPanelProps> = ({
+  isOpen,
+  settings,
+  onClose,
+  onSave,
+  onResetDefaults,
+}) => {
+  const { supportedProviders, validateApiKey, testConnection, getDefaultModel } =
+    useProviderDiagnostics();
+  const builtinProviders = useMemo(() => supportedProviders, [supportedProviders]);
+  const [draft, setDraft] = useState<GlobalSettings>(() => cloneSettings(settings));
+  const [activeTab, setActiveTab] = useState<'providers' | 'presets' | 'routing'>('providers');
+  const [touchedProviders, setTouchedProviders] = useState<Record<string, boolean>>({});
+  const [testStates, setTestStates] = useState<Record<string, ProviderTestState>>({});
+  const [newProviderId, setNewProviderId] = useState('');
+
+  useEffect(() => {
+    if (isOpen) {
+      setDraft(cloneSettings(settings));
+      setActiveTab('providers');
+      setTouchedProviders({});
+      setTestStates({});
+      setNewProviderId('');
+    }
+  }, [isOpen, settings]);
+
+  const providerOrder = useMemo(() => {
+    const seen = new Set<string>();
+    const providers: string[] = [];
+
+    builtinProviders.forEach((provider) => {
+      if (!seen.has(provider)) {
+        providers.push(provider);
+        seen.add(provider);
+      }
+    });
+
+    Object.keys(draft.apiKeys).forEach((provider) => {
+      if (!seen.has(provider)) {
+        providers.push(provider);
+        seen.add(provider);
+      }
+    });
+
+    return providers;
+  }, [builtinProviders, draft.apiKeys]);
+
+  const validationResults = useMemo(() => {
+    return providerOrder.reduce<Record<string, ReturnType<typeof validateApiKey>>>(
+      (acc, provider) => ({
+        ...acc,
+        [provider]: validateApiKey(provider, draft.apiKeys[provider] ?? ''),
+      }),
+      {}
+    );
+  }, [draft.apiKeys, providerOrder, validateApiKey]);
+
+  const handleApiKeyChange = useCallback((provider: string, value: string) => {
+    setDraft((prev) => ({
+      ...prev,
+      apiKeys: {
+        ...prev.apiKeys,
+        [provider]: value,
+      },
+    }));
+    setTouchedProviders((prev) => ({
+      ...prev,
+      [provider]: true,
+    }));
+  }, []);
+
+  const handleTestConnection = useCallback(
+    async (provider: string) => {
+      const apiKey = draft.apiKeys[provider] ?? '';
+      setTouchedProviders((prev) => ({
+        ...prev,
+        [provider]: true,
+      }));
+
+      const validation = validationResults[provider];
+      if (!validation?.valid) {
+        setTestStates((prev) => ({
+          ...prev,
+          [provider]: {
+            status: 'error',
+            message: validation.message ?? 'La API key no parece válida.',
+          },
+        }));
+        return;
+      }
+
+      setTestStates((prev) => ({
+        ...prev,
+        [provider]: { status: 'loading' },
+      }));
+
+      const result = await testConnection(provider, apiKey, getDefaultModel(provider));
+      setTestStates((prev) => ({
+        ...prev,
+        [provider]: result.ok
+          ? {
+              status: 'success',
+              latencyMs: result.latencyMs,
+              modelUsed: result.modelUsed,
+              message: result.message,
+            }
+          : {
+              status: 'error',
+              message: result.message,
+            },
+      }));
+    },
+    [draft.apiKeys, getDefaultModel, testConnection, validationResults]
+  );
+
+  const handleAddProvider = useCallback(() => {
+    const normalized = newProviderId.trim().toLowerCase();
+    if (!normalized) {
+      return;
+    }
+
+    setDraft((prev) => {
+      if (normalized in prev.apiKeys) {
+        return prev;
+      }
+      return {
+        ...prev,
+        apiKeys: {
+          ...prev.apiKeys,
+          [normalized]: '',
+        },
+      };
+    });
+    setNewProviderId('');
+  }, [newProviderId]);
+
+  const handleRemoveProvider = useCallback((provider: string) => {
+    if (builtinProviders.includes(provider as SupportedProvider)) {
+      return;
+    }
+    setDraft((prev) => {
+      const { [provider]: _removed, ...rest } = prev.apiKeys;
+      return {
+        ...prev,
+        apiKeys: rest,
+      };
+    });
+    setTouchedProviders((prev) => {
+      const { [provider]: _removed, ...rest } = prev;
+      return rest;
+    });
+    setTestStates((prev) => {
+      const { [provider]: _removed, ...rest } = prev;
+      return rest;
+    });
+  }, [builtinProviders]);
+
+  const handlePresetChange = useCallback(
+    (id: string, patch: Partial<CommandPreset>) => {
+      setDraft((prev) => ({
+        ...prev,
+        commandPresets: prev.commandPresets.map((preset) =>
+          preset.id === id
+            ? {
+                ...preset,
+                ...patch,
+                settings:
+                  patch.settings !== undefined
+                    ? patch.settings
+                    : preset.settings
+                    ? { ...preset.settings }
+                    : undefined,
+              }
+            : preset
+        ),
+      }));
+    },
+    []
+  );
+
+  const handlePresetSettingsChange = useCallback(
+    (id: string, patch: CommandPreset['settings']) => {
+      setDraft((prev) => ({
+        ...prev,
+        commandPresets: prev.commandPresets.map((preset) =>
+          preset.id === id
+            ? {
+                ...preset,
+                settings: {
+                  ...preset.settings,
+                  ...patch,
+                },
+              }
+            : preset
+        ),
+      }));
+    },
+    []
+  );
+
+  const handleAddPreset = useCallback(() => {
+    const newPreset: CommandPreset = {
+      id: getPresetId(),
+      label: 'Nuevo preset',
+      prompt: 'Describe la tarea que debe ejecutar este preset...',
+      provider: providerOrder[0] ?? '',
+      model: '',
+    };
+
+    setDraft((prev) => ({
+      ...prev,
+      commandPresets: [...prev.commandPresets, newPreset],
+    }));
+  }, [providerOrder]);
+
+  const handleRemovePreset = useCallback((id: string) => {
+    setDraft((prev) => ({
+      ...prev,
+      commandPresets: prev.commandPresets.filter((preset) => preset.id !== id),
+    }));
+  }, []);
+
+  const handleRoutingRuleChange = useCallback(
+    (routeKey: string, field: keyof RoutingRule | 'key', value: string) => {
+      setDraft((prev) => {
+        const currentRule = prev.defaultRoutingRules[routeKey];
+        if (!currentRule) {
+          return prev;
+        }
+
+        if (field === 'key') {
+          const newKey = value.trim();
+          if (!newKey || newKey === routeKey) {
+            return prev;
+          }
+          if (prev.defaultRoutingRules[newKey]) {
+            return prev;
+          }
+          const { [routeKey]: _removed, ...rest } = prev.defaultRoutingRules;
+          return {
+            ...prev,
+            defaultRoutingRules: {
+              ...rest,
+              [newKey]: { ...currentRule },
+            },
+          };
+        }
+
+        const trimmed = value.trim();
+        return {
+          ...prev,
+          defaultRoutingRules: {
+            ...prev.defaultRoutingRules,
+            [routeKey]: {
+              ...currentRule,
+              [field]:
+                field === 'commandPresetId'
+                  ? (trimmed ? trimmed : undefined)
+                  : trimmed,
+            },
+          },
+        };
+      });
+    },
+    []
+  );
+
+  const handleAddRoutingRule = useCallback(() => {
+    setDraft((prev) => {
+      let candidate = 'chat';
+      let index = 1;
+      while (prev.defaultRoutingRules[candidate]) {
+        candidate = `route-${index}`;
+        index += 1;
+      }
+
+      return {
+        ...prev,
+        defaultRoutingRules: {
+          ...prev.defaultRoutingRules,
+          [candidate]: {
+            provider: providerOrder[0] ?? '',
+            model: '',
+          },
+        },
+      };
+    });
+  }, [providerOrder]);
+
+  const handleRemoveRoutingRule = useCallback((routeKey: string) => {
+    setDraft((prev) => {
+      const { [routeKey]: _removed, ...rest } = prev.defaultRoutingRules;
+      return {
+        ...prev,
+        defaultRoutingRules: rest,
+      };
+    });
+  }, []);
+
+  const handleSave = useCallback(() => {
+    onSave(cloneSettings(draft));
+    onClose();
+  }, [draft, onClose, onSave]);
+
+  if (!isOpen) {
+    return null;
+  }
+
+  return (
+    <div className="settings-modal-overlay">
+      <div className="settings-modal-content wide">
+        <div className="settings-header">
+          <h2>🔐 Ajustes Globales de IA</h2>
+          <button className="close-button" onClick={onClose}>
+            ✕
+          </button>
+        </div>
+
+        <div className="settings-main">
+          <div className="settings-sidebar">
+            {[
+              { id: 'providers', label: 'Credenciales', icon: '🔑' },
+              { id: 'presets', label: 'Comandos', icon: '🧩' },
+              { id: 'routing', label: 'Preferencias', icon: '🧭' },
+            ].map((tab) => (
+              <button
+                key={tab.id}
+                className={`tab-button ${activeTab === tab.id ? 'active' : ''}`}
+                onClick={() => setActiveTab(tab.id as typeof activeTab)}
+              >
+                <span className="tab-icon">{tab.icon}</span>
+                {tab.label}
+              </button>
+            ))}
+          </div>
+
+          <div className="settings-content">
+            {activeTab === 'providers' && (
+              <div className="settings-section">
+                <h3>Credenciales por proveedor</h3>
+                <p className="setting-hint">
+                  Guarda tus API keys de manera local. Nunca se comparten fuera de tu dispositivo.
+                </p>
+
+                <div className="setting-group inline">
+                  <input
+                    type="text"
+                    placeholder="Agregar proveedor personalizado"
+                    value={newProviderId}
+                    onChange={(event) => setNewProviderId(event.target.value)}
+                    className="setting-input"
+                  />
+                  <button className="setting-button" onClick={handleAddProvider}>
+                    Añadir
+                  </button>
+                </div>
+
+                {providerOrder.map((provider) => {
+                  const value = draft.apiKeys[provider] ?? '';
+                  const validation = validationResults[provider];
+                  const testState = testStates[provider] ?? { status: 'idle' };
+                  const showValidation = touchedProviders[provider] && !validation?.valid;
+
+                  return (
+                    <div className="setting-group" key={provider}>
+                      <label className="setting-label">
+                        <span>{toTitle(provider)}</span>
+                        <input
+                          type="password"
+                          value={value}
+                          placeholder="sk-..."
+                          className="setting-input"
+                          onChange={(event) => handleApiKeyChange(provider, event.target.value)}
+                        />
+                      </label>
+
+                      <div className="setting-actions">
+                        {!builtinProviders.includes(provider as SupportedProvider) && (
+                          <button
+                            className="setting-button subtle"
+                            onClick={() => handleRemoveProvider(provider)}
+                          >
+                            Quitar
+                          </button>
+                        )}
+                        <button
+                          className="setting-button"
+                          onClick={() => handleTestConnection(provider)}
+                          disabled={testState.status === 'loading'}
+                        >
+                          {testState.status === 'loading' ? 'Probando…' : 'Probar conexión'}
+                        </button>
+                      </div>
+
+                      {showValidation && validation?.message && (
+                        <small className="setting-error">{validation.message}</small>
+                      )}
+
+                      {testState.status === 'success' && (
+                        <small className="setting-success">
+                          {testState.message || 'Conexión verificada.'}
+                          {typeof testState.latencyMs === 'number' && (
+                            <span> · {Math.round(testState.latencyMs)} ms</span>
+                          )}
+                          {testState.modelUsed && <span> · Modelo: {testState.modelUsed}</span>}
+                        </small>
+                      )}
+
+                      {testState.status === 'error' && testState.message && (
+                        <small className="setting-error">{testState.message}</small>
+                      )}
+                    </div>
+                  );
+                })}
+              </div>
+            )}
+
+            {activeTab === 'presets' && (
+              <div className="settings-section">
+                <div className="setting-header">
+                  <h3>Plantillas de comandos</h3>
+                  <button className="setting-button" onClick={handleAddPreset}>
+                    Nueva plantilla
+                  </button>
+                </div>
+
+                {draft.commandPresets.length === 0 && (
+                  <p className="setting-hint">
+                    Aún no hay plantillas configuradas. Crea una para reutilizar prompts frecuentes.
+                  </p>
+                )}
+
+                {draft.commandPresets.map((preset) => (
+                  <div className="setting-card" key={preset.id}>
+                    <div className="setting-card-header">
+                      <h4>{preset.label}</h4>
+                      <button
+                        className="setting-button subtle"
+                        onClick={() => handleRemovePreset(preset.id)}
+                      >
+                        Eliminar
+                      </button>
+                    </div>
+                    <label className="setting-label">
+                      <span>Nombre</span>
+                      <input
+                        type="text"
+                        className="setting-input"
+                        value={preset.label}
+                        onChange={(event) =>
+                          handlePresetChange(preset.id, { label: event.target.value })
+                        }
+                      />
+                    </label>
+                    <label className="setting-label">
+                      <span>Descripción</span>
+                      <input
+                        type="text"
+                        className="setting-input"
+                        value={preset.description ?? ''}
+                        onChange={(event) =>
+                          handlePresetChange(preset.id, { description: event.target.value })
+                        }
+                        placeholder="Uso recomendado o notas adicionales"
+                      />
+                    </label>
+                    <label className="setting-label">
+                      <span>Prompt</span>
+                      <textarea
+                        className="setting-textarea"
+                        rows={4}
+                        value={preset.prompt}
+                        onChange={(event) =>
+                          handlePresetChange(preset.id, { prompt: event.target.value })
+                        }
+                      />
+                    </label>
+                    <div className="setting-row">
+                      <label className="setting-label">
+                        <span>Proveedor</span>
+                        <input
+                          type="text"
+                          className="setting-input"
+                          value={preset.provider ?? ''}
+                          onChange={(event) =>
+                            handlePresetChange(preset.id, { provider: event.target.value })
+                          }
+                          placeholder="openai, anthropic, groq…"
+                        />
+                      </label>
+                      <label className="setting-label">
+                        <span>Modelo</span>
+                        <input
+                          type="text"
+                          className="setting-input"
+                          value={preset.model ?? ''}
+                          onChange={(event) =>
+                            handlePresetChange(preset.id, { model: event.target.value })
+                          }
+                          placeholder="gpt-4o-mini, claude-3-haiku, etc."
+                        />
+                      </label>
+                    </div>
+                    <div className="setting-row">
+                      <label className="setting-label">
+                        <span>Temperatura</span>
+                        <input
+                          type="number"
+                          step="0.1"
+                          min="0"
+                          max="2"
+                          className="setting-input"
+                          value={preset.settings?.temperature ?? ''}
+                          onChange={(event) =>
+                            handlePresetSettingsChange(preset.id, {
+                              temperature: event.target.value === '' ? undefined : Number(event.target.value),
+                            })
+                          }
+                        />
+                      </label>
+                      <label className="setting-label">
+                        <span>Máx. tokens</span>
+                        <input
+                          type="number"
+                          min="16"
+                          step="8"
+                          className="setting-input"
+                          value={preset.settings?.maxTokens ?? ''}
+                          onChange={(event) =>
+                            handlePresetSettingsChange(preset.id, {
+                              maxTokens: event.target.value === '' ? undefined : Number(event.target.value),
+                            })
+                          }
+                        />
+                      </label>
+                    </div>
+                  </div>
+                ))}
+              </div>
+            )}
+
+            {activeTab === 'routing' && (
+              <div className="settings-section">
+                <div className="setting-header">
+                  <h3>Preferencias por defecto</h3>
+                  <button className="setting-button" onClick={handleAddRoutingRule}>
+                    Añadir preferencia
+                  </button>
+                </div>
+
+                {Object.keys(draft.defaultRoutingRules).length === 0 && (
+                  <p className="setting-hint">
+                    Define reglas para elegir proveedor y modelo automáticamente según el contexto.
+                  </p>
+                )}
+
+                {Object.entries(draft.defaultRoutingRules).map(([routeKey, rule]) => (
+                  <div className="setting-card" key={routeKey}>
+                    <div className="setting-card-header">
+                      <input
+                        type="text"
+                        className="setting-input"
+                        value={routeKey}
+                        onChange={(event) =>
+                          handleRoutingRuleChange(routeKey, 'key', event.target.value)
+                        }
+                      />
+                      <button
+                        className="setting-button subtle"
+                        onClick={() => handleRemoveRoutingRule(routeKey)}
+                      >
+                        Eliminar
+                      </button>
+                    </div>
+
+                    <div className="setting-row">
+                      <label className="setting-label">
+                        <span>Proveedor</span>
+                        <input
+                          type="text"
+                          className="setting-input"
+                          value={rule.provider}
+                          onChange={(event) =>
+                            handleRoutingRuleChange(routeKey, 'provider', event.target.value)
+                          }
+                          placeholder="openai, anthropic, groq…"
+                        />
+                      </label>
+                      <label className="setting-label">
+                        <span>Modelo</span>
+                        <input
+                          type="text"
+                          className="setting-input"
+                          value={rule.model}
+                          onChange={(event) =>
+                            handleRoutingRuleChange(routeKey, 'model', event.target.value)
+                          }
+                          placeholder="Modelo preferido"
+                        />
+                      </label>
+                    </div>
+                    <label className="setting-label">
+                      <span>Plantilla vinculada</span>
+                      <select
+                        className="setting-select"
+                        value={rule.commandPresetId ?? ''}
+                        onChange={(event) =>
+                          handleRoutingRuleChange(routeKey, 'commandPresetId', event.target.value)
+                        }
+                      >
+                        <option value="">Ninguna</option>
+                        {draft.commandPresets.map((preset) => (
+                          <option key={preset.id} value={preset.id}>
+                            {preset.label}
+                          </option>
+                        ))}
+                      </select>
+                    </label>
+                  </div>
+                ))}
+              </div>
+            )}
+          </div>
+        </div>
+
+        <div className="settings-footer">
+          {onResetDefaults && (
+            <button className="setting-button subtle" onClick={onResetDefaults}>
+              Restaurar valores por defecto
+            </button>
+          )}
+          <div className="settings-footer-actions">
+            <button className="setting-button subtle" onClick={onClose}>
+              Cancelar
+            </button>
+            <button className="setting-button primary" onClick={handleSave}>
+              Guardar cambios
+            </button>
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+};
+
+export default GlobalSettingsPanel;

--- a/src/hooks/useProviderDiagnostics.ts
+++ b/src/hooks/useProviderDiagnostics.ts
@@ -1,0 +1,147 @@
+import { useCallback, useMemo } from 'react';
+import { callAnthropicChat, callGroqChat, callOpenAIChat } from '../utils/aiProviders';
+import {
+  getSupportedProviders,
+  isSupportedProvider,
+} from '../utils/globalSettings';
+import { SupportedProvider } from '../types/globalSettings';
+
+export interface ApiKeyValidationResult {
+  valid: boolean;
+  message?: string;
+}
+
+export interface ProviderTestResult {
+  ok: boolean;
+  latencyMs?: number;
+  modelUsed?: string;
+  message?: string;
+}
+
+const PROVIDER_PATTERNS: Partial<Record<SupportedProvider, RegExp>> = {
+  openai: /^sk-[a-zA-Z0-9]{20,}$/,
+  anthropic: /^sk-ant-[a-zA-Z0-9]{20,}$/,
+  groq: /^gsk_[a-zA-Z0-9]{20,}$/,
+};
+
+const PROVIDER_TEST_MODELS: Record<SupportedProvider, string> = {
+  openai: 'gpt-4o-mini',
+  anthropic: 'claude-3-haiku-20240307',
+  groq: 'mixtral-8x7b-32768',
+};
+
+const TEST_PROMPT = 'Responde únicamente con "OK".';
+
+const getTimestamp = () => (typeof performance !== 'undefined' ? performance.now() : Date.now());
+
+export const useProviderDiagnostics = () => {
+  const supportedProviders = useMemo(() => getSupportedProviders(), []);
+
+  const validateApiKey = useCallback(
+    (provider: string, rawKey: string): ApiKeyValidationResult => {
+      const apiKey = rawKey?.trim?.() ?? '';
+      if (!apiKey) {
+        return { valid: false, message: 'Ingresa una API key para continuar.' };
+      }
+
+      if (!isSupportedProvider(provider)) {
+        return { valid: true };
+      }
+
+      const pattern = PROVIDER_PATTERNS[provider];
+      if (pattern && !pattern.test(apiKey)) {
+        return {
+          valid: false,
+          message: 'El formato de la API key parece inválido.',
+        };
+      }
+
+      return { valid: true };
+    },
+    []
+  );
+
+  const testConnection = useCallback(
+    async (provider: string, rawKey: string, model?: string): Promise<ProviderTestResult> => {
+      const apiKey = rawKey?.trim?.() ?? '';
+      if (!apiKey) {
+        return { ok: false, message: 'Ingresa una API key antes de probar.' };
+      }
+
+      if (!isSupportedProvider(provider)) {
+        return {
+          ok: false,
+          message: 'El diagnóstico automático no está disponible para este proveedor.',
+        };
+      }
+
+      const selectedModel = model?.trim() || PROVIDER_TEST_MODELS[provider];
+      const requestPayload = {
+        apiKey,
+        model: selectedModel,
+        prompt: TEST_PROMPT,
+        systemPrompt: 'Eres un monitor de conectividad. Devuelve "OK".',
+        maxTokens: 8,
+        temperature: 0,
+      } as const;
+
+      const start = getTimestamp();
+
+      try {
+        switch (provider) {
+          case 'openai':
+            await callOpenAIChat(requestPayload);
+            break;
+          case 'anthropic':
+            await callAnthropicChat(requestPayload);
+            break;
+          case 'groq':
+            await callGroqChat(requestPayload);
+            break;
+          default:
+            return {
+              ok: false,
+              message: 'Proveedor no soportado para diagnóstico.',
+            };
+        }
+
+        const latencyMs = getTimestamp() - start;
+        return {
+          ok: true,
+          latencyMs,
+          modelUsed: selectedModel,
+          message: 'Conexión exitosa.',
+        };
+      } catch (error) {
+        const message =
+          error instanceof Error
+            ? error.message
+            : 'No fue posible completar la prueba de conexión.';
+        return {
+          ok: false,
+          message,
+        };
+      }
+    },
+    []
+  );
+
+  const getDefaultModel = useCallback(
+    (provider: string): string | undefined => {
+      if (!isSupportedProvider(provider)) {
+        return undefined;
+      }
+      return PROVIDER_TEST_MODELS[provider];
+    },
+    []
+  );
+
+  return {
+    supportedProviders,
+    validateApiKey,
+    testConnection,
+    getDefaultModel,
+  };
+};
+
+export type UseProviderDiagnostics = ReturnType<typeof useProviderDiagnostics>;

--- a/src/types/globalSettings.ts
+++ b/src/types/globalSettings.ts
@@ -1,7 +1,35 @@
 export type SupportedProvider = 'openai' | 'anthropic' | 'groq';
 
-export type ApiKeySettings = Record<SupportedProvider, string>;
+export const BUILTIN_PROVIDERS: SupportedProvider[] = ['openai', 'anthropic', 'groq'];
+
+export type ApiKeySettings = Record<string, string>;
+
+export interface CommandPresetSettings {
+  temperature?: number;
+  maxTokens?: number;
+}
+
+export interface CommandPreset {
+  id: string;
+  label: string;
+  prompt: string;
+  description?: string;
+  provider?: string;
+  model?: string;
+  settings?: CommandPresetSettings;
+}
+
+export interface RoutingRule {
+  provider: string;
+  model: string;
+  commandPresetId?: string;
+}
+
+export type DefaultRoutingRules = Record<string, RoutingRule>;
 
 export interface GlobalSettings {
+  version: number;
   apiKeys: ApiKeySettings;
+  commandPresets: CommandPreset[];
+  defaultRoutingRules: DefaultRoutingRules;
 }

--- a/src/utils/globalSettings.ts
+++ b/src/utils/globalSettings.ts
@@ -1,25 +1,232 @@
-import { ApiKeySettings, GlobalSettings, SupportedProvider } from '../types/globalSettings';
+import Ajv, { JSONSchemaType } from 'ajv';
+import {
+  ApiKeySettings,
+  BUILTIN_PROVIDERS,
+  CommandPreset,
+  DefaultRoutingRules,
+  GlobalSettings,
+  RoutingRule,
+  SupportedProvider,
+} from '../types/globalSettings';
 
 const STORAGE_KEY = 'global-settings';
+const CURRENT_SCHEMA_VERSION = 2;
 
-export const DEFAULT_GLOBAL_SETTINGS: GlobalSettings = {
-  apiKeys: {
-    openai: '',
-    anthropic: '',
-    groq: '',
+const ajv = new Ajv({ allErrors: true, removeAdditional: 'failing' });
+
+const globalSettingsSchema: JSONSchemaType<GlobalSettings> = {
+  type: 'object',
+  properties: {
+    version: { type: 'integer', minimum: 1 },
+    apiKeys: {
+      type: 'object',
+      required: [],
+      additionalProperties: { type: 'string' },
+    } as unknown as JSONSchemaType<ApiKeySettings>,
+    commandPresets: {
+      type: 'array',
+      items: {
+        type: 'object',
+        properties: {
+          id: { type: 'string' },
+          label: { type: 'string' },
+          prompt: { type: 'string' },
+          description: { type: 'string', nullable: true },
+          provider: { type: 'string', nullable: true },
+          model: { type: 'string', nullable: true },
+          settings: {
+            type: 'object',
+            nullable: true,
+            properties: {
+              temperature: { type: 'number', nullable: true },
+              maxTokens: { type: 'integer', nullable: true },
+            },
+            required: [],
+            additionalProperties: false,
+          },
+        },
+        required: ['id', 'label', 'prompt'],
+        additionalProperties: false,
+      },
+    },
+    defaultRoutingRules: {
+      type: 'object',
+      required: [],
+      additionalProperties: {
+        type: 'object',
+        properties: {
+          provider: { type: 'string' },
+          model: { type: 'string' },
+          commandPresetId: { type: 'string', nullable: true },
+        },
+        required: ['provider', 'model'],
+        additionalProperties: false,
+      },
+    } as unknown as JSONSchemaType<DefaultRoutingRules>,
   },
+  required: ['version', 'apiKeys', 'commandPresets', 'defaultRoutingRules'],
+  additionalProperties: false,
 };
 
-const SUPPORTED_PROVIDERS: SupportedProvider[] = ['openai', 'anthropic', 'groq'];
+const validateGlobalSettings = ajv.compile<GlobalSettings>(globalSettingsSchema);
+
+const SUPPORTED_PROVIDERS: SupportedProvider[] = [...BUILTIN_PROVIDERS];
+
+const normalizeApiKeys = (input: ApiKeySettings | undefined): ApiKeySettings => {
+  const normalized: ApiKeySettings = {};
+
+  if (input && typeof input === 'object') {
+    Object.entries(input).forEach(([provider, key]) => {
+      if (typeof key === 'string') {
+        const sanitized = key.trim();
+        normalized[provider] = sanitized;
+      }
+    });
+  }
+
+  SUPPORTED_PROVIDERS.forEach((provider) => {
+    if (!(provider in normalized)) {
+      normalized[provider] = '';
+    }
+  });
+
+  return normalized;
+};
+
+const normalizeCommandPresets = (presets: CommandPreset[] | undefined): CommandPreset[] => {
+  if (!Array.isArray(presets)) {
+    return [];
+  }
+
+  return presets
+    .filter(
+      (preset): preset is CommandPreset =>
+        typeof preset === 'object' &&
+        preset !== null &&
+        typeof preset.id === 'string' &&
+        typeof preset.label === 'string' &&
+        typeof preset.prompt === 'string'
+    )
+    .map((preset) => {
+      const rawSettings =
+        preset.settings && typeof preset.settings === 'object'
+          ? {
+              temperature:
+                typeof preset.settings.temperature === 'number'
+                  ? preset.settings.temperature
+                  : undefined,
+              maxTokens:
+                typeof preset.settings.maxTokens === 'number'
+                  ? Math.round(preset.settings.maxTokens)
+                  : undefined,
+            }
+          : undefined;
+
+      const settings = rawSettings
+        ? Object.fromEntries(
+            Object.entries(rawSettings).filter(([, value]) => typeof value === 'number')
+          )
+        : undefined;
+
+      return {
+        id: preset.id,
+        label: preset.label,
+        prompt: preset.prompt,
+        description: typeof preset.description === 'string' ? preset.description : undefined,
+        provider:
+          typeof preset.provider === 'string' && preset.provider.trim()
+            ? preset.provider.trim()
+            : undefined,
+        model:
+          typeof preset.model === 'string' && preset.model.trim()
+            ? preset.model.trim()
+            : undefined,
+        settings: settings && Object.keys(settings).length > 0 ? (settings as CommandPreset['settings']) : undefined,
+      };
+    });
+};
+
+const normalizeRoutingRules = (
+  rules: DefaultRoutingRules | undefined
+): DefaultRoutingRules => {
+  if (!rules || typeof rules !== 'object') {
+    return {};
+  }
+
+  return Object.entries(rules).reduce<DefaultRoutingRules>((acc, [key, value]) => {
+    if (
+      value &&
+      typeof value === 'object' &&
+      typeof (value as RoutingRule).provider === 'string' &&
+      typeof (value as RoutingRule).model === 'string'
+    ) {
+      const provider = (value as RoutingRule).provider.trim();
+      const model = (value as RoutingRule).model.trim();
+      if (!provider || !model) {
+        return acc;
+      }
+      acc[key] = {
+        provider,
+        model,
+        commandPresetId:
+          typeof (value as RoutingRule).commandPresetId === 'string'
+            ? (value as RoutingRule).commandPresetId.trim() || undefined
+            : undefined,
+      };
+    }
+    return acc;
+  }, {});
+};
+
+export const DEFAULT_GLOBAL_SETTINGS: GlobalSettings = {
+  version: CURRENT_SCHEMA_VERSION,
+  apiKeys: normalizeApiKeys({}),
+  commandPresets: [],
+  defaultRoutingRules: {},
+};
 
 export const isSupportedProvider = (value: string): value is SupportedProvider =>
   SUPPORTED_PROVIDERS.includes(value as SupportedProvider);
 
-const normalizeApiKeys = (input: Partial<ApiKeySettings> | undefined): ApiKeySettings => ({
-  openai: input?.openai ?? '',
-  anthropic: input?.anthropic ?? '',
-  groq: input?.groq ?? '',
-});
+type PersistedSettings = Partial<GlobalSettings> & { version?: number };
+
+const migrateSettings = (raw: PersistedSettings | undefined): GlobalSettings => {
+  if (!raw || typeof raw !== 'object') {
+    return { ...DEFAULT_GLOBAL_SETTINGS };
+  }
+
+  const version = typeof raw.version === 'number' ? raw.version : 1;
+
+  if (version > CURRENT_SCHEMA_VERSION) {
+    return {
+      ...DEFAULT_GLOBAL_SETTINGS,
+      apiKeys: normalizeApiKeys(raw.apiKeys),
+    };
+  }
+
+  if (version === 1) {
+    return {
+      ...DEFAULT_GLOBAL_SETTINGS,
+      apiKeys: normalizeApiKeys(raw.apiKeys),
+    };
+  }
+
+  if (version === CURRENT_SCHEMA_VERSION) {
+    const normalized: GlobalSettings = {
+      version: CURRENT_SCHEMA_VERSION,
+      apiKeys: normalizeApiKeys(raw.apiKeys),
+      commandPresets: normalizeCommandPresets(raw.commandPresets),
+      defaultRoutingRules: normalizeRoutingRules(raw.defaultRoutingRules),
+    };
+
+    if (validateGlobalSettings(normalized)) {
+      return normalized;
+    }
+  }
+
+  console.warn('Invalid global settings payload detected, using defaults');
+  return { ...DEFAULT_GLOBAL_SETTINGS };
+};
 
 export const loadGlobalSettings = (): GlobalSettings => {
   if (typeof window === 'undefined' || typeof localStorage === 'undefined') {
@@ -32,10 +239,8 @@ export const loadGlobalSettings = (): GlobalSettings => {
       return { ...DEFAULT_GLOBAL_SETTINGS };
     }
 
-    const parsed = JSON.parse(raw) as Partial<GlobalSettings>;
-    return {
-      apiKeys: normalizeApiKeys(parsed?.apiKeys),
-    };
+    const parsed = JSON.parse(raw) as PersistedSettings;
+    return migrateSettings(parsed);
   } catch (error) {
     console.warn('Unable to load global settings from storage', error);
     return { ...DEFAULT_GLOBAL_SETTINGS };
@@ -49,7 +254,10 @@ export const saveGlobalSettings = (settings: GlobalSettings) => {
 
   try {
     const payload: GlobalSettings = {
+      version: CURRENT_SCHEMA_VERSION,
       apiKeys: normalizeApiKeys(settings.apiKeys),
+      commandPresets: normalizeCommandPresets(settings.commandPresets),
+      defaultRoutingRules: normalizeRoutingRules(settings.defaultRoutingRules),
     };
     localStorage.setItem(STORAGE_KEY, JSON.stringify(payload));
   } catch (error) {
@@ -57,3 +265,4 @@ export const saveGlobalSettings = (settings: GlobalSettings) => {
   }
 };
 
+export const getSupportedProviders = (): SupportedProvider[] => [...SUPPORTED_PROVIDERS];


### PR DESCRIPTION
## Summary
- expand the global settings type to include schema versioning, command presets, routing rules, and provider-aware API key storage
- add Ajv-backed persistence helpers plus migrations for the enriched settings payload and expose provider diagnostics utilities
- introduce a GlobalSettingsPanel modal with credential management, command templates, default routing preferences, and API key validation hooks
- update app surfaces to accept dynamic provider keys and styling resources for the new modal

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68ce7d2db1f883339108e77241e840f7