### PR TITLE
feat: soporte de mensajes multimodales

### DIFF
--- a/src/components/chat/SidePanel.tsx
+++ b/src/components/chat/SidePanel.tsx
@@ -107,6 +107,20 @@ export const SidePanel: React.FC<SidePanelProps> = ({ apiKeys, onApiKeyChange })
                 return null;
               }
 
+              const preview = Array.isArray(message.content)
+                ? message.content
+                    .map(part => {
+                      if (typeof part === 'string') {
+                        return part;
+                      }
+                      if (part.type === 'text') {
+                        return part.text;
+                      }
+                      return `[${part.type}]`;
+                    })
+                    .join(' · ')
+                : message.content;
+
               return (
                 <li key={message.id} className="activity-item">
                   <span className="activity-dot" style={{ background: agent.accent }} />
@@ -115,7 +129,7 @@ export const SidePanel: React.FC<SidePanelProps> = ({ apiKeys, onApiKeyChange })
                       <strong>{agent.name}</strong>
                       <span>{formatTimestamp(message.timestamp)}</span>
                     </div>
-                    <p>{message.content}</p>
+                    <p>{preview}</p>
                   </div>
                 </li>
               );

--- a/src/components/chat/composer/AttachmentPicker.tsx
+++ b/src/components/chat/composer/AttachmentPicker.tsx
@@ -1,0 +1,109 @@
+import React, { useCallback, useRef } from 'react';
+import { ChatAttachment } from '../../../core/messages/messageTypes';
+
+interface AttachmentPickerProps {
+  attachments: ChatAttachment[];
+  onAdd: (attachments: ChatAttachment[]) => void;
+  onRemove: (attachmentId: string) => void;
+}
+
+const inferAttachmentType = (file: File): ChatAttachment['type'] => {
+  if (file.type.startsWith('image/')) {
+    return 'image';
+  }
+  if (file.type.startsWith('audio/')) {
+    return 'audio';
+  }
+  return 'file';
+};
+
+const formatFileSize = (bytes?: number): string => {
+  if (!bytes || Number.isNaN(bytes)) {
+    return '';
+  }
+  if (bytes < 1024) {
+    return `${bytes} B`;
+  }
+  if (bytes < 1024 * 1024) {
+    return `${(bytes / 1024).toFixed(1)} KB`;
+  }
+  return `${(bytes / (1024 * 1024)).toFixed(1)} MB`;
+};
+
+export const AttachmentPicker: React.FC<AttachmentPickerProps> = ({ attachments, onAdd, onRemove }) => {
+  const inputRef = useRef<HTMLInputElement | null>(null);
+
+  const handleClick = useCallback(() => {
+    inputRef.current?.click();
+  }, []);
+
+  const handleFiles = useCallback<React.ChangeEventHandler<HTMLInputElement>>(
+    event => {
+      const fileList = event.target.files;
+      if (!fileList?.length) {
+        return;
+      }
+
+      const newAttachments: ChatAttachment[] = Array.from(fileList).map(file => {
+        const id = `${inferAttachmentType(file)}-${Date.now()}-${Math.random().toString(16).slice(2, 8)}`;
+        const type = inferAttachmentType(file);
+        const url = URL.createObjectURL(file);
+
+        return {
+          id,
+          type,
+          name: file.name,
+          mimeType: file.type,
+          sizeBytes: file.size,
+          url,
+        };
+      });
+
+      onAdd(newAttachments);
+      event.target.value = '';
+    },
+    [onAdd],
+  );
+
+  return (
+    <div className="attachment-picker">
+      <button type="button" className="ghost-button" onClick={handleClick}>
+        Adjuntar archivos
+      </button>
+      <input
+        ref={inputRef}
+        type="file"
+        className="attachment-picker-input"
+        multiple
+        hidden
+        onChange={handleFiles}
+      />
+
+      {attachments.length > 0 && (
+        <ul className="attachment-picker-list">
+          {attachments.map(attachment => (
+            <li key={attachment.id} className={`attachment-item attachment-${attachment.type}`}>
+              <div className="attachment-item-meta">
+                <span className="attachment-name">{attachment.name ?? attachment.id}</span>
+                {attachment.mimeType && <span className="attachment-type">{attachment.mimeType}</span>}
+                {formatFileSize(attachment.sizeBytes) && (
+                  <span className="attachment-size">{formatFileSize(attachment.sizeBytes)}</span>
+                )}
+              </div>
+              <button
+                type="button"
+                className="attachment-remove"
+                onClick={() => onRemove(attachment.id)}
+                aria-label={`Eliminar adjunto ${attachment.name ?? attachment.id}`}
+              >
+                ×
+              </button>
+            </li>
+          ))}
+        </ul>
+      )}
+    </div>
+  );
+};
+
+export default AttachmentPicker;

