### PR TITLE
Add plugin framework integration

### DIFF
--- a/docs/plugins.md
+++ b/docs/plugins.md
@@ -1,0 +1,103 @@
+# Plugins de JungleMonkAI
+
+Los plugins permiten extender JungleMonkAI con nuevos paneles de interfaz, acciones sobre mensajes,
+proveedores de agentes y conexiones MCP. Esta guía describe el formato de los manifiestos, el
+esquema de archivos esperado y los puntos de integración disponibles tanto en el frontend como en
+la capa Tauri.
+
+## Estructura de directorios
+
+Los plugins se cargan desde `~/.config/JungleMonkAI/plugins` (en modo producción) o desde el
+subdirectorio `plugins/` creado junto a `config.json` cuando se ejecuta la aplicación en modo
+local. Cada plugin ocupa una carpeta con su identificador y debe incluir como mínimo un
+`manifest.json`:
+
+```
+plugins/
+  acme-labs/
+    manifest.json
+    panels/
+      metricsPanel.tsx
+    actions/
+      shareSnippet.ts
+```
+
+Los recursos front-end (componentes React, utilidades, etc.) se compilan dentro del propio bundle
+utilizando `import.meta.glob`. Basta con colocar los módulos dentro de `src/plugins/<pluginId>/` y
+asegurarse de que `module` en el manifiesto apunta al archivo correcto.
+
+## Manifiesto (`manifest.json`)
+
+Cada plugin se describe mediante un JSON que sigue este esquema simplificado:
+
+```jsonc
+{
+  "id": "acme-labs",
+  "name": "Acme Labs Toolkit",
+  "version": "1.2.0",
+  "description": "Widgets y acciones para el laboratorio.",
+  "integrity": { "algorithm": "sha256", "hash": "…" },
+  "compatibility": { "minVersion": "0.1.0" },
+  "credentials": [
+    {
+      "id": "apiKey",
+      "label": "Token privado",
+      "description": "Claves de servicio de Acme",
+      "secret": true
+    }
+  ],
+  "commands": [
+    {
+      "name": "share-snippet",
+      "description": "Envía un bloque de código al panel remoto.",
+      "signature": "c0ffee…"
+    }
+  ],
+  "capabilities": [
+    { "type": "chat-action", "id": "share", "label": "Compartir con Acme", "command": "share-snippet" },
+    { "type": "workspace-panel", "id": "metrics", "label": "Métricas", "slot": "side-panel", "module": "panels/metricsPanel" }
+  ]
+}
+```
+
+### Campos principales
+
+- **`id`**, **`name`** y **`version`** identifican el plugin.
+- **`description`**, `author`, `homepage` y `license` son opcionales.
+- **`integrity`**: si se declara, el `hash` debe coincidir con la firma SHA-256 del manifiesto
+  completo. La aplicación recalcula automáticamente la suma en frontend y backend; cualquier
+  discrepancia obliga a revalidar el plugin.
+- **`compatibility`**: `minVersion` y `maxVersion` se comparan con `CARGO_PKG_VERSION` en Tauri y con
+  `VITE_APP_VERSION` en el frontend. Versiones fuera de rango impiden la carga.
+- **`credentials`**: describe campos adicionales que aparecerán en los ajustes globales. Los valores
+  se almacenan en `pluginSettings` dentro de la configuración local.
+- **`commands`**: cada comando declarable debe incluir un `signature`. La capa Tauri valida que el
+  comando exista antes de aceptar una invocación (`plugin_invoke`).
+- **`capabilities`**: array de objetos que anuncia lo que el plugin expone:
+  - `agent-provider`: adjunta manifiestos de agentes (`agentManifests`).
+  - `chat-action`: añade botones a `MessageActions` que delegan en un comando del plugin.
+  - `workspace-panel`: registra un componente React adicional para `SidePanel` o la zona principal.
+  - `mcp-endpoint`: documenta endpoints compatibles con el protocolo MCP.
+
+## Flujo de carga
+
+1. **Tauri (`PluginManager`)** escanea el directorio `plugins/`, valida firmas, versiones y expone los
+   manifiestos a través del comando `plugin_list`.
+2. **`PluginHostProvider`** consume esa lista, sincroniza las aprobaciones almacenadas en
+   `GlobalSettings`, actualiza `enabledPlugins` y genera contribuciones de UI.
+3. **SidePanel** y **MessageActions** consultan el contexto para inyectar paneles adicionales y
+   botones de acción. Las credenciales configuradas por el usuario quedan disponibles para los
+   propios plugins mediante el almacenamiento de `pluginSettings`.
+
+## Pruebas
+
+El proyecto incluye pruebas de contrato (`vitest`) que cargan un manifiesto ficticio y verifican que
+las capacidades se propaguen al UI host. Puedes añadir nuevos casos en `src/core/plugins/__tests__`.
+
+Para comprobar la integridad de un manifiesto puedes ejecutar:
+
+```bash
+node -e "const fs=require('fs');const crypto=require('crypto');const raw=fs.readFileSync('manifest.json');const hash=crypto.createHash('sha256').update(raw).digest('hex');console.log(hash);"
+```
+
+Incluye el hash resultante en `integrity.hash`.

