### PR TITLE
feat: add dynamic agent registry and plugin manifests

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -117,7 +117,11 @@ const App: React.FC = () => {
   };
 
   return (
-    <AgentProvider apiKeys={globalSettings.apiKeys}>
+    <AgentProvider
+      apiKeys={globalSettings.apiKeys}
+      enabledPlugins={globalSettings.enabledPlugins}
+      approvedManifests={globalSettings.approvedManifests}
+    >
       <MessageProvider apiKeys={globalSettings.apiKeys}>
         <RepoWorkflowProvider>
           <AppContent apiKeys={globalSettings.apiKeys} onApiKeyChange={handleApiKeyChange} />

--- a/src/components/settings/GlobalSettingsPanel.tsx
+++ b/src/components/settings/GlobalSettingsPanel.tsx
@@ -39,6 +39,25 @@ const cloneSettings = (value: GlobalSettings): GlobalSettings => ({
     }),
     {}
   ),
+  enabledPlugins: [...value.enabledPlugins],
+  approvedManifests: Object.entries(value.approvedManifests).reduce(
+    (acc, [pluginId, entry]) => {
+      acc[pluginId] = {
+        checksum: entry.checksum,
+        approvedAt: entry.approvedAt,
+        manifests: entry.manifests.map((manifest) => ({
+          provider: manifest.provider,
+          capabilities: [...manifest.capabilities],
+          models: manifest.models.map((model) => ({
+            ...model,
+            aliases: model.aliases ? [...model.aliases] : undefined,
+          })),
+        })),
+      };
+      return acc;
+    },
+    {} as GlobalSettings['approvedManifests'],
+  ),
 });
 
 const getPresetId = () => {

--- a/src/core/agents/AgentRegistryService.ts
+++ b/src/core/agents/AgentRegistryService.ts
@@ -1,0 +1,218 @@
+import type { AgentManifest } from '../../types/agents';
+import { AgentManifestCacheEntry } from '../../types/agents';
+import type { AgentManifestModel } from '../../types/agents';
+import { AgentDefinition, INITIAL_AGENTS } from './agentRegistry';
+
+export interface PluginRegistryEntry {
+  pluginId: string;
+  manifests: AgentManifest[];
+}
+
+type AgentRegistrySubscriber = (agents: AgentDefinition[]) => void;
+
+const DEFAULT_PLUGIN_ACCENT = '#6C5CE7';
+
+const cloneAliases = (aliases: string[] | undefined): string[] | undefined =>
+  aliases ? [...aliases] : undefined;
+
+const cloneCapabilities = (capabilities: string[] | undefined): string[] | undefined =>
+  capabilities ? [...capabilities] : undefined;
+
+const cloneManifest = (manifest: AgentManifest): AgentManifest => ({
+  provider: manifest.provider,
+  capabilities: [...manifest.capabilities],
+  models: manifest.models.map(model => ({
+    ...model,
+    aliases: cloneAliases(model.aliases),
+  })),
+});
+
+const sanitizeChannel = (model: AgentManifestModel, provider: string): string | undefined => {
+  if (typeof model.channel === 'string' && model.channel.trim()) {
+    return model.channel.trim();
+  }
+  const normalizedProvider = provider.trim().toLowerCase();
+  return normalizedProvider ? normalizedProvider : undefined;
+};
+
+const cloneAgentDefinition = (agent: AgentDefinition): AgentDefinition => ({
+  ...agent,
+  aliases: cloneAliases(agent.aliases),
+  capabilities: cloneCapabilities(agent.capabilities),
+});
+
+export class AgentRegistryService {
+  private readonly builtinAgents: AgentDefinition[];
+
+  private readonly pluginAgents = new Map<string, AgentDefinition[]>();
+
+  private readonly subscribers = new Set<AgentRegistrySubscriber>();
+
+  constructor(initialAgents: AgentDefinition[] = INITIAL_AGENTS) {
+    this.builtinAgents = initialAgents.map(agent => cloneAgentDefinition(agent));
+  }
+
+  public getAgents(): AgentDefinition[] {
+    return this.buildSnapshot();
+  }
+
+  public subscribe(subscriber: AgentRegistrySubscriber): () => void {
+    this.subscribers.add(subscriber);
+    subscriber(this.buildSnapshot());
+    return () => {
+      this.subscribers.delete(subscriber);
+    };
+  }
+
+  public applyPluginManifests(entries: PluginRegistryEntry[]): void {
+    const activePluginIds = new Set(entries.map(entry => entry.pluginId));
+    let changed = false;
+
+    for (const pluginId of Array.from(this.pluginAgents.keys())) {
+      if (!activePluginIds.has(pluginId)) {
+        this.pluginAgents.delete(pluginId);
+        changed = true;
+      }
+    }
+
+    for (const entry of entries) {
+      const manifests = entry.manifests.map(manifest => cloneManifest(manifest));
+      const definitions = manifests.flatMap(manifest =>
+        AgentRegistryService.createAgentsFromManifest(entry.pluginId, manifest),
+      );
+      const previous = this.pluginAgents.get(entry.pluginId);
+      if (!previous || !AgentRegistryService.areAgentListsEqual(previous, definitions)) {
+        this.pluginAgents.set(entry.pluginId, definitions);
+        changed = true;
+      }
+    }
+
+    if (changed) {
+      this.notify();
+    }
+  }
+
+  public static computeManifestsChecksum(manifests: AgentManifest[]): string {
+    const normalized = manifests
+      .map(manifest => ({
+        provider: manifest.provider.trim(),
+        capabilities: [...manifest.capabilities].sort((a, b) => a.localeCompare(b)),
+        models: [...manifest.models]
+          .map(model => ({
+            ...model,
+            id: model.id.trim(),
+            name: model.name.trim(),
+            model: model.model.trim(),
+            description: model.description.trim(),
+            aliases: model.aliases ? [...model.aliases].sort((a, b) => a.localeCompare(b)) : undefined,
+          }))
+          .sort((a, b) => a.id.localeCompare(b.id)),
+      }))
+      .sort((a, b) => a.provider.localeCompare(b.provider));
+
+    const payload = AgentRegistryService.stableStringify(normalized);
+    let hash = 0;
+    for (let index = 0; index < payload.length; index += 1) {
+      hash = (hash * 31 + payload.charCodeAt(index)) >>> 0;
+    }
+    return hash.toString(16);
+  }
+
+  public static isCacheEntryValid(entry: AgentManifestCacheEntry): boolean {
+    if (!entry || typeof entry !== 'object') {
+      return false;
+    }
+
+    if (typeof entry.checksum !== 'string' || !entry.checksum.trim()) {
+      return false;
+    }
+
+    if (!Array.isArray(entry.manifests) || !entry.manifests.length) {
+      return false;
+    }
+
+    const checksum = AgentRegistryService.computeManifestsChecksum(entry.manifests);
+    return checksum === entry.checksum.trim();
+  }
+
+  private static createAgentsFromManifest(
+    pluginId: string,
+    manifest: AgentManifest,
+  ): AgentDefinition[] {
+    const baseCapabilities = cloneCapabilities(manifest.capabilities) ?? [];
+    return manifest.models.map(model => {
+      const active = Boolean(model.defaultActive);
+      return {
+        id: `${pluginId}-${model.id}`,
+        model: model.model,
+        name: model.name,
+        provider: manifest.provider,
+        description: model.description,
+        kind: model.kind,
+        accent: model.accent ?? DEFAULT_PLUGIN_ACCENT,
+        active,
+        status: active ? 'Disponible' : 'Inactivo',
+        aliases: cloneAliases(model.aliases),
+        channel: sanitizeChannel(model, manifest.provider),
+        pluginId,
+        capabilities: baseCapabilities,
+      } satisfies AgentDefinition;
+    });
+  }
+
+  private static areAgentListsEqual(a: AgentDefinition[], b: AgentDefinition[]): boolean {
+    if (a.length !== b.length) {
+      return false;
+    }
+
+    const signature = (list: AgentDefinition[]) =>
+      JSON.stringify(
+        [...list]
+          .map(agent => ({
+            id: agent.id,
+            model: agent.model,
+            name: agent.name,
+            provider: agent.provider,
+            description: agent.description,
+            kind: agent.kind,
+            accent: agent.accent,
+            active: agent.active,
+            status: agent.status,
+            aliases: agent.aliases ?? [],
+            channel: agent.channel ?? null,
+            pluginId: agent.pluginId ?? null,
+            capabilities: agent.capabilities ?? [],
+          }))
+          .sort((left, right) => left.id.localeCompare(right.id)),
+      );
+
+    return signature(a) === signature(b);
+  }
+
+  private notify() {
+    const snapshot = this.buildSnapshot();
+    this.subscribers.forEach(subscriber => subscriber(snapshot));
+  }
+
+  private buildSnapshot(): AgentDefinition[] {
+    const pluginAgents = Array.from(this.pluginAgents.values()).flat();
+    return [...this.builtinAgents, ...pluginAgents].map(agent => cloneAgentDefinition(agent));
+  }
+
+  private static stableStringify(value: unknown): string {
+    if (Array.isArray(value)) {
+      return `[${value.map(item => AgentRegistryService.stableStringify(item)).join(',')}]`;
+    }
+
+    if (value && typeof value === 'object') {
+      const entries = Object.entries(value as Record<string, unknown>)
+        .sort(([aKey], [bKey]) => aKey.localeCompare(bKey))
+        .map(([key, item]) => `${JSON.stringify(key)}:${AgentRegistryService.stableStringify(item)}`);
+      return `{${entries.join(',')}}`;
+    }
+
+    return JSON.stringify(value);
+  }
+}
+
+export const agentRegistryService = new AgentRegistryService();

--- a/src/core/agents/__tests__/AgentRegistryService.test.ts
+++ b/src/core/agents/__tests__/AgentRegistryService.test.ts
@@ -1,0 +1,87 @@
+import { describe, expect, it } from 'vitest';
+import type { AgentManifest } from '../../../types/agents';
+import { AgentRegistryService } from '../AgentRegistryService';
+import { syncAgentWithApiKeys } from '../agentRegistry';
+import { registerExternalProviders } from '../../../utils/globalSettings';
+
+const buildManifest = (overrides?: Partial<AgentManifest>): AgentManifest => ({
+  provider: 'AcmeAI',
+  capabilities: ['creative'],
+  models: [
+    {
+      id: 'acme-pro',
+      name: 'Acme Pro',
+      model: 'acme-pro-v1',
+      description: 'Agente de pruebas para validación de manifests.',
+      kind: 'cloud',
+      defaultActive: true,
+      aliases: ['acme'],
+      channel: 'acme',
+    },
+  ],
+  ...overrides,
+});
+
+describe('AgentRegistryService', () => {
+  it('combines builtin agents with plugin manifests', () => {
+    const service = new AgentRegistryService([]);
+    const manifest = buildManifest({
+      capabilities: ['vision', 'analysis'],
+      models: [
+        {
+          id: 'vision-pro',
+          name: 'Vision Pro',
+          model: 'vision-pro-1',
+          description: 'Modelo especializado en análisis visual.',
+          kind: 'cloud',
+          defaultActive: false,
+          accent: '#123456',
+          aliases: ['vision'],
+        },
+      ],
+    });
+
+    service.applyPluginManifests([{ pluginId: 'acme', manifests: [manifest] }]);
+
+    const agents = service.getAgents();
+    expect(agents).toHaveLength(1);
+    expect(agents[0]).toMatchObject({
+      id: 'acme-vision-pro',
+      name: 'Vision Pro',
+      provider: 'AcmeAI',
+      pluginId: 'acme',
+      capabilities: ['vision', 'analysis'],
+      active: false,
+      status: 'Inactivo',
+    });
+  });
+
+  it('synchronizes API keys for external providers loaded from manifests', () => {
+    const service = new AgentRegistryService([]);
+    const manifest = buildManifest({
+      provider: 'Replicate',
+      models: [
+        {
+          id: 'replicate-fast',
+          name: 'Replicate Fast',
+          model: 'replicate-fast-v1',
+          description: 'Modelo de inferencia rápida.',
+          kind: 'cloud',
+          defaultActive: true,
+        },
+      ],
+    });
+
+    service.applyPluginManifests([{ pluginId: 'replicate', manifests: [manifest] }]);
+
+    const [agent] = service.getAgents();
+    registerExternalProviders([agent.provider]);
+
+    const synced = syncAgentWithApiKeys(agent, { replicate: 'rk-test-key' });
+    expect(synced.apiKey).toBe('rk-test-key');
+    expect(synced.status).toBe('Disponible');
+
+    const withoutKey = syncAgentWithApiKeys({ ...agent, active: true }, { replicate: '' });
+    expect(withoutKey.status).toBe('Sin clave');
+  });
+});

--- a/src/core/agents/agentRegistry.ts
+++ b/src/core/agents/agentRegistry.ts
@@ -1,7 +1,9 @@
+import type { AgentManifest } from '../../types/agents';
 import { ApiKeySettings } from '../../types/globalSettings';
 import { isSupportedProvider } from '../../utils/globalSettings';
+import type { AgentKind } from '../../types/agents';
 
-export type AgentKind = 'cloud' | 'local';
+export type { AgentKind };
 
 export type AgentStatus = 'Disponible' | 'Sin clave' | 'Cargando' | 'Inactivo';
 
@@ -20,6 +22,8 @@ export interface AgentDefinition {
   objective?: string;
   aliases?: string[];
   channel?: string;
+  pluginId?: string;
+  capabilities?: AgentManifest['capabilities'];
 }
 
 export const INITIAL_AGENTS: AgentDefinition[] = [
@@ -130,5 +134,3 @@ export const syncAgentWithApiKeys = (
   };
 };
 
-export const initializeAgents = (apiKeys: ApiKeySettings): AgentDefinition[] =>
-  INITIAL_AGENTS.map(agent => syncAgentWithApiKeys({ ...agent }, apiKeys, true));

--- a/src/hooks/useProviderDiagnostics.ts
+++ b/src/hooks/useProviderDiagnostics.ts
@@ -1,10 +1,7 @@
 import { useCallback, useMemo } from 'react';
 import { callAnthropicChat, callGroqChat, callOpenAIChat } from '../utils/aiProviders';
-import {
-  getSupportedProviders,
-  isSupportedProvider,
-} from '../utils/globalSettings';
-import { SupportedProvider } from '../types/globalSettings';
+import { getSupportedProviders, isSupportedProvider } from '../utils/globalSettings';
+import { BuiltinProvider, SupportedProvider } from '../types/globalSettings';
 
 export interface ApiKeyValidationResult {
   valid: boolean;
@@ -18,13 +15,13 @@ export interface ProviderTestResult {
   message?: string;
 }
 
-const PROVIDER_PATTERNS: Partial<Record<SupportedProvider, RegExp>> = {
+const PROVIDER_PATTERNS: Partial<Record<BuiltinProvider, RegExp>> = {
   openai: /^sk-[a-zA-Z0-9]{20,}$/,
   anthropic: /^sk-ant-[a-zA-Z0-9]{20,}$/,
   groq: /^gsk_[a-zA-Z0-9]{20,}$/,
 };
 
-const PROVIDER_TEST_MODELS: Record<SupportedProvider, string> = {
+const PROVIDER_TEST_MODELS: Record<BuiltinProvider, string> = {
   openai: 'gpt-4o-mini',
   anthropic: 'claude-3-haiku-20240307',
   groq: 'mixtral-8x7b-32768',
@@ -35,7 +32,7 @@ const TEST_PROMPT = 'Responde únicamente con "OK".';
 const getTimestamp = () => (typeof performance !== 'undefined' ? performance.now() : Date.now());
 
 export const useProviderDiagnostics = () => {
-  const supportedProviders = useMemo(() => getSupportedProviders(), []);
+  const supportedProviders = getSupportedProviders();
 
   const validateApiKey = useCallback(
     (provider: string, rawKey: string): ApiKeyValidationResult => {

--- a/src/types/agents.ts
+++ b/src/types/agents.ts
@@ -1,0 +1,27 @@
+export type AgentKind = 'cloud' | 'local';
+
+export interface AgentManifestModel {
+  id: string;
+  name: string;
+  model: string;
+  description: string;
+  kind: AgentKind;
+  accent?: string;
+  channel?: string;
+  aliases?: string[];
+  defaultActive?: boolean;
+}
+
+export interface AgentManifest {
+  provider: string;
+  models: AgentManifestModel[];
+  capabilities: string[];
+}
+
+export interface AgentManifestCacheEntry {
+  checksum: string;
+  manifests: AgentManifest[];
+  approvedAt: string;
+}
+
+export type AgentManifestCache = Record<string, AgentManifestCacheEntry>;

--- a/src/types/globalSettings.ts
+++ b/src/types/globalSettings.ts
@@ -1,6 +1,10 @@
-export type SupportedProvider = 'openai' | 'anthropic' | 'groq' | 'github' | 'gitlab';
+import type { AgentManifestCache } from './agents';
 
-export const BUILTIN_PROVIDERS: SupportedProvider[] = ['openai', 'anthropic', 'groq', 'github', 'gitlab'];
+export type BuiltinProvider = 'openai' | 'anthropic' | 'groq' | 'github' | 'gitlab';
+
+export type SupportedProvider = BuiltinProvider | (string & {});
+
+export const BUILTIN_PROVIDERS: BuiltinProvider[] = ['openai', 'anthropic', 'groq', 'github', 'gitlab'];
 
 export type ApiKeySettings = Record<string, string>;
 
@@ -32,4 +36,6 @@ export interface GlobalSettings {
   apiKeys: ApiKeySettings;
   commandPresets: CommandPreset[];
   defaultRoutingRules: DefaultRoutingRules;
+  enabledPlugins: string[];
+  approvedManifests: AgentManifestCache;
 }


### PR DESCRIPTION
## Summary
- add an AgentRegistryService that merges built-in agents with plugin manifests and exposes checksum helpers
- update AgentContext to subscribe to the dynamic registry, load approved plugin manifests, and register external providers
- extend the global settings schema with plugin enablement, manifest cache support, and cover the new behavior with tests

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68cea23854b08333a24ded5cd736223f