--- a/src/components/chat/composer/AudioRecorder.tsx
+++ b/src/components/chat/composer/AudioRecorder.tsx
@@ -1,0 +1,141 @@
+import React, { useCallback, useEffect, useRef, useState } from 'react';
+import { ChatAttachment, ChatTranscription } from '../../../core/messages/messageTypes';
+
+interface AudioRecorderProps {
+  onRecordingComplete: (attachment: ChatAttachment, transcription?: ChatTranscription) => void;
+  onError?: (message: string) => void;
+  disabled?: boolean;
+}
+
+interface RecorderState {
+  supported: boolean;
+  permissionDenied: boolean;
+  error?: string;
+}
+
+const buildId = (prefix: string) => `${prefix}-${Date.now()}-${Math.random().toString(16).slice(2, 8)}`;
+
+export const AudioRecorder: React.FC<AudioRecorderProps> = ({
+  onRecordingComplete,
+  onError,
+  disabled = false,
+}) => {
+  const mediaRecorderRef = useRef<MediaRecorder | null>(null);
+  const chunksRef = useRef<Blob[]>([]);
+  const streamRef = useRef<MediaStream | null>(null);
+  const [isRecording, setIsRecording] = useState(false);
+  const [state, setState] = useState<RecorderState>({ supported: false, permissionDenied: false });
+
+  useEffect(() => {
+    const supported =
+      typeof navigator !== 'undefined' &&
+      typeof MediaRecorder !== 'undefined' &&
+      !!navigator.mediaDevices?.getUserMedia;
+    setState(prev => ({ ...prev, supported }));
+  }, []);
+
+  const stopStream = useCallback(() => {
+    streamRef.current?.getTracks().forEach(track => track.stop());
+    streamRef.current = null;
+  }, []);
+
+  const resetRecorder = useCallback(() => {
+    mediaRecorderRef.current = null;
+    chunksRef.current = [];
+    stopStream();
+  }, [stopStream]);
+
+  useEffect(() => () => resetRecorder(), [resetRecorder]);
+
+  const handleError = useCallback(
+    (message: string) => {
+      setState(prev => ({ ...prev, error: message }));
+      onError?.(message);
+    },
+    [onError],
+  );
+
+  const startRecording = useCallback(async () => {
+    if (!state.supported || disabled || isRecording) {
+      return;
+    }
+
+    try {
+      const stream = await navigator.mediaDevices.getUserMedia({ audio: true });
+      streamRef.current = stream;
+      const recorder = new MediaRecorder(stream);
+      mediaRecorderRef.current = recorder;
+      chunksRef.current = [];
+
+      recorder.addEventListener('dataavailable', event => {
+        if (event.data && event.data.size > 0) {
+          chunksRef.current.push(event.data);
+        }
+      });
+
+      recorder.addEventListener('stop', () => {
+        const blob = new Blob(chunksRef.current, { type: 'audio/webm' });
+        const url = URL.createObjectURL(blob);
+        const attachment: ChatAttachment = {
+          id: buildId('audio'),
+          type: 'audio',
+          name: 'Grabación de voz',
+          mimeType: blob.type,
+          sizeBytes: blob.size,
+          url,
+        };
+
+        const transcription: ChatTranscription = {
+          id: buildId('transcription'),
+          modality: 'audio',
+          text: 'Transcripción pendiente…',
+          source: 'user',
+          attachmentId: attachment.id,
+        };
+
+        onRecordingComplete(attachment, transcription);
+        setIsRecording(false);
+        resetRecorder();
+      });
+
+      recorder.start();
+      setIsRecording(true);
+      setState(prev => ({ ...prev, error: undefined, permissionDenied: false }));
+    } catch (error) {
+      if (error instanceof DOMException && error.name === 'NotAllowedError') {
+        setState(prev => ({ ...prev, permissionDenied: true }));
+        handleError('Permite el acceso al micrófono para grabar audio.');
+      } else {
+        handleError('No fue posible iniciar la grabación de audio.');
+      }
+    }
+  }, [disabled, handleError, isRecording, onRecordingComplete, state.supported, stopStream]);
+
+  const stopRecording = useCallback(() => {
+    if (!isRecording) {
+      return;
+    }
+
+    mediaRecorderRef.current?.stop();
+  }, [isRecording]);
+
+  return (
+    <div className="audio-recorder">
+      <button
+        type="button"
+        className={`ghost-button ${isRecording ? 'recording' : ''}`}
+        onClick={isRecording ? stopRecording : startRecording}
+        disabled={disabled || !state.supported}
+      >
+        {isRecording ? 'Detener audio' : 'Grabar audio'}
+      </button>
+      {!state.supported && <span className="recorder-hint">Grabación de audio no soportada en este navegador.</span>}
+      {state.permissionDenied && (
+        <span className="recorder-hint recorder-error">Permiso de micrófono denegado.</span>
+      )}
+      {state.error && <span className="recorder-hint recorder-error">{state.error}</span>}
+    </div>
+  );
+};
+
+export default AudioRecorder;