--- a/src-tauri/src/plugins/mod.rs
+++ b/src-tauri/src/plugins/mod.rs
@@ -1,0 +1,370 @@
+use anyhow::{Context, Result};
+use serde::{Deserialize, Serialize};
+use serde_json::Value;
+use sha2::{Digest, Sha256};
+use std::collections::HashMap;
+use std::fs;
+use std::path::{Path, PathBuf};
+use std::sync::RwLock;
+
+#[derive(Debug, Clone, Deserialize, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct AgentManifestModel {
+    pub id: String,
+    pub name: String,
+    pub model: String,
+    pub description: String,
+    pub kind: String,
+    #[serde(default)]
+    pub accent: Option<String>,
+    #[serde(default)]
+    pub channel: Option<String>,
+    #[serde(default)]
+    pub aliases: Option<Vec<String>>,
+    #[serde(default)]
+    pub default_active: Option<bool>,
+}
+
+#[derive(Debug, Clone, Deserialize, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct AgentManifest {
+    pub provider: String,
+    pub models: Vec<AgentManifestModel>,
+    pub capabilities: Vec<String>,
+}
+
+#[derive(Debug, Clone, Deserialize, Serialize)]
+#[serde(tag = "type", rename_all = "kebab-case")]
+pub enum PluginCapability {
+    #[serde(rename_all = "camelCase")]
+    AgentProvider {
+        #[serde(default)]
+        agent_manifests: Vec<AgentManifest>,
+    },
+    #[serde(rename_all = "camelCase")]
+    ChatAction {
+        id: String,
+        label: String,
+        #[serde(default)]
+        description: Option<String>,
+        command: String,
+        #[serde(default)]
+        icon: Option<String>,
+    },
+    #[serde(rename_all = "camelCase")]
+    WorkspacePanel {
+        id: String,
+        label: String,
+        slot: String,
+        module: String,
+        #[serde(rename = "export", default)]
+        export_name: Option<String>,
+    },
+    #[serde(rename_all = "camelCase")]
+    McpEndpoint {
+        id: String,
+        transport: String,
+        url: String,
+    },
+}
+
+#[derive(Debug, Clone, Deserialize, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct PluginCredentialField {
+    pub id: String,
+    pub label: String,
+    #[serde(default)]
+    pub description: Option<String>,
+    #[serde(default)]
+    pub secret: Option<bool>,
+    #[serde(default)]
+    pub required: Option<bool>,
+}
+
+#[derive(Debug, Clone, Deserialize, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct PluginCommandDescriptor {
+    pub name: String,
+    #[serde(default)]
+    pub description: Option<String>,
+    pub signature: String,
+}
+
+#[derive(Debug, Clone, Deserialize, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct PluginIntegrity {
+    pub algorithm: String,
+    pub hash: String,
+}
+
+#[derive(Debug, Clone, Deserialize, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct PluginCompatibility {
+    #[serde(default)]
+    pub min_version: Option<String>,
+    #[serde(default)]
+    pub max_version: Option<String>,
+}
+
+#[derive(Debug, Clone, Deserialize, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct PluginManifest {
+    pub id: String,
+    pub name: String,
+    pub version: String,
+    #[serde(default)]
+    pub description: Option<String>,
+    #[serde(default)]
+    pub author: Option<String>,
+    #[serde(default)]
+    pub homepage: Option<String>,
+    #[serde(default)]
+    pub license: Option<String>,
+    pub capabilities: Vec<PluginCapability>,
+    #[serde(default)]
+    pub credentials: Vec<PluginCredentialField>,
+    #[serde(default)]
+    pub commands: Vec<PluginCommandDescriptor>,
+    #[serde(default)]
+    pub integrity: Option<PluginIntegrity>,
+    #[serde(default)]
+    pub compatibility: Option<PluginCompatibility>,
+}
+
+#[derive(Debug, Clone, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct PluginRuntimeDescriptor {
+    pub plugin_id: String,
+    pub manifest: PluginManifest,
+    pub checksum: String,
+}
+
+pub struct PluginManager {
+    base_dir: PathBuf,
+    plugins: RwLock<HashMap<String, PluginRuntimeDescriptor>>,
+    app_version: String,
+}
+
+impl PluginManager {
+    pub fn new(base_dir: PathBuf) -> Result<Self> {
+        if !base_dir.exists() {
+            fs::create_dir_all(&base_dir).context("no se pudo crear el directorio de plugins")?;
+        }
+
+        Ok(Self {
+            base_dir,
+            plugins: RwLock::new(HashMap::new()),
+            app_version: env!("CARGO_PKG_VERSION").to_string(),
+        })
+    }
+
+    pub fn refresh(&self) -> Result<Vec<PluginRuntimeDescriptor>> {
+        let mut registry = HashMap::new();
+
+        if self.base_dir.exists() {
+            for entry in fs::read_dir(&self.base_dir)? {
+                let entry = entry?;
+                let path = entry.path();
+                if !path.is_dir() {
+                    continue;
+                }
+                match self.load_plugin(&path) {
+                    Ok(descriptor) => {
+                        registry.insert(descriptor.plugin_id.clone(), descriptor);
+                    }
+                    Err(error) => {
+                        println!(
+                            "[plugin-manager] no se pudo cargar el plugin en {:?}: {:?}",
+                            path, error
+                        );
+                    }
+                }
+            }
+        }
+
+        let descriptors: Vec<PluginRuntimeDescriptor> = registry.values().cloned().collect();
+        let mut guard = self.plugins.write().unwrap();
+        *guard = registry;
+        Ok(descriptors)
+    }
+
+    pub fn list(&self) -> Vec<PluginRuntimeDescriptor> {
+        let guard = self.plugins.read().unwrap();
+        guard.values().cloned().collect()
+    }
+
+    pub fn invoke_command(&self, plugin_id: &str, command: &str, _payload: Value) -> Result<Value> {
+        let guard = self.plugins.read().unwrap();
+        let plugin = guard
+            .get(plugin_id)
+            .with_context(|| format!("plugin «{}» no está registrado", plugin_id))?;
+
+        let exists = plugin
+            .manifest
+            .commands
+            .iter()
+            .any(|descriptor| descriptor.name == command);
+
+        if !exists {
+            anyhow::bail!(
+                "el comando {} no está disponible en el plugin {}",
+                command,
+                plugin_id
+            );
+        }
+
+        Ok(serde_json::json!({
+            "status": "queued",
+            "plugin": plugin_id,
+            "command": command,
+        }))
+    }
+
+    fn load_plugin(&self, dir: &Path) -> Result<PluginRuntimeDescriptor> {
+        let manifest_path = dir.join("manifest.json");
+        if !manifest_path.exists() {
+            anyhow::bail!("manifest.json no encontrado en {:?}", dir);
+        }
+
+        let raw = fs::read_to_string(&manifest_path)
+            .with_context(|| format!("no se pudo leer {:?}", manifest_path))?;
+        let value: Value = serde_json::from_str(&raw)
+            .with_context(|| format!("no se pudo parsear el manifiesto {:?}", manifest_path))?;
+        let checksum = compute_checksum(&value);
+        let manifest: PluginManifest = serde_json::from_value(value.clone())?;
+
+        if let Some(integrity) = &manifest.integrity {
+            if integrity.algorithm.to_lowercase() == "sha256" && integrity.hash != checksum {
+                anyhow::bail!(
+                    "el hash del manifiesto de {} no coincide con la integridad declarada",
+                    manifest.id
+                );
+            }
+        }
+
+        self.validate_compatibility(&manifest)?;
+
+        Ok(PluginRuntimeDescriptor {
+            plugin_id: manifest.id.clone(),
+            manifest,
+            checksum,
+        })
+    }
+
+    fn validate_compatibility(&self, manifest: &PluginManifest) -> Result<()> {
+        if let Some(compat) = &manifest.compatibility {
+            if let Some(min_version) = &compat.min_version {
+                if compare_versions(&self.app_version, min_version) == std::cmp::Ordering::Less {
+                    anyhow::bail!(
+                        "el plugin {} requiere la versión {} o superior",
+                        manifest.name,
+                        min_version
+                    );
+                }
+            }
+            if let Some(max_version) = &compat.max_version {
+                if compare_versions(&self.app_version, max_version) == std::cmp::Ordering::Greater {
+                    anyhow::bail!(
+                        "el plugin {} no es compatible con la versión actual",
+                        manifest.name
+                    );
+                }
+            }
+        }
+        Ok(())
+    }
+}
+
+fn compute_checksum(value: &Value) -> String {
+    let sanitized = sanitize_value(value);
+    let canonical = canonical_string(&sanitized);
+    let mut hasher = Sha256::new();
+    hasher.update(canonical.as_bytes());
+    format!("{:x}", hasher.finalize())
+}
+
+fn sanitize_value(value: &Value) -> Value {
+    match value {
+        Value::Object(map) => {
+            let mut sanitized = serde_json::Map::new();
+            for (key, val) in map {
+                if key == "integrity" {
+                    continue;
+                }
+                sanitized.insert(key.clone(), sanitize_value(val));
+            }
+            Value::Object(sanitized)
+        }
+        Value::Array(array) => Value::Array(array.iter().map(sanitize_value).collect()),
+        _ => value.clone(),
+    }
+}
+
+fn canonical_string(value: &Value) -> String {
+    match value {
+        Value::Null => "null".to_string(),
+        Value::Bool(flag) => flag.to_string(),
+        Value::Number(number) => number.to_string(),
+        Value::String(text) => serde_json::to_string(text).unwrap_or_else(|_| "\"\"".to_string()),
+        Value::Array(array) => {
+            let items: Vec<String> = array.iter().map(canonical_string).collect();
+            format!("[{}]", items.join(","))
+        }
+        Value::Object(map) => {
+            let mut entries: Vec<(&String, &Value)> = map.iter().collect();
+            entries.sort_by(|a, b| a.0.cmp(b.0));
+            let serialized: Vec<String> = entries
+                .into_iter()
+                .map(|(key, value)| {
+                    format!(
+                        "{}:{}",
+                        serde_json::to_string(key).unwrap(),
+                        canonical_string(value)
+                    )
+                })
+                .collect();
+            format!("{{{}}}", serialized.join(","))
+        }
+    }
+}
+
+fn compare_versions(a: &str, b: &str) -> std::cmp::Ordering {
+    let mut a_parts = a.split('.').map(|part| part.parse::<u32>().unwrap_or(0));
+    let mut b_parts = b.split('.').map(|part| part.parse::<u32>().unwrap_or(0));
+
+    loop {
+        match (a_parts.next(), b_parts.next()) {
+            (Some(av), Some(bv)) => {
+                if av > bv {
+                    return std::cmp::Ordering::Greater;
+                }
+                if av < bv {
+                    return std::cmp::Ordering::Less;
+                }
+            }
+            (Some(_), None) => return std::cmp::Ordering::Greater,
+            (None, Some(_)) => return std::cmp::Ordering::Less,
+            (None, None) => return std::cmp::Ordering::Equal,
+        }
+    }
+}
+
+#[tauri::command]
+pub async fn plugin_list(
+    manager: tauri::State<'_, PluginManager>,
+) -> Result<Vec<PluginRuntimeDescriptor>, String> {
+    manager.refresh().map_err(|error| error.to_string())?;
+    Ok(manager.list())
+}
+
+#[tauri::command]
+pub async fn plugin_invoke(
+    manager: tauri::State<'_, PluginManager>,
+    plugin_id: String,
+    command: String,
+    payload: Value,
+) -> Result<Value, String> {
+    manager
+        .invoke_command(&plugin_id, &command, payload)
+        .map_err(|error| error.to_string())
+}

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -14,6 +14,7 @@ import { RepoWorkflowProvider } from './core/codex';
 import { ApiKeySettings, GlobalSettings } from './types/globalSettings';
 import { DEFAULT_GLOBAL_SETTINGS, loadGlobalSettings, saveGlobalSettings } from './utils/globalSettings';
 import { ChatActorFilter } from './types/chat';
