### PR TITLE
feat: share messages across agents

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,26 @@
 # JungleMonkAI
+
+## Flujo de compartición entre agentes
+
+El panel de conversación ahora permite reenviar respuestas entre agentes para acelerar revisiones y hand-offs técnicos.
+
+1. Sitúate sobre cualquier bloque de código generado por un agente y abre la barra de acciones.
+2. Pulsa **Enviar a…** para desplegar el selector de agentes activos. Solo aparecen los modelos encendidos en el panel lateral.
+3. Selecciona el agente de destino. Se registrará un apunte interno y se creará una nueva respuesta pendiente con el contexto compartido.
+4. El contenido canónico (si procede de un bloque de código) se copia automáticamente al compositor para que puedas editarlo antes de reenviarlo.
+
+Cada compartición queda registrada en `shared-messages.json` (almacenamiento local o `AppData` en Tauri) junto al historial de correcciones para facilitar la trazabilidad del dashboard de calidad.
+
+## Controles sobre los mensajes
+
+- El botón **Usar como borrador** en la cabecera de cada mensaje no humano carga su contenido en el compositor y limpia adjuntos previos.
+- Puedes seguir utilizando **Añadir al compositor** para insertar fragmentos específicos sin reemplazar el borrador actual.
+- El dashboard de calidad incorpora una sección **Mensajes compartidos** con el histórico de hand-offs más recientes.
+
+## Pruebas
+
+Ejecuta toda la batería de tests con:
+
+```bash
+npm test
+```