--- a/src/components/chat/messages/AudioPlayer.tsx
+++ b/src/components/chat/messages/AudioPlayer.tsx
@@ -1,0 +1,30 @@
+import React from 'react';
+import { ChatTranscription } from '../../../core/messages/messageTypes';
+
+interface AudioPlayerProps {
+  src: string;
+  title?: string;
+  mimeType?: string;
+  transcriptions?: ChatTranscription[];
+}
+
+export const AudioPlayer: React.FC<AudioPlayerProps> = ({ src, title, mimeType, transcriptions }) => (
+  <div className="message-audio-player">
+    <audio src={src} controls preload="metadata" title={title ?? 'Mensaje de audio'} />
+    {transcriptions?.length ? (
+      <details className="audio-transcriptions">
+        <summary>Transcripciones ({transcriptions.length})</summary>
+        <ul>
+          {transcriptions.map(transcription => (
+            <li key={transcription.id}>
+              <span className="transcription-language">{transcription.language ?? 'es'}</span>
+              <span className="transcription-text">{transcription.text}</span>
+            </li>
+          ))}
+        </ul>
+      </details>
+    ) : null}
+  </div>
+);
+
+export default AudioPlayer;

--- a/src/components/chat/messages/MessageAttachment.tsx
+++ b/src/components/chat/messages/MessageAttachment.tsx
@@ -1,0 +1,43 @@
+import React from 'react';
+import { ChatAttachment, ChatTranscription } from '../../../core/messages/messageTypes';
+import { AudioPlayer } from './AudioPlayer';
+
+interface MessageAttachmentProps {
+  attachment: ChatAttachment;
+  transcriptions?: ChatTranscription[];
+}
+
+export const MessageAttachment: React.FC<MessageAttachmentProps> = ({ attachment, transcriptions }) => {
+  if (attachment.type === 'image' && attachment.url) {
+    return (
+      <figure className="message-attachment image-attachment">
+        <img src={attachment.url} alt={attachment.name ?? 'Imagen adjunta'} />
+        {attachment.name && <figcaption>{attachment.name}</figcaption>}
+      </figure>
+    );
+  }
+
+  if (attachment.type === 'audio' && attachment.url) {
+    const relatedTranscriptions = transcriptions?.filter(item => item.attachmentId === attachment.id);
+    return (
+      <div className="message-attachment audio-attachment">
+        <AudioPlayer src={attachment.url} title={attachment.name} mimeType={attachment.mimeType} transcriptions={relatedTranscriptions} />
+      </div>
+    );
+  }
+
+  return (
+    <div className="message-attachment file-attachment">
+      {attachment.url ? (
+        <a href={attachment.url} download={attachment.name} target="_blank" rel="noreferrer">
+          {attachment.name ?? 'Archivo adjunto'}
+        </a>
+      ) : (
+        <span>{attachment.name ?? 'Archivo adjunto'}</span>
+      )}
+      {attachment.mimeType && <span className="attachment-meta">{attachment.mimeType}</span>}
+    </div>
+  );
+};
+
+export default MessageAttachment;