+import { PluginHostProvider } from './core/plugins/PluginHostProvider';
 
 interface AppContentProps {
   apiKeys: ApiKeySettings;
@@ -117,17 +118,19 @@ const App: React.FC = () => {
   };
 
   return (
-    <AgentProvider
-      apiKeys={globalSettings.apiKeys}
-      enabledPlugins={globalSettings.enabledPlugins}
-      approvedManifests={globalSettings.approvedManifests}
-    >
-      <MessageProvider apiKeys={globalSettings.apiKeys}>
-        <RepoWorkflowProvider>
-          <AppContent apiKeys={globalSettings.apiKeys} onApiKeyChange={handleApiKeyChange} />
-        </RepoWorkflowProvider>
-      </MessageProvider>
-    </AgentProvider>
+    <PluginHostProvider settings={globalSettings} onSettingsChange={setGlobalSettings}>
+      <AgentProvider
+        apiKeys={globalSettings.apiKeys}
+        enabledPlugins={globalSettings.enabledPlugins}
+        approvedManifests={globalSettings.approvedManifests}
+      >
+        <MessageProvider apiKeys={globalSettings.apiKeys}>
+          <RepoWorkflowProvider>
+            <AppContent apiKeys={globalSettings.apiKeys} onApiKeyChange={handleApiKeyChange} />
+          </RepoWorkflowProvider>
+        </MessageProvider>
+      </AgentProvider>
+    </PluginHostProvider>
   );
 };
 

--- a/src/components/chat/SidePanel.tsx
+++ b/src/components/chat/SidePanel.tsx
@@ -14,6 +14,7 @@ import {
   getAgentDisplayName,
   getAgentVersionLabel,
 } from '../../utils/agentDisplay';
