### PR TITLE
Add correction feedback pipeline and quality dashboard

### DIFF
--- a/src/components/chat/ChatInterface.css
+++ b/src/components/chat/ChatInterface.css
@@ -730,10 +730,145 @@
   color: rgba(255, 255, 255, 0.75);
 }
 
+.activity-note {
+  font-size: 12px;
+  line-height: 1.4;
+  color: rgba(255, 183, 77, 0.85);
+  margin: 0;
+}
+
+.activity-flag {
+  padding: 2px 8px;
+  border-radius: 999px;
+  background: rgba(255, 107, 107, 0.2);
+  color: #ff6b6b;
+  font-size: 11px;
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+}
+
+.activity-actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
+}
+
+.activity-action {
+  border: 1px solid rgba(255, 255, 255, 0.15);
+  background: rgba(0, 0, 0, 0.45);
+  color: rgba(255, 255, 255, 0.8);
+  border-radius: 999px;
+  padding: 4px 10px;
+  font-size: 11px;
+  cursor: pointer;
+  transition: border 0.2s ease, background 0.2s ease;
+}
+
+.activity-action:hover {
+  border-color: rgba(255, 183, 77, 0.65);
+  background: rgba(255, 183, 77, 0.18);
+}
+
 .activity-empty {
   font-size: 12px;
   color: rgba(255, 255, 255, 0.5);
   font-style: italic;
+}
+
+.quality-metrics {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 12px;
+  margin-bottom: 16px;
+}
+
+.quality-card {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+  padding: 12px;
+  border-radius: 12px;
+  background: rgba(0, 0, 0, 0.5);
+  border: 1px solid rgba(255, 255, 255, 0.08);
+}
+
+.quality-label {
+  font-size: 11px;
+  color: rgba(255, 255, 255, 0.55);
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+}
+
+.quality-value {
+  font-size: 18px;
+  color: #fff;
+}
+
+.quality-tags {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+  margin-bottom: 16px;
+}
+
+.quality-tag-cloud {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
+}
+
+.quality-tag-chip {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  padding: 4px 10px;
+  border-radius: 999px;
+  background: rgba(142, 141, 255, 0.15);
+  color: rgba(255, 255, 255, 0.85);
+  font-size: 11px;
+}
+
+.quality-tag-chip small {
+  font-size: 10px;
+  color: rgba(255, 255, 255, 0.6);
+}
+
+.quality-tag-empty {
+  font-size: 11px;
+  color: rgba(255, 255, 255, 0.45);
+}
+
+.quality-history {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+
+.quality-history ul {
+  list-style: none;
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+  margin: 0;
+  padding: 0;
+}
+
+.quality-history li {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  font-size: 12px;
+  color: rgba(255, 255, 255, 0.75);
+}
+
+.quality-history li strong {
+  font-size: 12px;
+  color: rgba(255, 255, 255, 0.92);
+}
+
+.quality-history li em {
+  font-style: normal;
+  color: rgba(255, 183, 77, 0.8);
 }
 
 .chat-status-bar {

--- a/src/components/quality/QualityDashboard.tsx
+++ b/src/components/quality/QualityDashboard.tsx
@@ -1,0 +1,60 @@
+import React from 'react';
+import { useMessages } from '../../core/messages/MessageContext';
+
+export const QualityDashboard: React.FC = () => {
+  const { qualityMetrics, correctionHistory, formatTimestamp } = useMessages();
+
+  const { totalAgentMessages, flaggedResponses, totalCorrections, correctionRate, tagRanking } = qualityMetrics;
+
+  return (
+    <section className="panel-section">
+      <header className="panel-section-header">
+        <h2>Calidad de respuestas</h2>
+        <p>Audita errores recurrentes y seguimiento de correcciones.</p>
+      </header>
+      <div className="quality-metrics">
+        <div className="quality-card">
+          <span className="quality-label">Respuestas de agentes</span>
+          <strong className="quality-value">{totalAgentMessages}</strong>
+        </div>
+        <div className="quality-card">
+          <span className="quality-label">Marcadas con error</span>
+          <strong className="quality-value">{flaggedResponses}</strong>
+        </div>
+        <div className="quality-card">
+          <span className="quality-label">Correcciones enviadas</span>
+          <strong className="quality-value">{totalCorrections}</strong>
+        </div>
+        <div className="quality-card">
+          <span className="quality-label">Ratio de corrección</span>
+          <strong className="quality-value">{(correctionRate * 100).toFixed(1)}%</strong>
+        </div>
+      </div>
+      <div className="quality-tags">
+        <span className="quality-label">Etiquetas destacadas</span>
+        <div className="quality-tag-cloud">
+          {tagRanking.length === 0 && <span className="quality-tag-empty">Sin etiquetas registradas.</span>}
+          {tagRanking.map(entry => (
+            <span key={entry.tag} className="quality-tag-chip">
+              {entry.tag}
+              <small>{entry.count}</small>
+            </span>
+          ))}
+        </div>
+      </div>
+      <div className="quality-history">
+        <span className="quality-label">Últimas correcciones</span>
+        <ul>
+          {correctionHistory.slice(0, 3).map(correction => (
+            <li key={correction.id}>
+              <strong>#{correction.id.split('-')[0]}</strong>
+              <span>{formatTimestamp(correction.updatedAt)}</span>
+              {correction.tags?.length ? <em>{correction.tags.join(', ')}</em> : <em>sin etiquetas</em>}
+            </li>
+          ))}
+          {correctionHistory.length === 0 && <li className="quality-tag-empty">No hay correcciones registradas todavía.</li>}
+        </ul>
+      </div>
+    </section>
+  );
+};

--- a/src/core/agents/agentRegistry.ts
+++ b/src/core/agents/agentRegistry.ts
@@ -74,6 +74,17 @@ export const INITIAL_AGENTS: AgentDefinition[] = [
     active: false,
     status: 'Cargando',
   },
+  {
+    id: 'openai-quality-review',
+    model: 'gpt-4o-mini',
+    name: 'Quality Reviewer',
+    provider: 'OpenAI',
+    description: 'Agente dedicado a auditar correcciones y validar respuestas revisadas.',
+    kind: 'cloud',
+    accent: '#FF4F81',
+    active: false,
+    status: 'Disponible',
+  },
 ];
 
 export const syncAgentWithApiKeys = (

--- a/src/core/agents/providerRouter.ts
+++ b/src/core/agents/providerRouter.ts
@@ -6,6 +6,7 @@ import {
   callOpenAIChat,
 } from '../../utils/aiProviders';
 import { isSupportedProvider } from '../../utils/globalSettings';
+import { ChatContentPart, ChatMessage } from '../messages/messageTypes';
 import { AgentDefinition } from './agentRegistry';
 
 export const AGENT_SYSTEM_PROMPT =
@@ -78,5 +79,83 @@ export const fetchAgentReply = async ({
   return {
     content: fallback(agent, prompt),
     modalities: ['text'],
+  };
+};
+
+const contentToPlainText = (content: ChatMessage['content']): string => {
+  if (typeof content === 'string') {
+    return content;
+  }
+
+  return content
+    .map((part: ChatContentPart | string) => {
+      if (!part) {
+        return '';
+      }
+      if (typeof part === 'string') {
+        return part;
+      }
+      if (part.type === 'text') {
+        return part.text;
+      }
+      if (part.type === 'image') {
+        return part.alt ?? '[imagen]';
+      }
+      if (part.type === 'audio') {
+        return part.transcript ?? '[audio]';
+      }
+      if (part.type === 'file') {
+        return part.name ?? '[archivo]';
+      }
+      return '';
+    })
+    .filter(Boolean)
+    .join('\n');
+};
+
+export interface CorrectionRouteOptions {
+  correctionId: string;
+  originalMessage: ChatMessage;
+  correctedText: string;
+  notes?: string;
+  tags?: string[];
+  agent: AgentDefinition;
+  reviewer?: AgentDefinition | null;
+}
+
+export interface CorrectionRouteResult {
+  prompt: string;
+  targetAgent: AgentDefinition;
+}
+
+export const buildCorrectionPipeline = ({
+  correctionId,
+  originalMessage,
+  correctedText,
+  notes,
+  tags,
+  agent,
+  reviewer,
+}: CorrectionRouteOptions): CorrectionRouteResult => {
+  const targetAgent = reviewer ?? agent;
+
+  const originalText = contentToPlainText(originalMessage.content);
+  const contextHeader = `Corrección registrada (${correctionId}).`;
+  const tagLine = tags?.length ? `Etiquetas asociadas: ${tags.join(', ')}.` : 'Sin etiquetas registradas.';
+  const notesLine = notes?.trim().length ? `Notas del operador: ${notes.trim()}` : 'No se añadieron notas adicionales.';
+
+  const promptSections = [
+    contextHeader,
+    `Mensaje original del agente ${agent.name}:\n${originalText || '[vacío]'}`,
+    `Propuesta corregida por el operador:\n${correctedText.trim() || '[sin contenido]'}`,
+    notesLine,
+    tagLine,
+    'Revisa la corrección, valida los cambios y entrega una respuesta definitiva que incorpore los ajustes necesarios. '
+      + 'Si la corrección es inválida, justifícalo y propone una alternativa correcta.',
+  ];
+
+  return {
+    prompt: promptSections.join('\n\n'),
+    targetAgent,
   };
 };

--- a/src/core/messages/messageTypes.ts
+++ b/src/core/messages/messageTypes.ts
@@ -61,4 +61,25 @@ export interface ChatMessage {
   attachments?: ChatAttachment[];
   modalities?: ChatModality[];
   transcriptions?: ChatTranscription[];
+  feedback?: MessageFeedback;
+  correctionId?: string;
+}
+
+export interface MessageFeedback {
+  hasError?: boolean;
+  notes?: string;
+  tags?: string[];
+  lastUpdatedAt?: string;
+}
+
+export interface MessageCorrection {
+  id: string;
+  messageId: string;
+  agentId?: string;
+  reviewerId?: string;
+  createdAt: string;
+  updatedAt: string;
+  correctedText: string;
+  notes?: string;
+  tags?: string[];
 }


### PR DESCRIPTION
## Summary
- extend message state with feedback records, correction history, and persistence across browser/Tauri
- route correction prompts through provider router and expose editing/marking tools in recent activity
- surface a quality dashboard with correction metrics and supporting styles

## Testing
- npm run test

------
https://chatgpt.com/codex/tasks/task_e_68ce87dec7ac8333aa4a81284552a635