### PR TITLE
Add multi-agent orchestration strategies and collaboration UI

### DIFF
--- a/src/components/agents/AgentPresenceList.css
+++ b/src/components/agents/AgentPresenceList.css
@@ -52,6 +52,37 @@
   gap: 6px;
 }
 
+.agent-presence-role {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(160px, 1fr));
+  gap: 8px;
+  margin-top: 4px;
+}
+
+.agent-presence-role label {
+  display: flex;
+  flex-direction: column;
+  font-size: 11px;
+  text-transform: uppercase;
+  letter-spacing: 0.6px;
+  gap: 4px;
+  color: rgba(255, 255, 255, 0.65);
+}
+
+.agent-presence-role select,
+.agent-presence-role input {
+  background: rgba(18, 18, 18, 0.9);
+  border: 1px solid rgba(255, 255, 255, 0.12);
+  border-radius: 8px;
+  color: #fff;
+  padding: 6px 8px;
+  font-size: 12px;
+}
+
+.agent-presence-role input::placeholder {
+  color: rgba(255, 255, 255, 0.45);
+}
+
 .agent-presence-name {
   font-size: 14px;
   font-weight: 600;

--- a/src/components/agents/AgentPresenceList.tsx
+++ b/src/components/agents/AgentPresenceList.tsx
@@ -9,6 +9,7 @@ interface AgentPresenceListProps {
   onToggleAgent: (agentId: string) => void;
   onOpenConsole?: (agentId: string) => void;
   onRefreshAgent?: (agentId: string) => void | Promise<void>;
+  onUpdateRole: (agentId: string, updates: { role?: string; objective?: string }) => void;
 }
 
 const STATUS_LABELS: Record<AgentPresenceStatus, string> = {
@@ -39,12 +40,22 @@ const buildAvatarLabel = (agent: AgentDefinition): string => {
   return agent.provider.slice(0, 1).toUpperCase();
 };
 
+const ROLE_PRESETS = [
+  '',
+  'Diseñador/a',
+  'Crítico/a',
+  'Ejecutor/a',
+  'Investigador/a',
+  'Product Manager',
+];
+
 export const AgentPresenceList: React.FC<AgentPresenceListProps> = ({
   agents,
   presence,
   onToggleAgent,
   onOpenConsole,
   onRefreshAgent,
+  onUpdateRole,
 }) => (
   <ul className="agent-presence-list">
     {agents.map(agent => {
@@ -73,6 +84,35 @@ export const AgentPresenceList: React.FC<AgentPresenceListProps> = ({
               </span>
             </div>
             {entry.message && <div className="agent-presence-message">{entry.message}</div>}
+            <div className="agent-presence-role">
+              <label>
+                Rol
+                <select
+                  value={agent.role ?? ''}
+                  onChange={event => onUpdateRole(agent.id, { role: event.target.value || undefined, objective: agent.objective })}
+                >
+                  {ROLE_PRESETS.map(option => (
+                    <option key={option || 'none'} value={option}>
+                      {option ? option : 'Sin asignar'}
+                    </option>
+                  ))}
+                </select>
+              </label>
+              <label>
+                Objetivo
+                <input
+                  type="text"
+                  value={agent.objective ?? ''}
+                  onChange={event =>
+                    onUpdateRole(agent.id, {
+                      role: agent.role,
+                      objective: event.target.value.trim() ? event.target.value : undefined,
+                    })
+                  }
+                  placeholder="Describe el foco actual"
+                />
+              </label>
+            </div>
           </div>
           <div className="agent-presence-actions">
             <button

--- a/src/components/chat/ChatWorkspace.tsx
+++ b/src/components/chat/ChatWorkspace.tsx
@@ -35,6 +35,8 @@ export const ChatWorkspace: React.FC<ChatWorkspaceProps> = ({ sidePanel, actorFi
     formatTimestamp,
   } = useMessages();
 
+  const publicMessages = useMemo(() => messages.filter(message => message.visibility !== 'internal'), [messages]);
+
   const handleAddAttachments = useCallback(
     (items: ChatAttachment[]) => {
       items.forEach(attachment => addAttachment(attachment));
@@ -119,25 +121,25 @@ export const ChatWorkspace: React.FC<ChatWorkspaceProps> = ({ sidePanel, actorFi
 
   const filteredMessages = useMemo(() => {
     if (actorFilter === 'all') {
-      return messages;
+      return publicMessages;
     }
 
     if (actorFilter === 'user') {
-      return messages.filter(message => message.author === 'user');
+      return publicMessages.filter(message => message.author === 'user');
     }
 
     if (actorFilter === 'system') {
-      return messages.filter(message => message.author === 'system');
+      return publicMessages.filter(message => message.author === 'system');
     }
 
     if (actorFilter.startsWith('agent:')) {
       const targetId = actorFilter.slice('agent:'.length);
-      return messages.filter(message => message.agentId === targetId);
+      return publicMessages.filter(message => message.agentId === targetId);
     }
 
     if (actorFilter.startsWith('kind:')) {
       const kind = actorFilter.slice('kind:'.length) as AgentKind;
-      return messages.filter(message => {
+      return publicMessages.filter(message => {
         if (!message.agentId) {
           return false;
         }
@@ -146,8 +148,8 @@ export const ChatWorkspace: React.FC<ChatWorkspaceProps> = ({ sidePanel, actorFi
       });
     }
 
-    return messages;
-  }, [actorFilter, agentMap, messages]);
+    return publicMessages;
+  }, [actorFilter, agentMap, publicMessages]);
 
   return (
     <>

--- a/src/components/chat/SidePanel.tsx
+++ b/src/components/chat/SidePanel.tsx
@@ -7,6 +7,7 @@ import { ModelGallery } from '../models/ModelGallery';
 import { AgentPresenceList } from '../agents/AgentPresenceList';
 import { ChatMessage } from '../../core/messages/messageTypes';
 import { QualityDashboard } from '../quality/QualityDashboard';
+import { AgentConversationPanel } from '../orchestration/AgentConversationPanel';
 
 interface SidePanelProps {
   apiKeys: ApiKeySettings;
@@ -21,7 +22,7 @@ export const SidePanel: React.FC<SidePanelProps> = ({
   presenceMap,
   onRefreshAgentPresence,
 }) => {
-  const { agents, agentMap, toggleAgent } = useAgents();
+  const { agents, agentMap, toggleAgent, assignAgentRole } = useAgents();
   const {
     quickCommands,
     appendToDraft,
@@ -31,6 +32,10 @@ export const SidePanel: React.FC<SidePanelProps> = ({
     feedbackByMessage,
     markMessageFeedback,
     submitCorrection,
+    coordinationStrategy,
+    setCoordinationStrategy,
+    sharedSnapshot,
+    orchestrationTraces,
   } = useMessages();
 
   const recentActivity = useMemo(
@@ -149,6 +154,7 @@ export const SidePanel: React.FC<SidePanelProps> = ({
             agents={agents}
             presence={presenceMap}
             onToggleAgent={toggleAgent}
+            onUpdateRole={assignAgentRole}
             onOpenConsole={agentId =>
               console.log(`Abrir consola interactiva para el agente ${agentId}`)
             }
@@ -158,6 +164,20 @@ export const SidePanel: React.FC<SidePanelProps> = ({
 
         <section className="panel-section">
           <ModelGallery />
+        </section>
+
+        <section className="panel-section">
+          <header className="panel-section-header">
+            <h2>Conversa entre agentes</h2>
+            <p>Visualiza cómo coordinan los modelos antes de responder.</p>
+          </header>
+          <AgentConversationPanel
+            traces={orchestrationTraces}
+            sharedSnapshot={sharedSnapshot}
+            agents={agents}
+            currentStrategy={coordinationStrategy}
+            onChangeStrategy={setCoordinationStrategy}
+          />
         </section>
 
         <QualityDashboard />

--- a/src/components/orchestration/AgentConversationPanel.css
+++ b/src/components/orchestration/AgentConversationPanel.css
@@ -1,0 +1,145 @@
+.agent-conversation-panel {
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+  padding: 12px;
+  border-radius: 12px;
+  background: rgba(12, 12, 12, 0.6);
+  border: 1px solid rgba(255, 255, 255, 0.08);
+}
+
+.conversation-strategy label {
+  display: block;
+  font-size: 11px;
+  letter-spacing: 0.6px;
+  text-transform: uppercase;
+  color: rgba(255, 255, 255, 0.6);
+  margin-bottom: 6px;
+}
+
+.conversation-strategy select {
+  width: 100%;
+  padding: 6px 10px;
+  border-radius: 8px;
+  background: rgba(20, 20, 20, 0.9);
+  border: 1px solid rgba(255, 255, 255, 0.1);
+  color: #fff;
+  font-size: 13px;
+}
+
+.strategy-description {
+  margin-top: 6px;
+  font-size: 12px;
+  color: rgba(255, 255, 255, 0.65);
+}
+
+.conversation-shared-state {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+
+.conversation-shared-state h3,
+.conversation-trace h3 {
+  font-size: 14px;
+  text-transform: uppercase;
+  letter-spacing: 0.8px;
+  color: rgba(255, 255, 255, 0.75);
+  margin: 0;
+}
+
+.shared-summary {
+  margin: 0;
+  font-size: 13px;
+  color: rgba(255, 255, 255, 0.8);
+}
+
+.shared-conclusions {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+}
+
+.shared-conclusions li {
+  display: grid;
+  grid-template-columns: 64px 1fr;
+  gap: 8px;
+  font-size: 12px;
+  background: rgba(255, 255, 255, 0.05);
+  padding: 6px 8px;
+  border-radius: 8px;
+}
+
+.conclusion-time {
+  font-variant-numeric: tabular-nums;
+  color: rgba(255, 255, 255, 0.55);
+}
+
+.conclusion-author {
+  font-weight: 600;
+}
+
+.trace-empty {
+  font-size: 12px;
+  color: rgba(255, 255, 255, 0.55);
+  margin: 0;
+}
+
+.trace-list {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+}
+
+.trace-item {
+  border-radius: 10px;
+  padding: 10px 12px;
+  background: rgba(255, 255, 255, 0.05);
+  border: 1px solid rgba(255, 255, 255, 0.08);
+}
+
+.trace-item.trace-system {
+  border-color: rgba(142, 141, 255, 0.3);
+}
+
+.trace-item.trace-agent {
+  border-color: rgba(255, 179, 71, 0.3);
+}
+
+.trace-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  margin-bottom: 4px;
+  font-size: 11px;
+  color: rgba(255, 255, 255, 0.6);
+}
+
+.trace-actor {
+  font-weight: 600;
+}
+
+.trace-description {
+  font-size: 12px;
+  color: rgba(255, 255, 255, 0.82);
+  margin: 0;
+}
+
+.trace-details {
+  font-size: 11px;
+  color: rgba(255, 255, 255, 0.6);
+  margin: 4px 0 0;
+  white-space: pre-line;
+}
+
+@media (max-width: 1280px) {
+  .agent-conversation-panel {
+    padding: 10px;
+  }
+}

--- a/src/components/orchestration/AgentConversationPanel.tsx
+++ b/src/components/orchestration/AgentConversationPanel.tsx
@@ -1,0 +1,110 @@
+import React, { useMemo } from 'react';
+import { AgentDefinition } from '../../core/agents/agentRegistry';
+import {
+  CoordinationStrategyId,
+  OrchestrationTraceEntry,
+  SharedConversationSnapshot,
+  listCoordinationStrategies,
+} from '../../core/orchestration';
+import './AgentConversationPanel.css';
+
+interface AgentConversationPanelProps {
+  traces: OrchestrationTraceEntry[];
+  sharedSnapshot: SharedConversationSnapshot;
+  agents: AgentDefinition[];
+  currentStrategy: CoordinationStrategyId;
+  onChangeStrategy: (strategy: CoordinationStrategyId) => void;
+}
+
+const STRATEGIES = listCoordinationStrategies();
+
+const formatTime = (isoString: string): string => {
+  try {
+    return new Date(isoString).toLocaleTimeString([], { hour: '2-digit', minute: '2-digit' });
+  } catch {
+    return '';
+  }
+};
+
+export const AgentConversationPanel: React.FC<AgentConversationPanelProps> = ({
+  traces,
+  sharedSnapshot,
+  agents,
+  currentStrategy,
+  onChangeStrategy,
+}) => {
+  const agentLookup = useMemo(() => {
+    const map = new Map<string, AgentDefinition>();
+    agents.forEach(agent => map.set(agent.id, agent));
+    return map;
+  }, [agents]);
+
+  const recentTraces = useMemo(() => traces.slice(-12).reverse(), [traces]);
+
+  return (
+    <div className="agent-conversation-panel">
+      <div className="conversation-strategy">
+        <label htmlFor="coordination-strategy">Estrategia de coordinación</label>
+        <select
+          id="coordination-strategy"
+          value={currentStrategy}
+          onChange={event => onChangeStrategy(event.target.value as CoordinationStrategyId)}
+        >
+          {STRATEGIES.map(strategy => (
+            <option key={strategy.id} value={strategy.id}>
+              {strategy.label}
+            </option>
+          ))}
+        </select>
+        <p className="strategy-description">
+          {STRATEGIES.find(strategy => strategy.id === currentStrategy)?.description}
+        </p>
+      </div>
+
+      <div className="conversation-shared-state">
+        <h3>Estado compartido</h3>
+        <p className="shared-summary">{sharedSnapshot.sharedSummary}</p>
+        {sharedSnapshot.lastConclusions.length > 0 && (
+          <ul className="shared-conclusions">
+            {sharedSnapshot.lastConclusions.slice(-4).reverse().map(entry => {
+              const agent = entry.agentId ? agentLookup.get(entry.agentId) : undefined;
+              return (
+                <li key={`${entry.timestamp}-${entry.agentId ?? entry.author}`}>
+                  <span className="conclusion-time">{formatTime(entry.timestamp)}</span>
+                  <span className="conclusion-author">
+                    {entry.author === 'system' ? 'Control' : agent?.name ?? 'Agente desconocido'}
+                  </span>
+                  <span className="conclusion-text">{entry.content}</span>
+                </li>
+              );
+            })}
+          </ul>
+        )}
+      </div>
+
+      <div className="conversation-trace">
+        <h3>Últimos intercambios</h3>
+        {recentTraces.length === 0 ? (
+          <p className="trace-empty">Aún no hay trazas registradas entre agentes.</p>
+        ) : (
+          <ul className="trace-list">
+            {recentTraces.map(entry => {
+              const agent = entry.agentId ? agentLookup.get(entry.agentId) : undefined;
+              const actorLabel = entry.actor === 'system' ? 'Control' : agent?.name ?? 'Agente';
+              return (
+                <li key={entry.id} className={`trace-item trace-${entry.actor}`}>
+                  <div className="trace-header">
+                    <span className="trace-actor">{actorLabel}</span>
+                    <span className="trace-time">{formatTime(entry.timestamp)}</span>
+                  </div>
+                  <p className="trace-description">{entry.description}</p>
+                  {entry.details && <p className="trace-details">{entry.details}</p>}
+                </li>
+              );
+            })}
+          </ul>
+        )}
+      </div>
+    </div>
+  );
+};

--- a/src/core/agents/AgentContext.tsx
+++ b/src/core/agents/AgentContext.tsx
@@ -9,6 +9,7 @@ interface AgentContextValue {
   agentMap: Map<string, AgentDefinition>;
   toggleAgent: (agentId: string) => void;
   updateLocalAgentState: (agentId: string, status: AgentStatus, active?: boolean) => void;
+  assignAgentRole: (agentId: string, updates: { role?: string; objective?: string }) => void;
 }
 
 const AgentContext = createContext<AgentContextValue | undefined>(undefined);
@@ -96,6 +97,26 @@ export const AgentProvider: React.FC<AgentProviderProps> = ({ apiKeys, children 
     [],
   );
 
+  const assignAgentRole = useCallback((agentId: string, updates: { role?: string; objective?: string }) => {
+    setAgents(prev =>
+      prev.map(agent => {
+        if (agent.id !== agentId) {
+          return agent;
+        }
+
+        if (agent.role === updates.role && agent.objective === updates.objective) {
+          return agent;
+        }
+
+        return {
+          ...agent,
+          role: updates.role,
+          objective: updates.objective,
+        };
+      }),
+    );
+  }, []);
+
   const value = useMemo(() => {
     const activeAgents = agents.filter(agent => agent.active);
     const agentMap = new Map<string, AgentDefinition>();
@@ -107,8 +128,9 @@ export const AgentProvider: React.FC<AgentProviderProps> = ({ apiKeys, children 
       agentMap,
       toggleAgent,
       updateLocalAgentState,
+      assignAgentRole,
     };
-  }, [agents, toggleAgent, updateLocalAgentState]);
+  }, [agents, toggleAgent, updateLocalAgentState, assignAgentRole]);
 
   return <AgentContext.Provider value={value}>{children}</AgentContext.Provider>;
 };

--- a/src/core/agents/agentRegistry.ts
+++ b/src/core/agents/agentRegistry.ts
@@ -16,6 +16,8 @@ export interface AgentDefinition {
   active: boolean;
   status: AgentStatus;
   apiKey?: string;
+  role?: string;
+  objective?: string;
 }
 
 export const INITIAL_AGENTS: AgentDefinition[] = [

--- a/src/core/messages/messageTypes.ts
+++ b/src/core/messages/messageTypes.ts
@@ -1,4 +1,8 @@
+import type { MultiAgentContext } from '../orchestration';
+
 export type ChatAuthor = 'system' | 'user' | 'agent';
+
+export type ChatVisibility = 'public' | 'internal';
 
 export type ChatModality = 'text' | 'image' | 'audio' | 'video' | 'file';
 
@@ -63,6 +67,8 @@ export interface ChatMessage {
   transcriptions?: ChatTranscription[];
   feedback?: MessageFeedback;
   correctionId?: string;
+  visibility?: ChatVisibility;
+  orchestrationContext?: MultiAgentContext;
 }
 
 export interface MessageFeedback {

--- a/src/core/orchestration/index.ts
+++ b/src/core/orchestration/index.ts
@@ -1,0 +1,88 @@
+import { criticReviewerStrategy } from './strategies/criticReviewer';
+import { sequentialTurnStrategy } from './strategies/sequentialTurn';
+import {
+  CoordinationStrategy,
+  CoordinationStrategyId,
+  createInitialSnapshot,
+  OrchestrationTraceEntry,
+  SharedConversationSnapshot,
+} from './types';
+
+const STRATEGIES: Record<CoordinationStrategyId, CoordinationStrategy> = {
+  'sequential-turn': sequentialTurnStrategy,
+  'critic-reviewer': criticReviewerStrategy,
+};
+
+export const listCoordinationStrategies = (): CoordinationStrategy[] => Object.values(STRATEGIES);
+
+export const getCoordinationStrategy = (id: CoordinationStrategyId): CoordinationStrategy => STRATEGIES[id];
+
+export const buildTraceFromBridge = (
+  message: { id: string; author: 'system' | 'agent'; agentId?: string; content: string; timestamp: string },
+  strategyId: CoordinationStrategyId,
+  description?: string,
+): OrchestrationTraceEntry => ({
+  id: `${message.id}-trace`,
+  timestamp: message.timestamp,
+  actor: message.author,
+  agentId: message.agentId,
+  description: description ?? message.content,
+  strategyId,
+});
+
+export const registerAgentConclusion = (
+  snapshot: SharedConversationSnapshot,
+  agentId: string,
+  content: string,
+  timestamp: string,
+): SharedConversationSnapshot => {
+  const cleaned = content.trim();
+  const concise = cleaned.length > 480 ? `${cleaned.slice(0, 477)}…` : cleaned;
+
+  const nextSharedSummary = concise
+    ? `Última conclusión (${timestamp.split('T')[0]}): ${concise}`
+    : snapshot.sharedSummary;
+
+  return {
+    ...snapshot,
+    sharedSummary: nextSharedSummary,
+    agentSummaries: {
+      ...snapshot.agentSummaries,
+      [agentId]: concise || 'Respuesta sin contenido utilizable.',
+    },
+    lastConclusions: [
+      ...snapshot.lastConclusions,
+      {
+        agentId,
+        author: 'agent',
+        content: concise || '—',
+        timestamp,
+      },
+    ],
+  };
+};
+
+export const registerSystemNote = (
+  snapshot: SharedConversationSnapshot,
+  content: string,
+  timestamp: string,
+): SharedConversationSnapshot => ({
+  ...snapshot,
+  lastConclusions: [
+    ...snapshot.lastConclusions,
+    {
+      author: 'system',
+      content,
+      timestamp,
+    },
+  ],
+});
+
+export { createInitialSnapshot, limitSnapshotHistory } from './types';
+export type {
+  CoordinationStrategyId,
+  SharedConversationSnapshot,
+  MultiAgentContext,
+  OrchestrationPlan,
+  OrchestrationTraceEntry,
+} from './types';

--- a/src/core/orchestration/strategies/criticReviewer.ts
+++ b/src/core/orchestration/strategies/criticReviewer.ts
@@ -1,0 +1,149 @@
+import { CoordinationStrategy, OrchestrationPlan } from '../types';
+import {
+  AgentRoleAssignment,
+  InternalBridgeMessage,
+  MultiAgentContext,
+  SharedConversationSnapshot,
+} from '../types';
+import { AgentDefinition } from '../../agents/agentRegistry';
+
+const isReviewer = (role: AgentRoleAssignment | undefined): boolean => {
+  if (!role?.role) {
+    return false;
+  }
+  const normalized = role.role.toLowerCase();
+  return normalized.includes('crític') || normalized.includes('critic') || normalized.includes('revisor');
+};
+
+const splitRoles = (
+  agents: AgentDefinition[],
+  roles: Record<string, AgentRoleAssignment | undefined>,
+): { producers: AgentDefinition[]; reviewers: AgentDefinition[] } => {
+  const producers: AgentDefinition[] = [];
+  const reviewers: AgentDefinition[] = [];
+
+  agents.forEach(agent => {
+    if (isReviewer(roles[agent.id])) {
+      reviewers.push(agent);
+    } else {
+      producers.push(agent);
+    }
+  });
+
+  if (producers.length === 0 && reviewers.length > 1) {
+    producers.push(reviewers.shift()!);
+  }
+
+  if (reviewers.length === 0 && producers.length > 1) {
+    reviewers.push(producers[producers.length - 1]);
+  }
+
+  return { producers, reviewers };
+};
+
+const buildProducerInstructions = (
+  agent: AgentDefinition,
+  role: AgentRoleAssignment | undefined,
+  snapshot: SharedConversationSnapshot,
+  userPrompt: string,
+): string[] => {
+  const instructions: string[] = [];
+  if (role?.role) {
+    instructions.push(`Rol productor: ${role.role}.`);
+  }
+  if (role?.objective) {
+    instructions.push(`Objetivo prioritario: ${role.objective}.`);
+  }
+  if (snapshot.sharedSummary) {
+    instructions.push(`Resumen colectivo vigente: ${snapshot.sharedSummary}`);
+  }
+  if (snapshot.lastConclusions.length) {
+    const last = snapshot.lastConclusions
+      .slice(-2)
+      .map(entry => `${entry.author === 'system' ? 'Coordinador' : `Agente ${entry.agentId ?? 'desconocido'}`}: ${entry.content}`)
+      .join('\n');
+    instructions.push(`Contexto inmediato:\n${last}`);
+  }
+  instructions.push(`Genera una propuesta sólida para: ${userPrompt}`);
+  instructions.push('Incluye supuestos clave y pasos ejecutables.');
+  return instructions;
+};
+
+const buildReviewerInstructions = (
+  agent: AgentDefinition,
+  role: AgentRoleAssignment | undefined,
+  snapshot: SharedConversationSnapshot,
+  userPrompt: string,
+): string[] => {
+  const instructions: string[] = [];
+  instructions.push('Actúas como crítico/revisor de la propuesta previa.');
+  if (role?.role) {
+    instructions.push(`Rol asignado: ${role.role}.`);
+  }
+  if (role?.objective) {
+    instructions.push(`Criterios clave: ${role.objective}.`);
+  }
+  if (snapshot.lastConclusions.length) {
+    const [latest] = snapshot.lastConclusions.slice(-1);
+    if (latest) {
+      instructions.push(`Última propuesta recibida: ${latest.content}`);
+    }
+  }
+  instructions.push(`Valida o mejora la respuesta respecto a: ${userPrompt}`);
+  instructions.push('Entrega veredicto y mejoras puntuales.');
+  return instructions;
+};
+
+const buildContext = (
+  agent: AgentDefinition,
+  role: AgentRoleAssignment | undefined,
+  snapshot: SharedConversationSnapshot,
+  userPrompt: string,
+  instructions: string[],
+): MultiAgentContext => ({
+  strategyId: 'critic-reviewer',
+  snapshot,
+  role,
+  instructions,
+  userPrompt,
+});
+
+export const criticReviewerStrategy: CoordinationStrategy = {
+  id: 'critic-reviewer',
+  label: 'Productor + crítico',
+  description: 'Un agente genera propuestas y otro(s) las audita antes de publicarlas.',
+  buildPlan: ({ userPrompt, agents, snapshot, roles }): OrchestrationPlan => {
+    const timestamp = new Date().toISOString();
+    const { producers, reviewers } = splitRoles(agents, roles);
+    const sharedMessages: InternalBridgeMessage[] = [
+      {
+        id: `bridge-critic-${timestamp}`,
+        author: 'system',
+        content: `Coordinador: modo crítico. Productores (${producers.length}) → Revisores (${reviewers.length}).`,
+        timestamp,
+      },
+    ];
+
+    const steps = [
+      ...producers.map(agent => ({
+        agent,
+        prompt: userPrompt,
+        context: buildContext(agent, roles[agent.id], snapshot, userPrompt, buildProducerInstructions(agent, roles[agent.id], snapshot, userPrompt)),
+      })),
+      ...reviewers.map(agent => ({
+        agent,
+        prompt: userPrompt,
+        context: buildContext(agent, roles[agent.id], snapshot, userPrompt, buildReviewerInstructions(agent, roles[agent.id], snapshot, userPrompt)),
+      })),
+    ];
+
+    return {
+      steps,
+      sharedBridgeMessages: sharedMessages,
+      nextSnapshot: {
+        ...snapshot,
+        turn: snapshot.turn + 1,
+      },
+    };
+  },
+};

--- a/src/core/orchestration/strategies/sequentialTurn.ts
+++ b/src/core/orchestration/strategies/sequentialTurn.ts
@@ -1,0 +1,88 @@
+import { CoordinationStrategy, OrchestrationPlan } from '../types';
+import {
+  AgentRoleAssignment,
+  InternalBridgeMessage,
+  MultiAgentContext,
+  SharedConversationSnapshot,
+} from '../types';
+import { AgentDefinition } from '../../agents/agentRegistry';
+
+const buildInstructions = (
+  agent: AgentDefinition,
+  role: AgentRoleAssignment | undefined,
+  snapshot: SharedConversationSnapshot,
+  userPrompt: string,
+): string[] => {
+  const instructions: string[] = [];
+
+  if (role?.role) {
+    instructions.push(`Rol asignado: ${role.role}.`);
+  }
+  if (role?.objective) {
+    instructions.push(`Objetivo específico: ${role.objective}.`);
+  }
+
+  const personalSummary = snapshot.agentSummaries[agent.id];
+  if (personalSummary) {
+    instructions.push(`Tu último aporte registrado: ${personalSummary}`);
+  }
+
+  if (snapshot.sharedSummary) {
+    instructions.push(`Resumen colectivo: ${snapshot.sharedSummary}`);
+  }
+
+  if (snapshot.lastConclusions.length) {
+    const recent = snapshot.lastConclusions
+      .slice(-3)
+      .map(entry => `${entry.author === 'system' ? 'Coordinador' : `Agente ${entry.agentId ?? 'desconocido'}`}: ${entry.content}`)
+      .join('\n');
+    instructions.push(`Conclusiones recientes:\n${recent}`);
+  }
+
+  instructions.push(`Nueva petición del usuario: ${userPrompt}`);
+
+  return instructions;
+};
+
+const buildContext = (
+  agent: AgentDefinition,
+  role: AgentRoleAssignment | undefined,
+  snapshot: SharedConversationSnapshot,
+  userPrompt: string,
+): MultiAgentContext => ({
+  strategyId: 'sequential-turn',
+  snapshot,
+  role,
+  instructions: buildInstructions(agent, role, snapshot, userPrompt),
+  userPrompt,
+});
+
+export const sequentialTurnStrategy: CoordinationStrategy = {
+  id: 'sequential-turn',
+  label: 'Turno secuencial',
+  description: 'Cada agente responde en orden compartiendo el contexto acumulado.',
+  buildPlan: ({ userPrompt, agents, snapshot, roles }): OrchestrationPlan => {
+    const timestamp = new Date().toISOString();
+    const sharedBridge: InternalBridgeMessage = {
+      id: `bridge-system-${timestamp}`,
+      author: 'system',
+      content: `Coordinador: turno #${snapshot.turn + 1}. Participarán ${agents.length} agente(s) en secuencia.`,
+      timestamp,
+    };
+
+    const steps = agents.map(agent => ({
+      agent,
+      prompt: userPrompt,
+      context: buildContext(agent, roles[agent.id], snapshot, userPrompt),
+    }));
+
+    return {
+      steps,
+      sharedBridgeMessages: [sharedBridge],
+      nextSnapshot: {
+        ...snapshot,
+        turn: snapshot.turn + 1,
+      },
+    };
+  },
+};

--- a/src/core/orchestration/types.ts
+++ b/src/core/orchestration/types.ts
@@ -1,0 +1,119 @@
+import type { AgentDefinition } from '../agents/agentRegistry';
+import type { ChatMessage } from '../messages/messageTypes';
+
+export type CoordinationStrategyId = 'sequential-turn' | 'critic-reviewer';
+
+export interface AgentRoleAssignment {
+  role?: string;
+  objective?: string;
+}
+
+export interface SharedConversationSnapshot {
+  turn: number;
+  sharedSummary: string;
+  agentSummaries: Record<string, string>;
+  lastConclusions: Array<{
+    agentId?: string;
+    author: 'system' | 'agent';
+    content: string;
+    timestamp: string;
+  }>;
+}
+
+export interface InternalBridgeMessage {
+  id: string;
+  author: 'system' | 'agent';
+  agentId?: string;
+  content: string;
+  timestamp: string;
+}
+
+export interface MultiAgentContext {
+  strategyId: CoordinationStrategyId;
+  snapshot: SharedConversationSnapshot;
+  role?: AgentRoleAssignment;
+  instructions?: string[];
+  bridgeMessages?: InternalBridgeMessage[];
+  userPrompt: string;
+}
+
+export interface OrchestrationStepPlan {
+  agent: AgentDefinition;
+  prompt: string;
+  context: MultiAgentContext;
+  bridgeMessages?: InternalBridgeMessage[];
+}
+
+export interface OrchestrationPlan {
+  steps: OrchestrationStepPlan[];
+  sharedBridgeMessages: InternalBridgeMessage[];
+  nextSnapshot: SharedConversationSnapshot;
+}
+
+export interface OrchestrationTraceEntry {
+  id: string;
+  timestamp: string;
+  actor: 'system' | 'agent';
+  agentId?: string;
+  description: string;
+  details?: string;
+  strategyId: CoordinationStrategyId;
+}
+
+export interface CoordinationStrategy {
+  id: CoordinationStrategyId;
+  label: string;
+  description: string;
+  buildPlan: (input: {
+    userPrompt: string;
+    agents: AgentDefinition[];
+    snapshot: SharedConversationSnapshot;
+    roles: Record<string, AgentRoleAssignment | undefined>;
+  }) => OrchestrationPlan;
+}
+
+export const createInitialSnapshot = (): SharedConversationSnapshot => ({
+  turn: 0,
+  sharedSummary: 'Sin conclusiones previas registradas.',
+  agentSummaries: {},
+  lastConclusions: [],
+});
+
+export const limitSnapshotHistory = (
+  snapshot: SharedConversationSnapshot,
+  maxEntries = 8,
+): SharedConversationSnapshot => ({
+  ...snapshot,
+  lastConclusions:
+    snapshot.lastConclusions.length > maxEntries
+      ? snapshot.lastConclusions.slice(-maxEntries)
+      : snapshot.lastConclusions,
+});
+
+export const summarizeMessage = (message: ChatMessage): string => {
+  if (typeof message.content === 'string') {
+    return message.content;
+  }
+
+  return message.content
+    .map(part => {
+      if (typeof part === 'string') {
+        return part;
+      }
+      if (part.type === 'text') {
+        return part.text;
+      }
+      if (part.type === 'image') {
+        return part.alt ?? '[imagen]';
+      }
+      if (part.type === 'audio') {
+        return part.transcript ?? '[audio]';
+      }
+      if (part.type === 'file') {
+        return part.name ?? '[archivo]';
+      }
+      return '';
+    })
+    .filter(Boolean)
+    .join('\n');
+};


### PR DESCRIPTION
## Summary
- add orchestration core modules providing sequential and critic/reviewer strategies with shared snapshot utilities
- extend message pipeline to propagate multi-agent context, record internal system messages, and trace provider exchanges
- expose UI controls for per-agent roles and a "Conversa entre agentes" panel while filtering internal chatter from the main feed

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68ce89fc11a48333977003ae6c6596c3