+import { usePluginHost } from '../../core/plugins/PluginHostProvider';
 
 interface SidePanelProps {
   apiKeys: ApiKeySettings;
@@ -64,6 +65,7 @@ export const SidePanel: React.FC<SidePanelProps> = ({
   const [gitlabStored, setGitlabStored] = useState(false);
 
   const { agents, agentMap, toggleAgent, assignAgentRole } = useAgents();
+  const { sidePanels: pluginPanels } = usePluginHost();
   const {
     quickCommands,
     appendToDraft,
@@ -417,6 +419,16 @@ export const SidePanel: React.FC<SidePanelProps> = ({
         <section className="panel-section">
           <ModelGallery />
         </section>
+
+        {pluginPanels.map(panel => (
+          <section key={`${panel.pluginId}-${panel.id}`} className="panel-section">
+            <header className="panel-section-header">
+              <h2>{panel.label}</h2>
+              <p>Integración proporcionada por el plugin {panel.pluginId}.</p>
+            </header>
+            <panel.Component />
+          </section>
+        ))}
 
         <section className="panel-section">
           <header className="panel-section-header">

--- a/src/components/chat/messages/__tests__/MessageContent.test.tsx
+++ b/src/components/chat/messages/__tests__/MessageContent.test.tsx
@@ -5,23 +5,33 @@ import { MessageContent } from '../MessageContent';
 import { AgentProvider } from '../../../../core/agents/AgentContext';
 import { MessageProvider } from '../../../../core/messages/MessageContext';
 import { RepoWorkflowProvider } from '../../../../core/codex';
+import { PluginHostProvider } from '../../../../core/plugins/PluginHostProvider';
+import { DEFAULT_GLOBAL_SETTINGS } from '../../../../utils/globalSettings';
 
 const noop = vi.fn();
 
-const withProviders = (node: React.ReactNode) => (
-  <AgentProvider apiKeys={{}}>
-    <MessageProvider apiKeys={{}}>
-      <RepoWorkflowProvider>{node}</RepoWorkflowProvider>
-    </MessageProvider>
-  </AgentProvider>
-);
+const ProviderHarness: React.FC<{ children: React.ReactNode }> = ({ children }) => {
+  const [settings, setSettings] = React.useState(() => ({
+    ...JSON.parse(JSON.stringify(DEFAULT_GLOBAL_SETTINGS)),
+  }));
+
+  return (
+    <AgentProvider apiKeys={{}}>
+      <PluginHostProvider settings={settings} onSettingsChange={setSettings}>
+        <MessageProvider apiKeys={{}}>
+          <RepoWorkflowProvider>{children}</RepoWorkflowProvider>
+        </MessageProvider>
+      </PluginHostProvider>
+    </AgentProvider>
+  );
+};
 
 describe('MessageContent', () => {
   it('renders plain text segments', () => {
     const { container } = render(
-      withProviders(
-        <MessageContent messageId="message-1" content="Hola mundo" onAppendToComposer={noop} />,
-      ),
+      <ProviderHarness>
+        <MessageContent messageId="message-1" content="Hola mundo" onAppendToComposer={noop} />
+      </ProviderHarness>,
     );
     expect(container).toMatchSnapshot();
   });
@@ -29,9 +39,9 @@ describe('MessageContent', () => {
   it('renders fenced code blocks with actions', () => {
     const codeMessage = `Respuesta:\n\n\`\`\`ts\nconst saludo: string = 'hola';\nconsole.log(saludo);\n\`\`\`\n\nFin.`;
     const { container } = render(
-      withProviders(
-        <MessageContent messageId="message-2" content={codeMessage} onAppendToComposer={noop} />,
-      ),
+      <ProviderHarness>
+        <MessageContent messageId="message-2" content={codeMessage} onAppendToComposer={noop} />
+      </ProviderHarness>,
     );
     expect(container).toMatchSnapshot();
   });

--- a/src/components/repo/__tests__/RepoWorkflow.integration.test.tsx
+++ b/src/components/repo/__tests__/RepoWorkflow.integration.test.tsx
@@ -6,6 +6,8 @@ import { RepoWorkflowProvider } from '../../../core/codex';
 import { MessageActions } from '../../chat/messages/MessageActions';
 import { RepoStudio } from '../RepoStudio';
 import type { ChatMessage } from '../../../core/messages/messageTypes';
+import { PluginHostProvider } from '../../../core/plugins/PluginHostProvider';
+import { DEFAULT_GLOBAL_SETTINGS } from '../../../utils/globalSettings';
 
 const invokeMock = vi.hoisted(() => vi.fn());
 
@@ -52,13 +54,26 @@ describe('Repo workflow integration', () => {
   });
 
   it('propagates message content to Repo Studio and triggers auto-PR workflow', async () => {
+    const PluginWrapper: React.FC<{ children: React.ReactNode }> = ({ children }) => {
+      const [settings, setSettings] = React.useState(() => ({
+        ...JSON.parse(JSON.stringify(DEFAULT_GLOBAL_SETTINGS)),
+      }));
+      return (
+        <PluginHostProvider settings={settings} onSettingsChange={setSettings}>
+          {children}
+        </PluginHostProvider>
+      );
+    };
+
     const { container } = render(
       <AgentProvider apiKeys={{}}>
         <RepoWorkflowProvider>
-          <div>
-            <MessageActions messageId="message-123" value={canonicalSnippet} />
-            <RepoStudio />
-          </div>
+          <PluginWrapper>
+            <div>
+              <MessageActions messageId="message-123" value={canonicalSnippet} />
+              <RepoStudio />
+            </div>
+          </PluginWrapper>
         </RepoWorkflowProvider>
       </AgentProvider>,
     );

--- a/src/components/settings/GlobalSettingsPanel.css
+++ b/src/components/settings/GlobalSettingsPanel.css
@@ -138,6 +138,28 @@
   margin-bottom: 18px;
 }
 
+.setting-meta {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 12px;
+  font-size: 12px;
+  color: rgba(255, 255, 255, 0.65);
+}
+
+.setting-code {
+  font-family: 'JetBrains Mono', monospace;
+  background: rgba(255, 255, 255, 0.1);
+  padding: 2px 6px;
+  border-radius: 6px;
+}
+
+.setting-list {
+  margin: 0;
+  padding-left: 18px;
+  color: rgba(255, 255, 255, 0.85);
+  font-size: 12px;
+}
+
 .settings-footer {
   padding: 14px 16px;
   border-top: 1px solid rgba(255, 255, 255, 0.1);

--- a/src/core/plugins/PluginHostProvider.tsx
+++ b/src/core/plugins/PluginHostProvider.tsx
@@ -1,0 +1,434 @@
+import React, { createContext, useCallback, useContext, useEffect, useMemo, useState } from 'react';
+import type { GlobalSettings, PluginSettingsEntry } from '../../types/globalSettings';
+import type {
+  LoadedPluginManifest,
+  PluginCapability,
+  PluginManifest,
+  PluginCommandDescriptor,
+} from './index';
+import { loadPluginManifest } from './index';
+
+interface PluginManagerEntry extends LoadedPluginManifest {}
+
+interface PluginHostTransport {
+  listPlugins: () => Promise<PluginManagerEntry[]>;
+  invokeCommand: (pluginId: string, command: string, payload: unknown) => Promise<unknown>;
+}
+
+interface PluginMessageActionContext {
+  pluginId: string;
+  id: string;
+  label: string;
+  description?: string;
+  icon?: string;
+  signature: string;
+  command: string;
+  run: (input: { messageId: string; value: string }) => Promise<void>;
+}
+
+interface PluginSidePanelContribution {
+  pluginId: string;
+  id: string;
+  label: string;
+  Component: React.ComponentType;
+}
+
+interface RuntimePluginEntry {
+  pluginId: string;
+  manifest: PluginManifest;
+  checksum: string;
+  commands: PluginCommandDescriptor[];
+}
+
+interface PluginHostContextValue {
+  plugins: RuntimePluginEntry[];
+  messageActions: PluginMessageActionContext[];
+  sidePanels: PluginSidePanelContribution[];
+  updatePluginSettings: (
+    pluginId: string,
+    updater: (entry: PluginSettingsEntry | undefined) => PluginSettingsEntry,
+  ) => void;
+  refresh: () => void;
+}
+
+const PluginHostContext = createContext<PluginHostContextValue | undefined>(undefined);
+
+const DEFAULT_TRANSPORT: PluginHostTransport = {
+  listPlugins: async () => {
+    if (typeof window !== 'undefined') {
+      try {
+        const { invoke } = await import('@tauri-apps/api/tauri');
+        const response = await invoke<PluginManagerEntry[]>('plugin_list');
+        return response;
+      } catch (error) {
+        console.warn('No se pudo consultar el listado de plugins', error);
+      }
+    }
+    return [];
+  },
+  invokeCommand: async (pluginId, command, payload) => {
+    if (typeof window !== 'undefined') {
+      try {
+        const { invoke } = await import('@tauri-apps/api/tauri');
+        await invoke('plugin_invoke', { pluginId, command, payload });
+        return;
+      } catch (error) {
+        console.warn(`No se pudo invocar el comando ${command} del plugin ${pluginId}`, error);
+        throw error;
+      }
+    }
+    throw new Error('Plugin command transport is not disponible');
+  },
+};
+
+const MODULE_EXTENSIONS = ['tsx', 'ts', 'jsx', 'js'];
+
+const normalizeModulePath = (value: string): string => {
+  const trimmed = value.replace(/^\.\/+/, '');
+  return trimmed.replace(/\.(tsx|ts|jsx|js)$/i, '');
+};
+
+const buildLoaderIndex = (
+  loaders: Record<string, () => Promise<{ default: React.ComponentType }>>,
+) => {
+  const index = new Map<string, Map<string, () => Promise<{ default: React.ComponentType }>>>();
+  Object.entries(loaders).forEach(([path, loader]) => {
+    const normalized = path.replace(/\\/g, '/');
+    const match = normalized.match(/plugins\/(.+?)\/(.+)$/);
+    if (!match) {
+      return;
+    }
+    const [, pluginId, modulePath] = match;
+    const withoutExtension = modulePath.replace(/\.(tsx|ts|jsx|js)$/i, '');
+    if (!index.has(pluginId)) {
+      index.set(pluginId, new Map());
+    }
+    const pluginMap = index.get(pluginId)!;
+    pluginMap.set(withoutExtension, loader);
+    pluginMap.set(modulePath, loader);
+  });
+  return index;
+};
+
+const moduleLoaders = buildLoaderIndex(
+  import.meta.glob<{ default: React.ComponentType }>(
+    '../../plugins/**/*.{ts,tsx,js,jsx}',
+  ),
+);
+
+const resolvePanelComponent = async (
+  pluginId: string,
+  capability: Extract<PluginCapability, { type: 'workspace-panel' }>,
+): Promise<React.ComponentType | null> => {
+  if (capability.slot !== 'side-panel') {
+    return null;
+  }
+
+  const loaderGroup = moduleLoaders.get(pluginId);
+  if (!loaderGroup) {
+    return null;
+  }
+  const normalized = normalizeModulePath(capability.module);
+  const loader =
+    loaderGroup.get(normalized) ??
+    MODULE_EXTENSIONS.map(ext => `${normalized}.${ext}`)
+      .map(candidate => loaderGroup.get(candidate))
+      .find((candidate): candidate is (() => Promise<{ default: React.ComponentType }>) => !!candidate);
+
+  if (!loader) {
+    return null;
+  }
+
+  const module = await loader();
+  return module.default ?? null;
+};
+
+const getAppVersion = (): string => {
+  if (typeof import.meta !== 'undefined' && import.meta.env && import.meta.env.VITE_APP_VERSION) {
+    return String(import.meta.env.VITE_APP_VERSION);
+  }
+  if (typeof window !== 'undefined') {
+    return (window as unknown as { __APP_VERSION__?: string }).__APP_VERSION__ ?? '0.0.0';
+  }
+  return '0.0.0';
+};
+
+interface PluginHostProviderProps {
+  settings: GlobalSettings;
+  onSettingsChange: (updater: (prev: GlobalSettings) => GlobalSettings) => void;
+  children: React.ReactNode;
+  transport?: PluginHostTransport;
+  appVersion?: string;
+}
+
+export const PluginHostProvider: React.FC<PluginHostProviderProps> = ({
+  settings,
+  onSettingsChange,
+  children,
+  transport = DEFAULT_TRANSPORT,
+  appVersion = getAppVersion(),
+}) => {
+  const [runtimePlugins, setRuntimePlugins] = useState<RuntimePluginEntry[]>([]);
+  const [messageActions, setMessageActions] = useState<PluginMessageActionContext[]>([]);
+  const [sidePanels, setSidePanels] = useState<PluginSidePanelContribution[]>([]);
+  const [revision, setRevision] = useState(0);
+
+  const refresh = useCallback(() => {
+    setRevision(prev => prev + 1);
+  }, []);
+
+  useEffect(() => {
+    let cancelled = false;
+
+    const loadPlugins = async () => {
+      try {
+        const response = await transport.listPlugins();
+        const pluginList = Array.isArray(response) ? response : [];
+        const entries: RuntimePluginEntry[] = [];
+        for (const entry of pluginList) {
+          try {
+            const loaded = await loadPluginManifest({
+              source: entry,
+              currentVersion: appVersion,
+              expectedChecksum: entry.checksum,
+            });
+            entries.push({
+              pluginId: loaded.manifest.id,
+              manifest: loaded.manifest,
+              checksum: loaded.checksum,
+              commands: loaded.manifest.commands ?? [],
+            });
+          } catch (error) {
+            console.warn('No se pudo validar el manifiesto del plugin', error);
+          }
+        }
+        if (!cancelled) {
+          setRuntimePlugins(entries);
+        }
+      } catch (error) {
+        console.warn('No se pudo cargar el manifiesto de plugins', error);
+        if (!cancelled) {
+          setRuntimePlugins([]);
+        }
+      }
+    };
+
+    void loadPlugins();
+
+    return () => {
+      cancelled = true;
+    };
+  }, [appVersion, transport, revision]);
+
+  useEffect(() => {
+    onSettingsChange(prev => {
+      let changed = false;
+      const pluginSettings: GlobalSettings['pluginSettings'] = Object.entries(prev.pluginSettings).reduce(
+        (acc, [pluginId, entry]) => {
+          acc[pluginId] = {
+            enabled: entry.enabled,
+            credentials: { ...entry.credentials },
+            lastApprovedChecksum: entry.lastApprovedChecksum,
+          };
+          return acc;
+        },
+        {} as GlobalSettings['pluginSettings'],
+      );
+      const approvedManifests = { ...prev.approvedManifests };
+      const enabledSet = new Set(prev.enabledPlugins);
+
+      runtimePlugins.forEach(plugin => {
+        if (!pluginSettings[plugin.pluginId]) {
+          pluginSettings[plugin.pluginId] = { enabled: false, credentials: {} };
+          changed = true;
+        }
+
+        const entry = pluginSettings[plugin.pluginId];
+        if (entry.enabled) {
+          enabledSet.add(plugin.pluginId);
+        } else {
+          enabledSet.delete(plugin.pluginId);
+        }
+
+        const agentProvider = plugin.manifest.capabilities.find(
+          capability => capability.type === 'agent-provider',
+        ) as Extract<PluginCapability, { type: 'agent-provider' }> | undefined;
+
+        if (agentProvider?.agentManifests?.length && entry.enabled) {
+          if (entry.lastApprovedChecksum !== plugin.checksum) {
+            entry.lastApprovedChecksum = plugin.checksum;
+            changed = true;
+          }
+
+          const previous = approvedManifests[plugin.pluginId];
+          const manifests = agentProvider.agentManifests;
+          const manifestsChanged =
+            !previous ||
+            previous.checksum !== plugin.checksum ||
+            previous.manifests.length !== manifests.length ||
+            previous.manifests.some((manifest, index) => {
+              const candidate = manifests[index];
+              return JSON.stringify(manifest) !== JSON.stringify(candidate);
+            });
+
+          if (manifestsChanged) {
+            approvedManifests[plugin.pluginId] = {
+              checksum: plugin.checksum,
+              approvedAt:
+                previous && previous.checksum === plugin.checksum
+                  ? previous.approvedAt
+                  : new Date().toISOString(),
+              manifests,
+            };
+            changed = true;
+          }
+        } else if (approvedManifests[plugin.pluginId]) {
+          delete approvedManifests[plugin.pluginId];
+          changed = true;
+        }
+      });
+
+      const enabledPlugins = Array.from(enabledSet).sort();
+      const previousEnabled = [...prev.enabledPlugins].sort();
+
+      if (
+        !changed &&
+        enabledPlugins.length === previousEnabled.length &&
+        enabledPlugins.every((value, index) => value === previousEnabled[index]) &&
+        Object.keys(pluginSettings).length === Object.keys(prev.pluginSettings).length &&
+        Object.keys(approvedManifests).length === Object.keys(prev.approvedManifests).length
+      ) {
+        return prev;
+      }
+
+      return {
+        ...prev,
+        pluginSettings,
+        enabledPlugins,
+        approvedManifests,
+      };
+    });
+  }, [runtimePlugins, onSettingsChange]);
+
+  useEffect(() => {
+    const activePlugins = runtimePlugins.filter(plugin => {
+      const entry = settings.pluginSettings[plugin.pluginId];
+      if (!entry || !entry.enabled) {
+        return false;
+      }
+      if (entry.lastApprovedChecksum && entry.lastApprovedChecksum !== plugin.checksum) {
+        return false;
+      }
+      return true;
+    });
+
+    const actionEntries: PluginMessageActionContext[] = [];
+    activePlugins.forEach(plugin => {
+      const commandMap = new Map<string, string>();
+      plugin.commands.forEach(command => {
+        commandMap.set(command.name, command.signature);
+      });
+
+      plugin.manifest.capabilities
+        .filter(capability => capability.type === 'chat-action')
+        .forEach(capability => {
+          const signature = commandMap.get(capability.command);
+          if (!signature) {
+            return;
+          }
+          actionEntries.push({
+            pluginId: plugin.pluginId,
+            id: capability.id,
+            label: capability.label,
+            description: capability.description,
+            icon: capability.icon,
+            signature,
+            command: capability.command,
+            run: async ({ messageId, value }) => {
+              await transport.invokeCommand(plugin.pluginId, capability.command, {
+                messageId,
+                value,
+              });
+            },
+          });
+        });
+    });
+
+    setMessageActions(actionEntries);
+
+    let cancelled = false;
+    const loadPanels = async () => {
+      const panelPromises = activePlugins.flatMap(plugin =>
+        plugin.manifest.capabilities
+          .filter(capability => capability.type === 'workspace-panel')
+          .map(async capability => {
+            const Component = await resolvePanelComponent(
+              plugin.pluginId,
+              capability as Extract<PluginCapability, { type: 'workspace-panel' }>,
+            );
+            if (!Component) {
+              return null;
+            }
+            return {
+              pluginId: plugin.pluginId,
+              id: capability.id,
+              label: capability.label,
+              Component,
+            };
+          }),
+      );
+
+      const resolved = (await Promise.all(panelPromises)).filter(
+        (value): value is PluginSidePanelContribution => value !== null,
+      );
+
+      if (!cancelled) {
+        setSidePanels(resolved);
+      }
+    };
+
+    void loadPanels();
+
+    return () => {
+      cancelled = true;
+    };
+  }, [runtimePlugins, settings.pluginSettings, transport]);
+
+  const updatePluginSettings = useCallback(
+    (pluginId: string, updater: (entry: PluginSettingsEntry | undefined) => PluginSettingsEntry) => {
+      onSettingsChange(prev => {
+        const current = prev.pluginSettings[pluginId];
+        const nextEntry = updater(current);
+        if (current === nextEntry) {
+          return prev;
+        }
+        return {
+          ...prev,
+          pluginSettings: {
+            ...prev.pluginSettings,
+            [pluginId]: nextEntry,
+          },
+        };
+      });
+    },
+    [onSettingsChange],
+  );
+
+  const value = useMemo<PluginHostContextValue>(() => ({
+    plugins: runtimePlugins,
+    messageActions,
+    sidePanels,
+    updatePluginSettings,
+    refresh,
+  }), [runtimePlugins, messageActions, sidePanels, updatePluginSettings, refresh]);
+
+  return <PluginHostContext.Provider value={value}>{children}</PluginHostContext.Provider>;
+};
+
+export const usePluginHost = (): PluginHostContextValue => {
+  const context = useContext(PluginHostContext);
+  if (!context) {
+    throw new Error('usePluginHost must be used within a PluginHostProvider');
+  }
+  return context;
+};

--- a/src/core/plugins/__tests__/PluginHostProvider.test.tsx
+++ b/src/core/plugins/__tests__/PluginHostProvider.test.tsx
@@ -1,0 +1,115 @@
+import React from 'react';
+import { act, render, screen, waitFor } from '@testing-library/react';
+import { describe, expect, it, vi } from 'vitest';
+import { PluginHostProvider, usePluginHost } from '../PluginHostProvider';
+import { DEFAULT_GLOBAL_SETTINGS } from '../../../utils/globalSettings';
+import { loadPluginManifest } from '../index';
+
+const manifestSource = {
+  id: 'test-plugin',
+  name: 'Plugin de pruebas',
+  version: '1.0.0',
+  capabilities: [
+    {
+      type: 'workspace-panel' as const,
+      id: 'panel-extra',
+      label: 'Panel de pruebas',
+      slot: 'side-panel' as const,
+      module: 'panels/TestPanel',
+    },
+    {
+      type: 'chat-action' as const,
+      id: 'notify',
+      label: 'Notificar',
+      command: 'notify',
+    },
+  ],
+  commands: [
+    {
+      name: 'notify',
+      description: 'Envía una notificación al backend.',
+      signature: 'signature-notify',
+    },
+  ],
+};
+
+describe('PluginHostProvider', () => {
+  it('inyecta paneles y acciones cuando el plugin está habilitado', async () => {
+    const loaded = await loadPluginManifest({ source: manifestSource, currentVersion: '1.0.0' });
+    const transport = {
+      listPlugins: vi.fn(async () => [loaded]),
+      invokeCommand: vi.fn(async () => undefined),
+    };
+
+    const Wrapper: React.FC<{ children: React.ReactNode }> = ({ children }) => {
+      const [settings, setSettings] = React.useState(() => {
+        const base = JSON.parse(JSON.stringify(DEFAULT_GLOBAL_SETTINGS)) as typeof DEFAULT_GLOBAL_SETTINGS;
+        return {
+          ...base,
+          enabledPlugins: ['test-plugin'],
+          pluginSettings: {
+            ...base.pluginSettings,
+            'test-plugin': {
+              enabled: true,
+              credentials: {},
+            },
+          },
+        };
+      });
+
+      return (
+        <PluginHostProvider
+          settings={settings}
+          onSettingsChange={setSettings}
+          transport={transport}
+          appVersion="1.0.0"
+        >
+          {children}
+        </PluginHostProvider>
+      );
+    };
+
+    const Consumer: React.FC = () => {
+      const { sidePanels, messageActions, plugins } = usePluginHost();
+      const action = messageActions[0];
+
+      return (
+        <div>
+          <span data-testid="plugin-count">{plugins.length}</span>
+          {sidePanels.map(panel => (
+            <panel.Component key={`${panel.pluginId}-${panel.id}`} />
+          ))}
+          <button
+            type="button"
+            data-testid="trigger-action"
+            disabled={!action}
+            onClick={() => action?.run({ messageId: 'msg-1', value: 'Hola' })}
+          >
+            Ejecutar acción
+          </button>
+        </div>
+      );
+    };
+
+    render(
+      <Wrapper>
+        <Consumer />
+      </Wrapper>,
+    );
+
+    await screen.findByTestId('test-plugin-panel');
+    await waitFor(() =>
+      expect(screen.getByTestId('trigger-action').hasAttribute('disabled')).toBe(false),
+    );
+    expect(screen.getByTestId('plugin-count').textContent).toBe('1');
+
+    await act(async () => {
+      screen.getByTestId('trigger-action').click();
+    });
+
+    expect(transport.invokeCommand).toHaveBeenCalledWith('test-plugin', 'notify', {
+      messageId: 'msg-1',
+      value: 'Hola',
+    });
+  });
+});

--- a/src/core/plugins/__tests__/pluginLoader.test.ts
+++ b/src/core/plugins/__tests__/pluginLoader.test.ts
@@ -1,0 +1,56 @@
+import { describe, expect, it } from 'vitest';
+import { loadPluginManifest } from '../index';
+
+const baseManifest = {
+  id: 'acme-tools',
+  name: 'Acme Tools',
+  version: '1.0.0',
+  capabilities: [
+    {
+      type: 'chat-action',
+      id: 'share-snippet',
+      label: 'Compartir con Acme',
+      command: 'send-snippet',
+    },
+  ],
+  commands: [
+    {
+      name: 'send-snippet',
+      description: 'Envía el fragmento al servicio remoto.',
+      signature: 'dummy-signature',
+    },
+  ],
+};
+
+describe('loadPluginManifest', () => {
+  it('calcula la firma y valida la compatibilidad', async () => {
+    const loaded = await loadPluginManifest({ source: baseManifest, currentVersion: '0.1.0' });
+    expect(loaded.manifest.id).toBe('acme-tools');
+
+    const verified = await loadPluginManifest({
+      source: {
+        ...baseManifest,
+        integrity: {
+          algorithm: 'sha256',
+          hash: loaded.checksum,
+        },
+      },
+      currentVersion: '0.1.0',
+      expectedChecksum: loaded.checksum,
+    });
+
+    expect(verified.checksum).toBe(loaded.checksum);
+  });
+
+  it('rechaza manifiestos incompatibles', async () => {
+    await expect(
+      loadPluginManifest({
+        source: {
+          ...baseManifest,
+          compatibility: { minVersion: '9.9.9' },
+        },
+        currentVersion: '0.1.0',
+      }),
+    ).rejects.toThrow(/requiere la versión 9\.9\.9/);
+  });
+});

--- a/src/core/plugins/index.ts
+++ b/src/core/plugins/index.ts
@@ -1,0 +1,270 @@
+import type { AgentManifest } from '../../types/agents';
+
+export type PluginCapability =
+  | {
+      type: 'agent-provider';
+      agentManifests?: AgentManifest[];
+    }
+  | {
+      type: 'chat-action';
+      id: string;
+      label: string;
+      description?: string;
+      command: string;
+      icon?: string;
+    }
+  | {
+      type: 'workspace-panel';
+      id: string;
+      label: string;
+      slot: 'side-panel' | 'workspace';
+      module: string;
+      export?: string;
+    }
+  | {
+      type: 'mcp-endpoint';
+      id: string;
+      transport: 'http' | 'ws';
+      url: string;
+    };
+
+export interface PluginCredentialField {
+  id: string;
+  label: string;
+  description?: string;
+  secret?: boolean;
+  required?: boolean;
+}
+
+export interface PluginCommandDescriptor {
+  name: string;
+  description?: string;
+  signature: string;
+}
+
+export interface PluginManifest {
+  id: string;
+  name: string;
+  version: string;
+  description?: string;
+  author?: string;
+  homepage?: string;
+  license?: string;
+  capabilities: PluginCapability[];
+  credentials?: PluginCredentialField[];
+  commands?: PluginCommandDescriptor[];
+  integrity?: PluginIntegrity;
+  compatibility?: PluginCompatibility;
+}
+
+export interface PluginIntegrity {
+  algorithm: 'sha256';
+  hash: string;
+}
+
+export interface PluginCompatibility {
+  minVersion?: string;
+  maxVersion?: string;
+}
+
+export interface LoadedPluginManifest {
+  manifest: PluginManifest;
+  checksum: string;
+}
+
+export interface PluginManifestLoadOptions {
+  source: string | LoadedPluginManifest | PluginManifest;
+  currentVersion: string;
+  expectedChecksum?: string;
+}
+
+const textEncoder = new TextEncoder();
+
+const normalizeVersion = (value: string): number[] => {
+  return value
+    .split('.')
+    .map(part => parseInt(part, 10))
+    .map(part => (Number.isFinite(part) && part >= 0 ? part : 0));
+};
+
+const compareVersions = (a: string, b: string): number => {
+  const av = normalizeVersion(a);
+  const bv = normalizeVersion(b);
+  const length = Math.max(av.length, bv.length);
+  for (let i = 0; i < length; i += 1) {
+    const ai = av[i] ?? 0;
+    const bi = bv[i] ?? 0;
+    if (ai > bi) {
+      return 1;
+    }
+    if (ai < bi) {
+      return -1;
+    }
+  }
+  return 0;
+};
+
+const canonicalize = (input: unknown): string => {
+  if (Array.isArray(input)) {
+    return `[${input.map(item => canonicalize(item)).join(',')}]`;
+  }
+  if (input && typeof input === 'object') {
+    const entries = Object.entries(input as Record<string, unknown>);
+    const sorted = entries.sort(([a], [b]) => (a > b ? 1 : a < b ? -1 : 0));
+    return `{${sorted
+      .map(([key, value]) => `${JSON.stringify(key)}:${canonicalize(value)}`)
+      .join(',')}}`;
+  }
+  return JSON.stringify(input);
+};
+
+const computeSha256 = async (payload: string): Promise<string> => {
+  const data = textEncoder.encode(payload);
+  if (typeof globalThis.crypto !== 'undefined' && 'subtle' in globalThis.crypto) {
+    const digest = await globalThis.crypto.subtle.digest('SHA-256', data);
+    const bytes = Array.from(new Uint8Array(digest));
+    return bytes.map(byte => byte.toString(16).padStart(2, '0')).join('');
+  }
+
+  const { createHash } = await import('crypto');
+  return createHash('sha256').update(payload).digest('hex');
+};
+
+const prepareForChecksum = (manifest: PluginManifest): Omit<PluginManifest, 'integrity'> => {
+  const { integrity: _integrity, ...rest } = manifest;
+  return rest;
+};
+
+const isPluginManifest = (value: unknown): value is PluginManifest => {
+  if (!value || typeof value !== 'object') {
+    return false;
+  }
+  const candidate = value as PluginManifest;
+  return (
+    typeof candidate.id === 'string' &&
+    typeof candidate.name === 'string' &&
+    typeof candidate.version === 'string' &&
+    Array.isArray(candidate.capabilities)
+  );
+};
+
+const validateCapabilities = (capabilities: PluginCapability[]): PluginCapability[] => {
+  return capabilities.filter(capability => {
+    if (!capability || typeof capability !== 'object') {
+      return false;
+    }
+    switch (capability.type) {
+      case 'agent-provider':
+        return true;
+      case 'chat-action':
+        return (
+          typeof capability.id === 'string' &&
+          typeof capability.label === 'string' &&
+          typeof capability.command === 'string'
+        );
+      case 'workspace-panel':
+        return (
+          typeof capability.id === 'string' &&
+          typeof capability.label === 'string' &&
+          (capability.slot === 'side-panel' || capability.slot === 'workspace') &&
+          typeof capability.module === 'string'
+        );
+      case 'mcp-endpoint':
+        return (
+          typeof capability.id === 'string' &&
+          (capability.transport === 'http' || capability.transport === 'ws') &&
+          typeof capability.url === 'string'
+        );
+      default:
+        return false;
+    }
+  });
+};
+
+const validateCredentials = (credentials: PluginCredentialField[] | undefined) => {
+  if (!credentials) {
+    return undefined;
+  }
+  return credentials.filter(field => typeof field.id === 'string' && typeof field.label === 'string');
+};
+
+const validateCommands = (commands: PluginCommandDescriptor[] | undefined) => {
+  if (!commands) {
+    return undefined;
+  }
+  const seen = new Set<string>();
+  return commands.filter(command => {
+    if (!command || typeof command.name !== 'string') {
+      return false;
+    }
+    const normalized = command.name.trim();
+    if (!normalized || seen.has(normalized)) {
+      return false;
+    }
+    if (typeof command.signature !== 'string' || !command.signature.trim()) {
+      return false;
+    }
+    seen.add(normalized);
+    return true;
+  });
+};
+
+export const loadPluginManifest = async (
+  options: PluginManifestLoadOptions,
+): Promise<LoadedPluginManifest> => {
+  let rawManifest: PluginManifest | null = null;
+  let checksum: string | undefined;
+
+  if (typeof options.source === 'string') {
+    const parsed = JSON.parse(options.source) as PluginManifest;
+    rawManifest = parsed;
+    checksum = await computeSha256(canonicalize(prepareForChecksum(parsed)));
+  } else if (isPluginManifest(options.source)) {
+    rawManifest = options.source;
+  } else if (
+    typeof options.source === 'object' &&
+    options.source !== null &&
+    'manifest' in options.source
+  ) {
+    const { manifest, checksum: providedChecksum } = options.source as LoadedPluginManifest;
+    rawManifest = manifest;
+    checksum = providedChecksum;
+  }
+
+  if (!rawManifest) {
+    throw new Error('Invalid plugin manifest payload');
+  }
+
+  const manifest: PluginManifest = {
+    ...rawManifest,
+    capabilities: validateCapabilities(rawManifest.capabilities ?? []),
+    credentials: validateCredentials(rawManifest.credentials),
+    commands: validateCommands(rawManifest.commands),
+  };
+
+  if (!manifest.capabilities.length) {
+    throw new Error(`El plugin «${manifest.id}» no declara capacidades válidas.`);
+  }
+
+  const { compatibility } = manifest;
+  if (compatibility?.minVersion && compareVersions(options.currentVersion, compatibility.minVersion) < 0) {
+    throw new Error(
+      `El plugin «${manifest.name}» requiere la versión ${compatibility.minVersion} o superior.`,
+    );
+  }
+  if (compatibility?.maxVersion && compareVersions(options.currentVersion, compatibility.maxVersion) > 0) {
+    throw new Error(
+      `El plugin «${manifest.name}» no es compatible con la versión actual de la aplicación.`,
+    );
+  }
+
+  const serialized = canonicalize(prepareForChecksum(manifest));
+  const computed = await computeSha256(serialized);
+  const expected = manifest.integrity?.hash ?? checksum ?? options.expectedChecksum;
+
+  if (expected && expected !== computed) {
+    throw new Error(`La firma del manifiesto del plugin «${manifest.id}» no coincide.`);
+  }
+
+  return { manifest, checksum: computed };
+};

--- a/src/plugins/test-plugin/panels/TestPanel.tsx
+++ b/src/plugins/test-plugin/panels/TestPanel.tsx
@@ -1,0 +1,7 @@
+import React from 'react';
+
+const TestPanel: React.FC = () => (
+  <div data-testid="test-plugin-panel">Panel de prueba del plugin</div>
+);
+
+export default TestPanel;

--- a/src/types/globalSettings.ts
+++ b/src/types/globalSettings.ts
@@ -38,4 +38,13 @@ export interface GlobalSettings {
   defaultRoutingRules: DefaultRoutingRules;
   enabledPlugins: string[];
   approvedManifests: AgentManifestCache;
+  pluginSettings: PluginSettingsMap;
 }
+
+export interface PluginSettingsEntry {
+  enabled: boolean;
+  credentials: Record<string, string>;
+  lastApprovedChecksum?: string;
+}
+
+export type PluginSettingsMap = Record<string, PluginSettingsEntry>;


### PR DESCRIPTION
## Summary
- add TypeScript manifest types and loader utilities with validation for plugin capabilities
- introduce a Tauri plugin manager that discovers plugins, checks integrity, and exposes commands to the frontend
- integrate PluginHostProvider across UI, add plugin management settings, documentation, and tests for the new plugin infrastructure

## Testing
- npm test -- --run

------
https://chatgpt.com/codex/tasks/task_e_68cea5d02ea08333826fae220cf2fce9