--- a/src/core/agents/providerRouter.ts
+++ b/src/core/agents/providerRouter.ts
@@ -1,5 +1,10 @@
 import { ApiKeySettings } from '../../types/globalSettings';
-import { callAnthropicChat, callGroqChat, callOpenAIChat } from '../../utils/aiProviders';
+import {
+  ChatProviderResponse,
+  callAnthropicChat,
+  callGroqChat,
+  callOpenAIChat,
+} from '../../utils/aiProviders';
 import { isSupportedProvider } from '../../utils/globalSettings';
 import { AgentDefinition } from './agentRegistry';
 
@@ -18,20 +23,29 @@ export const fetchAgentReply = async ({
   prompt,
   apiKeys,
   fallback,
-}: FetchAgentReplyOptions): Promise<string> => {
+}: FetchAgentReplyOptions): Promise<ChatProviderResponse> => {
   const providerKey = agent.provider.toLowerCase();
   if (agent.kind !== 'cloud' || !isSupportedProvider(providerKey)) {
-    return fallback(agent, prompt);
+    return {
+      content: fallback(agent, prompt),
+      modalities: ['text'],
+    };
   }
 
   const apiKey = apiKeys[providerKey];
   if (!apiKey) {
-    return `${agent.name} no tiene una API key configurada. Abre los ajustes globales para habilitar sus respuestas.`;
+    return {
+      content: `${agent.name} no tiene una API key configurada. Abre los ajustes globales para habilitar sus respuestas.`,
+      modalities: ['text'],
+    };
   }
 
   const sanitizedPrompt = prompt.trim();
   if (!sanitizedPrompt) {
-    return 'Necesito un prompt válido para generar una respuesta.';
+    return {
+      content: 'Necesito un prompt válido para generar una respuesta.',
+      modalities: ['text'],
+    };
   }
 
   if (providerKey === 'openai') {
@@ -61,5 +75,8 @@ export const fetchAgentReply = async ({
     });
   }
 
-  return fallback(agent, prompt);
+  return {
+    content: fallback(agent, prompt),
+    modalities: ['text'],
+  };
 };

--- a/src/core/messages/messageTypes.ts
+++ b/src/core/messages/messageTypes.ts
@@ -1,0 +1,64 @@
+export type ChatAuthor = 'system' | 'user' | 'agent';
+
+export type ChatModality = 'text' | 'image' | 'audio' | 'video' | 'file';
+
+export interface ChatAttachment {
+  id: string;
+  type: 'image' | 'audio' | 'file';
+  url?: string;
+  name?: string;
+  mimeType?: string;
+  sizeBytes?: number;
+  durationSeconds?: number;
+  previewUrl?: string;
+  waveform?: number[];
+  metadata?: Record<string, unknown>;
+}
+
+export interface ChatTranscription {
+  id: string;
+  text: string;
+  language?: string;
+  confidence?: number;
+  modality?: Exclude<ChatModality, 'text'>;
+  attachmentId?: string;
+  createdAt?: string;
+  source?: ChatAuthor;
+}
+
+export type ChatContentPart =
+  | string
+  | {
+      type: 'text';
+      text: string;
+    }
+  | {
+      type: 'image';
+      url: string;
+      alt?: string;
+    }
+  | {
+      type: 'audio';
+      url: string;
+      durationSeconds?: number;
+      transcript?: string;
+    }
+  | {
+      type: 'file';
+      url: string;
+      name?: string;
+      mimeType?: string;
+    };
+
+export interface ChatMessage {
+  id: string;
+  author: ChatAuthor;
+  content: string | ChatContentPart[];
+  timestamp: string;
+  agentId?: string;
+  status?: 'pending' | 'sent';
+  sourcePrompt?: string;
+  attachments?: ChatAttachment[];
+  modalities?: ChatModality[];
+  transcriptions?: ChatTranscription[];
+}


### PR DESCRIPTION
## Summary
- expand ChatMessage metadata to capture attachments, modalities, and transcriptions and plumb the new structure through the message provider
- upgrade the chat composer with attachment picking, audio recording, and modality previews while rendering multimodal replies in the workspace and side panel
- update AI provider connectors to send/receive multimodal payloads and surface attachments/audio with dedicated renderers

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68ce8015c93083339f3cfcbd68333bcb