### PR TITLE
feat(chat): refactor message rendering and add code block actions

### DIFF
--- a/src/components/chat/ChatInterface.css
+++ b/src/components/chat/ChatInterface.css
@@ -466,6 +466,108 @@
   white-space: pre-wrap;
 }
 
+.message-card-body {
+  display: flex;
+  flex-direction: column;
+  gap: 14px;
+}
+
+.message-card-media {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+  border-radius: 12px;
+  overflow: hidden;
+}
+
+.message-card-media img {
+  width: 100%;
+  border-radius: 12px;
+}
+
+.message-code-block {
+  position: relative;
+  padding: 52px 18px 18px;
+  border-radius: 14px;
+  background: radial-gradient(circle at top, rgba(29, 35, 60, 0.75), rgba(14, 16, 30, 0.85));
+  border: 1px solid rgba(142, 141, 255, 0.2);
+  box-shadow: inset 0 0 0 1px rgba(142, 141, 255, 0.08);
+  color: rgba(233, 236, 255, 0.92);
+  overflow: hidden;
+}
+
+.message-code-block pre {
+  margin: 0;
+  font-family: 'JetBrains Mono', 'Fira Code', 'SFMono-Regular', Menlo, Monaco, Consolas, 'Liberation Mono', 'Courier New',
+    monospace;
+  font-size: 13px;
+  line-height: 1.7;
+  background: transparent;
+  color: inherit;
+  white-space: pre;
+  overflow-x: auto;
+}
+
+.message-code-block code {
+  display: block;
+  white-space: inherit;
+}
+
+.message-code-toolbar {
+  position: absolute;
+  top: 14px;
+  left: 18px;
+  right: 18px;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+  padding: 8px 14px;
+  border-radius: 999px;
+  background: linear-gradient(120deg, rgba(20, 24, 44, 0.95), rgba(35, 41, 72, 0.75));
+  border: 1px solid rgba(142, 141, 255, 0.18);
+  box-shadow: 0 12px 24px rgba(12, 14, 28, 0.55);
+  pointer-events: none;
+}
+
+.message-code-language {
+  font-size: 11px;
+  letter-spacing: 0.8px;
+  text-transform: uppercase;
+  color: rgba(178, 182, 255, 0.9);
+  padding: 4px 10px;
+  border-radius: 999px;
+  border: 1px solid rgba(178, 182, 255, 0.3);
+  background: rgba(178, 182, 255, 0.08);
+}
+
+.message-actions {
+  display: flex;
+  gap: 8px;
+  margin-left: auto;
+  pointer-events: auto;
+}
+
+.message-action {
+  background: rgba(255, 255, 255, 0.08);
+  color: #fff;
+  border: 1px solid rgba(255, 255, 255, 0.14);
+  border-radius: 999px;
+  font-size: 11px;
+  padding: 6px 12px;
+  letter-spacing: 0.6px;
+  text-transform: uppercase;
+  cursor: pointer;
+  transition: transform 0.2s ease, background 0.2s ease, border-color 0.2s ease, box-shadow 0.2s ease;
+}
+
+.message-action:hover {
+  transform: translateY(-1px);
+  background: rgba(255, 183, 77, 0.16);
+  border-color: rgba(255, 183, 77, 0.4);
+  box-shadow: 0 10px 20px rgba(255, 183, 77, 0.18);
+}
+
 .chat-suggestions {
   display: flex;
   align-items: center;

--- a/src/components/chat/messages/MessageActions.tsx
+++ b/src/components/chat/messages/MessageActions.tsx
@@ -1,0 +1,38 @@
+import React, { useCallback } from 'react';
+
+interface MessageActionsProps {
+  value: string;
+  onAppend?: (value: string) => void;
+}
+
+export const MessageActions: React.FC<MessageActionsProps> = ({ value, onAppend }) => {
+  const handleCopy = useCallback(() => {
+    const clipboard = typeof window !== 'undefined' ? window.navigator?.clipboard : undefined;
+    if (clipboard?.writeText) {
+      clipboard.writeText(value).catch(() => {
+        // Silently ignore clipboard errors to avoid disrupting the UI
+      });
+    }
+  }, [value]);
+
+  const handleAppend = useCallback(() => {
+    if (onAppend) {
+      onAppend(value);
+    }
+  }, [onAppend, value]);
+
+  return (
+    <div className="message-actions" role="group" aria-label="Acciones del bloque de código">
+      <button type="button" className="message-action" onClick={handleCopy}>
+        Copiar
+      </button>
+      {onAppend ? (
+        <button type="button" className="message-action" onClick={handleAppend}>
+          Añadir al compositor
+        </button>
+      ) : null}
+    </div>
+  );
+};
+
+export default MessageActions;

--- a/src/components/chat/messages/MessageCard.tsx
+++ b/src/components/chat/messages/MessageCard.tsx
@@ -1,0 +1,79 @@
+import React from 'react';
+import { ChatMessage } from '../../../core/messages/messageTypes';
+import { MessageContent } from './MessageContent';
+import { MessageAttachment } from './MessageAttachment';
+
+interface MessageCardProps {
+  message: ChatMessage;
+  chipColor: string;
+  agentDisplayName?: string;
+  providerLabel?: string;
+  formatTimestamp: (timestamp: string) => string;
+  onAppendToComposer?: (value: string) => void;
+}
+
+export const MessageCard: React.FC<MessageCardProps> = ({
+  message,
+  chipColor,
+  agentDisplayName,
+  providerLabel,
+  formatTimestamp,
+  onAppendToComposer,
+}) => {
+  const isUser = message.author === 'user';
+  const isSystem = message.author === 'system';
+  const authorLabel = isUser ? 'Tú' : isSystem ? 'Control Hub' : agentDisplayName ?? 'Agente';
+
+  return (
+    <div
+      className={`message-card ${isUser ? 'message-user' : ''} ${isSystem ? 'message-system' : ''}`}
+      data-author={message.author}
+    >
+      <div className="message-card-header">
+        <div className="message-card-author" style={{ borderColor: chipColor }}>
+          {authorLabel}
+        </div>
+        <div className="message-card-meta">
+          {!isUser && !isSystem && providerLabel ? (
+            <span className="message-card-tag" style={{ color: chipColor }}>
+              {providerLabel}
+            </span>
+          ) : null}
+          <span className="message-card-time">{formatTimestamp(message.timestamp)}</span>
+          {message.status === 'pending' && <span className="message-card-status">orquestando…</span>}
+        </div>
+      </div>
+
+      <div className="message-card-body">
+        <MessageContent
+          content={message.content}
+          transcriptions={message.transcriptions}
+          onAppendToComposer={!isUser ? onAppendToComposer : undefined}
+        />
+        {message.attachments?.length ? (
+          <div className="message-card-attachments">
+            {message.attachments.map(attachment => (
+              <MessageAttachment
+                key={attachment.id}
+                attachment={attachment}
+                transcriptions={message.transcriptions}
+              />
+            ))}
+          </div>
+        ) : null}
+      </div>
+
+      {message.modalities?.length ? (
+        <div className="message-card-modalities">
+          {message.modalities.map(modality => (
+            <span key={modality} className="modality-chip">
+              {modality}
+            </span>
+          ))}
+        </div>
+      ) : null}
+    </div>
+  );
+};
+
+export default MessageCard;

--- a/src/components/chat/messages/MessageContent.tsx
+++ b/src/components/chat/messages/MessageContent.tsx
@@ -1,0 +1,94 @@
+import React from 'react';
+import {
+  ChatContentPart,
+  ChatTranscription,
+} from '../../../core/messages/messageTypes';
+import {
+  normalizeContentParts,
+  splitMarkdownContent,
+} from '../../../core/messages/format';
+import { AudioPlayer } from './AudioPlayer';
+import { MessageActions } from './MessageActions';
+
+interface MessageContentProps {
+  content: string | ChatContentPart[];
+  transcriptions?: ChatTranscription[];
+  onAppendToComposer?: (value: string) => void;
+}
+
+export const MessageContent: React.FC<MessageContentProps> = ({
+  content,
+  transcriptions,
+  onAppendToComposer,
+}) => {
+  const parts = normalizeContentParts(content);
+
+  return (
+    <>
+      {parts.map((part, index) => {
+        if (part.type === 'text') {
+          const segments = splitMarkdownContent(part.text);
+          if (!segments.length) {
+            return null;
+          }
+
+          return segments.map((segment, segmentIndex) => {
+            if (segment.kind === 'code') {
+              return (
+                <div className="message-code-block" key={`code-${index}-${segmentIndex}`}>
+                  <div className="message-code-toolbar">
+                    {segment.language ? (
+                      <span className="message-code-language">{segment.language}</span>
+                    ) : null}
+                    <MessageActions value={segment.code} onAppend={onAppendToComposer} />
+                  </div>
+                  <pre>
+                    <code>{segment.code}</code>
+                  </pre>
+                </div>
+              );
+            }
+
+            return (
+              <p key={`text-${index}-${segmentIndex}`} className="message-card-content">
+                {segment.text}
+              </p>
+            );
+          });
+        }
+
+        if (part.type === 'image') {
+          return (
+            <figure key={`image-${index}`} className="message-card-media">
+              <img src={part.url} alt={part.alt ?? 'Imagen generada'} />
+              {part.alt && <figcaption>{part.alt}</figcaption>}
+            </figure>
+          );
+        }
+
+        if (part.type === 'audio') {
+          const relatedTranscriptions = transcriptions?.filter(item => !item.attachmentId);
+          return (
+            <div key={`audio-${index}`} className="message-card-media">
+              <AudioPlayer src={part.url} title="Respuesta de audio" transcriptions={relatedTranscriptions} />
+            </div>
+          );
+        }
+
+        if (part.type === 'file') {
+          return (
+            <div key={`file-${index}`} className="message-card-media">
+              <a href={part.url} target="_blank" rel="noreferrer">
+                {part.name ?? 'Archivo'}
+              </a>
+            </div>
+          );
+        }
+
+        return null;
+      })}
+    </>
+  );
+};
+
+export default MessageContent;

--- a/src/components/chat/messages/__tests__/MessageContent.test.tsx
+++ b/src/components/chat/messages/__tests__/MessageContent.test.tsx
@@ -1,0 +1,19 @@
+import React from 'react';
+import { describe, expect, it, vi } from 'vitest';
+import { render } from '@testing-library/react';
+import { MessageContent } from '../MessageContent';
+
+const noop = vi.fn();
+
+describe('MessageContent', () => {
+  it('renders plain text segments', () => {
+    const { container } = render(<MessageContent content="Hola mundo" onAppendToComposer={noop} />);
+    expect(container).toMatchSnapshot();
+  });
+
+  it('renders fenced code blocks with actions', () => {
+    const codeMessage = `Respuesta:\n\n\`\`\`ts\nconst saludo: string = 'hola';\nconsole.log(saludo);\n\`\`\`\n\nFin.`;
+    const { container } = render(<MessageContent content={codeMessage} onAppendToComposer={noop} />);
+    expect(container).toMatchSnapshot();
+  });
+});

--- a/src/components/chat/messages/__tests__/__snapshots__/MessageContent.test.tsx.snap
+++ b/src/components/chat/messages/__tests__/__snapshots__/MessageContent.test.tsx.snap
@@ -1,0 +1,67 @@
+// Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
+
+exports[`MessageContent > renders fenced code blocks with actions 1`] = `
+<div>
+  <p
+    class="message-card-content"
+  >
+    Respuesta:
+
+
+  </p>
+  <div
+    class="message-code-block"
+  >
+    <div
+      class="message-code-toolbar"
+    >
+      <span
+        class="message-code-language"
+      >
+        ts
+      </span>
+      <div
+        aria-label="Acciones del bloque de código"
+        class="message-actions"
+        role="group"
+      >
+        <button
+          class="message-action"
+          type="button"
+        >
+          Copiar
+        </button>
+        <button
+          class="message-action"
+          type="button"
+        >
+          Añadir al compositor
+        </button>
+      </div>
+    </div>
+    <pre>
+      <code>
+        const saludo: string = 'hola';
+console.log(saludo);
+      </code>
+    </pre>
+  </div>
+  <p
+    class="message-card-content"
+  >
+    
+
+Fin.
+  </p>
+</div>
+`;
+
+exports[`MessageContent > renders plain text segments 1`] = `
+<div>
+  <p
+    class="message-card-content"
+  >
+    Hola mundo
+  </p>
+</div>
+`;

--- a/src/core/messages/format.ts
+++ b/src/core/messages/format.ts
@@ -1,0 +1,101 @@
+import { ChatContentPart } from './messageTypes';
+
+export type NormalizedContentPart =
+  | { type: 'text'; text: string }
+  | Extract<ChatContentPart, { type: 'image' }>
+  | Extract<ChatContentPart, { type: 'audio' }>
+  | Extract<ChatContentPart, { type: 'file' }>;
+
+export interface MarkdownTextSegment {
+  kind: 'text';
+  text: string;
+}
+
+export interface MarkdownCodeSegment {
+  kind: 'code';
+  code: string;
+  language?: string;
+}
+
+export type MarkdownSegment = MarkdownTextSegment | MarkdownCodeSegment;
+
+export function normalizeContentParts(content: string | ChatContentPart[]): NormalizedContentPart[] {
+  if (!content) {
+    return [];
+  }
+
+  if (Array.isArray(content)) {
+    return content
+      .map<NormalizedContentPart | null>(part => {
+        if (!part) {
+          return null;
+        }
+
+        if (typeof part === 'string') {
+          return { type: 'text', text: part };
+        }
+
+        if ('type' in part) {
+          if (part.type === 'text') {
+            return { type: 'text', text: part.text };
+          }
+
+          return part as NormalizedContentPart;
+        }
+
+        return null;
+      })
+      .filter((part): part is NormalizedContentPart => part !== null);
+  }
+
+  return [{ type: 'text', text: content }];
+}
+
+const CODE_BLOCK_REGEX = /```([^\n`]*)\r?\n([\s\S]*?)```/g;
+
+export function splitMarkdownContent(text: string): MarkdownSegment[] {
+  if (!text.includes('```')) {
+    return text ? [{ kind: 'text', text }] : [];
+  }
+
+  const segments: MarkdownSegment[] = [];
+  let lastIndex = 0;
+  let match: RegExpExecArray | null;
+
+  // Reset regex state in case the function is reused
+  CODE_BLOCK_REGEX.lastIndex = 0;
+
+  while ((match = CODE_BLOCK_REGEX.exec(text)) !== null) {
+    const [block, language, code = ''] = match;
+    const index = match.index ?? 0;
+
+    if (index > lastIndex) {
+      const preceding = text.slice(lastIndex, index);
+      if (preceding.trim().length > 0) {
+        segments.push({ kind: 'text', text: preceding });
+      }
+    }
+
+    const cleanedCode = code.replace(/\s+$/u, '');
+    segments.push({
+      kind: 'code',
+      code: cleanedCode,
+      language: language?.trim() || undefined,
+    });
+
+    lastIndex = index + block.length;
+  }
+
+  if (lastIndex < text.length) {
+    const trailing = text.slice(lastIndex);
+    if (trailing.trim().length > 0) {
+      segments.push({ kind: 'text', text: trailing });
+    }
+  }
+
+  if (segments.length === 0 && text.trim().length > 0) {
+    return [{ kind: 'text', text }];
+  }
+
+  return segments;
+}


### PR DESCRIPTION
## Summary
- add message formatting utilities to normalize parts and detect fenced code blocks
- refactor chat workspace to delegate rendering to new message card/content/actions components with floating code block controls
- update chat interface styles and add snapshot tests to cover text and code rendering

## Testing
- npx vitest run

------
https://chatgpt.com/codex/tasks/task_e_68ce971cd1748333a3b38bd1eb1be705