--- a/src/components/agents/AgentPresenceList.tsx
+++ b/src/components/agents/AgentPresenceList.tsx
@@ -11,6 +11,8 @@ interface AgentPresenceListProps {
   onOpenConsole?: (agentId: string) => void;
   onRefreshAgent?: (agentId: string) => void | Promise<void>;
   onUpdateRole: (agentId: string, updates: { role?: string; objective?: string }) => void;
+  selectionMode?: boolean;
+  onSelectAgent?: (agentId: string) => void;
 }
 
 const STATUS_LABELS: Record<AgentPresenceStatus, string> = {
@@ -58,8 +60,10 @@ export const AgentPresenceList: React.FC<AgentPresenceListProps> = ({
   onOpenConsole,
   onRefreshAgent,
   onUpdateRole,
+  selectionMode = false,
+  onSelectAgent,
 }) => (
-  <ul className="agent-presence-list">
+  <ul className={`agent-presence-list ${selectionMode ? 'is-selection-mode' : ''}`}>
     {agents.map(agent => {
       const entry = presence.get(agent.id) ?? { status: 'loading', lastChecked: null };
       const statusClass = getStatusClass(entry.status);
@@ -91,59 +95,76 @@ export const AgentPresenceList: React.FC<AgentPresenceListProps> = ({
               </span>
             </div>
             {entry.message && <div className="agent-presence-message">{entry.message}</div>}
-            <div className="agent-presence-role">
-              <label>
-                Rol
-                <select
-                  value={agent.role ?? ''}
-                  onChange={event => onUpdateRole(agent.id, { role: event.target.value || undefined, objective: agent.objective })}
-                >
-                  {ROLE_PRESETS.map(option => (
-                    <option key={option || 'none'} value={option}>
-                      {option ? option : 'Sin asignar'}
-                    </option>
-                  ))}
-                </select>
-              </label>
-              <label>
-                Objetivo
-                <input
-                  type="text"
-                  value={agent.objective ?? ''}
-                  onChange={event =>
-                    onUpdateRole(agent.id, {
-                      role: agent.role,
-                      objective: event.target.value.trim() ? event.target.value : undefined,
-                    })
-                  }
-                  placeholder="Describe el foco actual"
-                />
-              </label>
-            </div>
+            {selectionMode ? null : (
+              <div className="agent-presence-role">
+                <label>
+                  Rol
+                  <select
+                    value={agent.role ?? ''}
+                    onChange={event =>
+                      onUpdateRole(agent.id, { role: event.target.value || undefined, objective: agent.objective })
+                    }
+                  >
+                    {ROLE_PRESETS.map(option => (
+                      <option key={option || 'none'} value={option}>
+                        {option ? option : 'Sin asignar'}
+                      </option>
+                    ))}
+                  </select>
+                </label>
+                <label>
+                  Objetivo
+                  <input
+                    type="text"
+                    value={agent.objective ?? ''}
+                    onChange={event =>
+                      onUpdateRole(agent.id, {
+                        role: agent.role,
+                        objective: event.target.value.trim() ? event.target.value : undefined,
+                      })
+                    }
+                    placeholder="Describe el foco actual"
+                  />
+                </label>
+              </div>
+            )}
           </div>
           <div className="agent-presence-actions">
-            <button
-              type="button"
-              className={`presence-action ${agent.active ? 'is-active' : ''}`}
-              onClick={() => onToggleAgent(agent.id)}
-            >
-              {agent.active ? 'Desactivar' : 'Activar'}
-            </button>
-            <button
-              type="button"
-              className="presence-action"
-              onClick={() => onOpenConsole?.(agent.id)}
-            >
-              Consola
-            </button>
-            <button
-              type="button"
-              className="presence-action is-ghost"
-              onClick={() => onRefreshAgent?.(agent.id)}
-              title="Reevaluar disponibilidad"
-            >
-              ↻
-            </button>
+            {selectionMode && onSelectAgent ? (
+              <button
+                type="button"
+                className="presence-action"
+                onClick={() => onSelectAgent(agent.id)}
+                disabled={!agent.active}
+              >
+                Enviar
+              </button>
+            ) : (
+              <>
+                <button
+                  type="button"
+                  className={`presence-action ${agent.active ? 'is-active' : ''}`}
+                  onClick={() => onToggleAgent(agent.id)}
+                >
+                  {agent.active ? 'Desactivar' : 'Activar'}
+                </button>
+                <button
+                  type="button"
+                  className="presence-action"
+                  onClick={() => onOpenConsole?.(agent.id)}
+                >
+                  Consola
+                </button>
+                <button
+                  type="button"
+                  className="presence-action is-ghost"
+                  onClick={() => onRefreshAgent?.(agent.id)}
+                  title="Reevaluar disponibilidad"
+                >
+                  ↻
+                </button>
+              </>
+            )}
           </div>
         </li>
       );

--- a/src/components/chat/ChatInterface.css
+++ b/src/components/chat/ChatInterface.css
@@ -546,6 +546,7 @@
   gap: 8px;
   margin-left: auto;
   pointer-events: auto;
+  position: relative;
 }
 
 .message-action {
@@ -566,6 +567,45 @@
   background: rgba(255, 183, 77, 0.16);
   border-color: rgba(255, 183, 77, 0.4);
   box-shadow: 0 10px 20px rgba(255, 183, 77, 0.18);
+}
+
+.message-action-popover {
+  position: absolute;
+  top: 36px;
+  right: 0;
+  width: 320px;
+  max-height: 260px;
+  overflow-y: auto;
+  padding: 12px;
+  border-radius: 12px;
+  background: rgba(14, 16, 32, 0.96);
+  border: 1px solid rgba(142, 141, 255, 0.24);
+  box-shadow: 0 18px 34px rgba(12, 14, 28, 0.55);
+  z-index: 10;
+}
+
+.message-action-empty {
+  margin: 0;
+  font-size: 12px;
+  color: rgba(255, 255, 255, 0.7);
+}
+
+.message-card-action {
+  border: none;
+  background: rgba(255, 255, 255, 0.08);
+  color: rgba(255, 255, 255, 0.85);
+  padding: 4px 10px;
+  border-radius: 999px;
+  font-size: 10px;
+  letter-spacing: 0.6px;
+  text-transform: uppercase;
+  cursor: pointer;
+  transition: background 0.2s ease, color 0.2s ease;
+}
+
+.message-card-action:hover {
+  background: rgba(255, 183, 77, 0.16);
+  color: #fff;
 }
 
 .chat-suggestions {
@@ -1143,6 +1183,21 @@
 .quality-history li em {
   font-style: normal;
   color: rgba(255, 183, 77, 0.8);
+}
+
+.quality-share-log {
+  margin-top: 10px;
+}
+
+.quality-share-code {
+  font-family: 'JetBrains Mono', 'Fira Code', 'SFMono-Regular', Menlo, Monaco, Consolas, 'Liberation Mono', 'Courier New',
+    monospace;
+  font-size: 10px;
+  padding: 2px 6px;
+  border-radius: 6px;
+  background: rgba(255, 255, 255, 0.08);
+  border: 1px solid rgba(255, 255, 255, 0.14);
+  color: rgba(255, 255, 255, 0.8);
 }
 
 .chat-status-bar {

--- a/src/components/chat/ChatWorkspace.tsx
+++ b/src/components/chat/ChatWorkspace.tsx
@@ -33,6 +33,8 @@ export const ChatWorkspace: React.FC<ChatWorkspaceProps> = ({ sidePanel, actorFi
     lastUserMessage,
     quickCommands,
     formatTimestamp,
+    shareMessageWithAgent,
+    loadMessageIntoDraft,
   } = useMessages();
 
   const publicMessages = useMemo(() => messages.filter(message => message.visibility !== 'internal'), [messages]);
@@ -156,6 +158,10 @@ export const ChatWorkspace: React.FC<ChatWorkspaceProps> = ({ sidePanel, actorFi
                         providerLabel={providerLabel}
                         formatTimestamp={formatTimestamp}
                         onAppendToComposer={appendToDraft}
+                        onShareMessage={(agentId, messageId, canonicalCode) =>
+                          shareMessageWithAgent(agentId, messageId, { canonicalCode })
+                        }
+                        onLoadIntoDraft={loadMessageIntoDraft}
                       />
                     );
                   })}

--- a/src/components/chat/messages/MessageActions.tsx
+++ b/src/components/chat/messages/MessageActions.tsx
@@ -1,11 +1,25 @@
-import React, { useCallback } from 'react';
+import React, { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import { AgentPresenceList } from '../../agents/AgentPresenceList';
+import { useAgents } from '../../../core/agents/AgentContext';
+import type { AgentPresenceEntry } from '../../../core/agents/presence';
 
 interface MessageActionsProps {
+  messageId: string;
   value: string;
   onAppend?: (value: string) => void;
+  onShare?: (agentId: string, canonicalCode?: string) => void;
 }
 
-export const MessageActions: React.FC<MessageActionsProps> = ({ value, onAppend }) => {
+export const MessageActions: React.FC<MessageActionsProps> = ({
+  messageId,
+  value,
+  onAppend,
+  onShare,
+}) => {
+  const containerRef = useRef<HTMLDivElement | null>(null);
+  const { agents } = useAgents();
+  const [isPickerOpen, setIsPickerOpen] = useState(false);
+
   const handleCopy = useCallback(() => {
     const clipboard = typeof window !== 'undefined' ? window.navigator?.clipboard : undefined;
     if (clipboard?.writeText) {
@@ -21,8 +35,67 @@ export const MessageActions: React.FC<MessageActionsProps> = ({ value, onAppend 
     }
   }, [onAppend, value]);
 
+  const handleTogglePicker = useCallback(() => {
+    if (!onShare) {
+      return;
+    }
+    setIsPickerOpen(prev => !prev);
+  }, [onShare]);
+
+  const shareableAgents = useMemo(() => agents.filter(agent => agent.active), [agents]);
+
+  const noopToggleAgent = useCallback((_: string) => {}, []);
+  const noopUpdateRole = useCallback(
+    (_agentId: string, _updates: { role?: string; objective?: string }) => {},
+    [],
+  );
+
+  const presenceMap = useMemo(() => {
+    const now = Date.now();
+    const entries = new Map<string, AgentPresenceEntry>();
+    shareableAgents.forEach(agent => {
+      entries.set(agent.id, {
+        status: 'online',
+        lastChecked: now,
+        message: 'Disponible para recibir mensajes compartidos',
+      });
+    });
+    return entries;
+  }, [shareableAgents]);
+
+  const handleShareWithAgent = useCallback(
+    (agentId: string) => {
+      if (!onShare) {
+        return;
+      }
+      onShare(agentId, value);
+      setIsPickerOpen(false);
+    },
+    [onShare, value],
+  );
+
+  useEffect(() => {
+    if (!isPickerOpen) {
+      return;
+    }
+
+    const handleClickOutside = (event: MouseEvent) => {
+      if (!containerRef.current) {
+        return;
+      }
+      if (!containerRef.current.contains(event.target as Node)) {
+        setIsPickerOpen(false);
+      }
+    };
+
+    document.addEventListener('mousedown', handleClickOutside);
+    return () => {
+      document.removeEventListener('mousedown', handleClickOutside);
+    };
+  }, [isPickerOpen]);
+
   return (
-    <div className="message-actions" role="group" aria-label="Acciones del bloque de código">
+    <div ref={containerRef} className="message-actions" role="group" aria-label="Acciones del bloque de código">
       <button type="button" className="message-action" onClick={handleCopy}>
         Copiar
       </button>
@@ -30,6 +103,27 @@ export const MessageActions: React.FC<MessageActionsProps> = ({ value, onAppend 
         <button type="button" className="message-action" onClick={handleAppend}>
           Añadir al compositor
         </button>
+      ) : null}
+      {onShare ? (
+        <button type="button" className="message-action" onClick={handleTogglePicker}>
+          Enviar a…
+        </button>
+      ) : null}
+      {onShare && isPickerOpen ? (
+        <div className="message-action-popover" role="dialog" aria-label={`Compartir mensaje ${messageId}`}>
+          {shareableAgents.length === 0 ? (
+            <p className="message-action-empty">No hay agentes activos para compartir.</p>
+          ) : (
+            <AgentPresenceList
+              agents={shareableAgents}
+              presence={presenceMap}
+              onToggleAgent={noopToggleAgent}
+              onUpdateRole={noopUpdateRole}
+              selectionMode
+              onSelectAgent={handleShareWithAgent}
+            />
+          )}
+        </div>
       ) : null}
     </div>
   );

--- a/src/components/chat/messages/MessageContent.tsx
+++ b/src/components/chat/messages/MessageContent.tsx
@@ -11,15 +11,19 @@ import { AudioPlayer } from './AudioPlayer';
 import { MessageActions } from './MessageActions';
 
 interface MessageContentProps {
+  messageId: string;
   content: string | ChatContentPart[];
   transcriptions?: ChatTranscription[];
   onAppendToComposer?: (value: string) => void;
+  onShare?: (agentId: string, canonicalCode?: string) => void;
 }
 
 export const MessageContent: React.FC<MessageContentProps> = ({
+  messageId,
   content,
   transcriptions,
   onAppendToComposer,
+  onShare,
 }) => {
   const parts = normalizeContentParts(content);
 
@@ -40,7 +44,12 @@ export const MessageContent: React.FC<MessageContentProps> = ({
                     {segment.language ? (
                       <span className="message-code-language">{segment.language}</span>
                     ) : null}
-                    <MessageActions value={segment.code} onAppend={onAppendToComposer} />
+                    <MessageActions
+                      messageId={messageId}
+                      value={segment.code}
+                      onAppend={onAppendToComposer}
+                      onShare={onShare}
+                    />
                   </div>
                   <pre>
                     <code>{segment.code}</code>

--- a/src/components/chat/messages/__tests__/MessageContent.test.tsx
+++ b/src/components/chat/messages/__tests__/MessageContent.test.tsx
@@ -2,18 +2,27 @@ import React from 'react';
 import { describe, expect, it, vi } from 'vitest';
 import { render } from '@testing-library/react';
 import { MessageContent } from '../MessageContent';
+import { AgentProvider } from '../../../../core/agents/AgentContext';
 
 const noop = vi.fn();
 
 describe('MessageContent', () => {
   it('renders plain text segments', () => {
-    const { container } = render(<MessageContent content="Hola mundo" onAppendToComposer={noop} />);
+    const { container } = render(
+      <AgentProvider apiKeys={{}}>
+        <MessageContent messageId="message-1" content="Hola mundo" onAppendToComposer={noop} />
+      </AgentProvider>,
+    );
     expect(container).toMatchSnapshot();
   });
 
   it('renders fenced code blocks with actions', () => {
     const codeMessage = `Respuesta:\n\n\`\`\`ts\nconst saludo: string = 'hola';\nconsole.log(saludo);\n\`\`\`\n\nFin.`;
-    const { container } = render(<MessageContent content={codeMessage} onAppendToComposer={noop} />);
+    const { container } = render(
+      <AgentProvider apiKeys={{}}>
+        <MessageContent messageId="message-2" content={codeMessage} onAppendToComposer={noop} />
+      </AgentProvider>,
+    );
     expect(container).toMatchSnapshot();
   });
 });

--- a/src/core/messages/__tests__/MessageContext.test.tsx
+++ b/src/core/messages/__tests__/MessageContext.test.tsx
@@ -1,0 +1,32 @@
+import React from 'react';
+import { renderHook, act } from '@testing-library/react';
+import { describe, expect, it } from 'vitest';
+import { AgentProvider } from '../../agents/AgentContext';
+import { MessageProvider, useMessages } from '../MessageContext';
+
+const Wrapper: React.FC<{ children: React.ReactNode }> = ({ children }) => (
+  <AgentProvider apiKeys={{}}>
+    <MessageProvider apiKeys={{}}>{children}</MessageProvider>
+  </AgentProvider>
+);
+
+describe('MessageContext', () => {
+  it('carga el contenido del mensaje en el borrador', () => {
+    const { result } = renderHook(() => useMessages(), { wrapper: Wrapper });
+    const initialMessage = result.current.messages[0];
+    const expectedDraft =
+      typeof initialMessage.content === 'string' ? initialMessage.content : 'Bienvenido a JungleMonk.AI Control Hub.';
+
+    act(() => {
+      result.current.setDraft('borrador previo');
+      result.current.addAttachment({ id: 'temp', type: 'file', name: 'temp.txt' });
+    });
+
+    act(() => {
+      result.current.loadMessageIntoDraft(initialMessage.id);
+    });
+
+    expect(result.current.draft).toBe(expectedDraft);
+    expect(result.current.composerAttachments).toHaveLength(0);
+  });
+});

--- a/src/core/messages/messageTypes.ts
+++ b/src/core/messages/messageTypes.ts
@@ -60,6 +60,7 @@ export interface ChatMessage {
   content: string | ChatContentPart[];
   timestamp: string;
   agentId?: string;
+  originAgentId?: string;
   status?: 'pending' | 'sent';
   sourcePrompt?: string;
   attachments?: ChatAttachment[];
@@ -69,6 +70,8 @@ export interface ChatMessage {
   correctionId?: string;
   visibility?: ChatVisibility;
   orchestrationContext?: MultiAgentContext;
+  sharedByMessageId?: string;
+  canonicalCode?: string;
 }
 
 export interface MessageFeedback {


### PR DESCRIPTION
## Summary
- extend chat message metadata and persistence layers to track shared messages between agents
- add "Enviar a…" actions with agent selector, message-to-draft shortcut, and sharing metrics in the quality dashboard
- document the sharing workflow and cover the new draft loading helper with unit tests

## Testing
- npm test -- --run

------
https://chatgpt.com/codex/tasks/task_e_68ce9939554c8333a839a816766b6f1a