### PR TITLE
Refactor side panel layout with tabs and saved preferences

### DIFF
--- a/src/components/chat/ChatInterface.css
+++ b/src/components/chat/ChatInterface.css
@@ -884,13 +884,115 @@
   backdrop-filter: blur(14px);
 }
 
+.controls-panel-toolbar {
+  display: flex;
+  align-items: center;
+  justify-content: flex-start;
+  gap: 12px;
+  flex-wrap: wrap;
+  margin-bottom: 20px;
+}
+
+.panel-control {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  gap: 6px;
+  padding: 6px 12px;
+  border-radius: 10px;
+  border: 1px solid rgba(255, 255, 255, 0.12);
+  background: rgba(255, 255, 255, 0.06);
+  color: rgba(255, 255, 255, 0.85);
+  font-size: 11px;
+  letter-spacing: 0.6px;
+  text-transform: uppercase;
+  cursor: pointer;
+  transition: border-color 0.2s ease, box-shadow 0.2s ease, background 0.2s ease;
+}
+
+.panel-control:hover {
+  border-color: rgba(255, 255, 255, 0.28);
+}
+
+.panel-control.is-active {
+  background: rgba(142, 141, 255, 0.18);
+  border-color: rgba(142, 141, 255, 0.45);
+  box-shadow: 0 6px 18px rgba(142, 141, 255, 0.25);
+}
+
+.panel-control-group {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+}
+
+.panel-control-label {
+  font-size: 11px;
+  letter-spacing: 0.5px;
+  text-transform: uppercase;
+  color: rgba(255, 255, 255, 0.55);
+}
+
+.panel-control-buttons {
+  display: inline-flex;
+  gap: 6px;
+}
+
+.panel-width-control {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+}
+
+.panel-width-control input[type='range'] {
+  width: 160px;
+  accent-color: rgba(142, 141, 255, 0.8);
+}
+
+.panel-container {
+  display: flex;
+  flex-direction: column;
+  gap: 24px;
+}
+
+.panel-container-tabs .panel-tablist {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
+  margin-bottom: 8px;
+}
+
+.panel-tab {
+  padding: 6px 14px;
+  border-radius: 999px;
+  border: 1px solid rgba(255, 255, 255, 0.12);
+  background: rgba(255, 255, 255, 0.04);
+  color: rgba(255, 255, 255, 0.75);
+  font-size: 12px;
+  letter-spacing: 0.4px;
+  text-transform: uppercase;
+  cursor: pointer;
+  transition: border-color 0.2s ease, background 0.2s ease, color 0.2s ease;
+}
+
+.panel-tab.is-active {
+  background: rgba(255, 183, 77, 0.18);
+  border-color: rgba(255, 183, 77, 0.6);
+  color: rgba(255, 255, 255, 0.95);
+  box-shadow: 0 8px 24px rgba(255, 183, 77, 0.28);
+}
+
+.panel-tabpanel {
+  padding-top: 4px;
+}
+
 .panel-section {
   display: flex;
   flex-direction: column;
   gap: 14px;
-  margin-bottom: 32px;
-  padding-bottom: 24px;
-  border-bottom: 1px solid rgba(255, 255, 255, 0.04);
+  margin-bottom: 28px;
+  padding-bottom: 20px;
+  border-bottom: 1px solid rgba(255, 255, 255, 0.05);
 }
 
 .panel-section:last-of-type {
@@ -899,15 +1001,75 @@
   padding-bottom: 0;
 }
 
-.panel-section-header h2 {
-  font-size: 15px;
+.panel-section-header {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+
+.panel-section-toggle,
+.panel-section-heading {
+  display: inline-flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+  font-size: 14px;
+  font-weight: 600;
   letter-spacing: 0.6px;
+  text-transform: uppercase;
+  color: rgba(255, 255, 255, 0.85);
+}
+
+.panel-section-toggle {
+  width: 100%;
+  background: transparent;
+  border: none;
+  padding: 0;
+  cursor: pointer;
+  text-align: left;
+}
+
+.panel-section-toggle::after {
+  content: '';
+  width: 10px;
+  height: 10px;
+  border-right: 2px solid rgba(255, 255, 255, 0.6);
+  border-bottom: 2px solid rgba(255, 255, 255, 0.6);
+  transform: rotate(45deg);
+  transition: transform 0.2s ease;
+}
+
+.panel-section.is-collapsed .panel-section-toggle::after {
+  transform: rotate(-135deg);
+}
+
+.panel-section-title {
+  flex: 1;
+}
+
+.panel-section-meta {
+  font-size: 11px;
+  letter-spacing: 0.5px;
+  color: rgba(255, 255, 255, 0.6);
+  border: 1px solid rgba(255, 255, 255, 0.12);
+  border-radius: 999px;
+  padding: 3px 10px;
   text-transform: uppercase;
 }
 
-.panel-section-header p {
+.panel-plugin-origin {
+  color: rgba(255, 255, 255, 0.7);
+}
+
+.panel-section-description {
   font-size: 12px;
   color: rgba(255, 255, 255, 0.55);
+}
+
+.panel-section-body {
+  display: flex;
+  flex-direction: column;
+  gap: 18px;
 }
 
 .channel-status-list {
@@ -1396,15 +1558,116 @@
   line-height: 1.4;
 }
 
+.bottom-section {
+  display: flex;
+  align-items: stretch;
+  gap: 24px;
+  position: relative;
+  width: 100%;
+  --side-panel-width: 320px;
+}
+
+.bottom-section .visual-stage {
+  flex: 1 1 auto;
+  min-width: 0;
+}
+
+.bottom-section.side-panel-left {
+  flex-direction: row;
+}
+
+.bottom-section.side-panel-right {
+  flex-direction: row-reverse;
+}
+
+.bottom-section .controls-panel {
+  flex: 0 0 var(--side-panel-width, 320px);
+  min-width: 240px;
+  max-width: 520px;
+  position: relative;
+  z-index: 30;
+  transition: transform 0.3s ease, opacity 0.3s ease;
+}
+
+.bottom-section.is-panel-collapsed .controls-panel {
+  pointer-events: none;
+  opacity: 0;
+  transform: translateX(24px);
+}
+
+.bottom-section.side-panel-left.is-panel-collapsed .controls-panel {
+  transform: translateX(-24px);
+}
+
+.bottom-section.is-panel-expanded .controls-panel {
+  opacity: 1;
+  transform: translateX(0);
+}
+
+.side-panel-toggle-button {
+  position: absolute;
+  bottom: 24px;
+  left: 24px;
+  display: none;
+  align-items: center;
+  gap: 6px;
+  padding: 10px 16px;
+  border-radius: 999px;
+  border: 1px solid rgba(255, 255, 255, 0.12);
+  background: rgba(0, 0, 0, 0.72);
+  color: rgba(255, 255, 255, 0.85);
+  letter-spacing: 0.5px;
+  text-transform: uppercase;
+  font-size: 11px;
+  cursor: pointer;
+  box-shadow: 0 12px 30px rgba(0, 0, 0, 0.35);
+  z-index: 50;
+}
+
+.side-panel-toggle-button.is-visible {
+  display: inline-flex;
+}
+
+.side-panel-overlay {
+  position: absolute;
+  inset: 0;
+  border: none;
+  background: rgba(0, 0, 0, 0.5);
+  backdrop-filter: blur(6px);
+  cursor: pointer;
+  z-index: 20;
+  display: none;
+}
+
 @media (max-width: 1280px) {
   .bottom-section {
     flex-direction: column;
+    align-items: stretch;
   }
 
-  .controls-panel {
-    width: 100%;
+  .bottom-section .controls-panel {
+    position: absolute;
+    top: 0;
+    bottom: 0;
+    width: min(100%, var(--side-panel-width, 320px));
+    max-width: calc(100% - 32px);
+    right: 24px;
+    left: auto;
     flex: none;
-    order: -1;
+    order: initial;
+  }
+
+  .bottom-section.side-panel-left .controls-panel {
+    left: 24px;
+    right: auto;
+  }
+
+  .bottom-section.is-panel-collapsed .controls-panel {
+    transform: translateY(24px);
+  }
+
+  .bottom-section.is-panel-expanded .side-panel-overlay {
+    display: block;
   }
 
   .chat-header {

--- a/src/components/chat/ChatWorkspace.tsx
+++ b/src/components/chat/ChatWorkspace.tsx
@@ -8,13 +8,25 @@ import { ChatActorFilter } from '../../types/chat';
 import { AgentKind } from '../../core/agents/agentRegistry';
 import { getAgentDisplayName, getAgentVersionLabel } from '../../utils/agentDisplay';
 import { MessageCard } from './messages/MessageCard';
+import { SidePanelPosition } from '../../types/globalSettings';
 
 interface ChatWorkspaceProps {
   sidePanel: React.ReactNode;
   actorFilter: ChatActorFilter;
+  sidePanelPosition: SidePanelPosition;
+  sidePanelWidth: number;
+  isSidePanelCollapsed: boolean;
+  onSidePanelCollapse: (collapsed: boolean) => void;
 }
 
-export const ChatWorkspace: React.FC<ChatWorkspaceProps> = ({ sidePanel, actorFilter }) => {
+export const ChatWorkspace: React.FC<ChatWorkspaceProps> = ({
+  sidePanel,
+  actorFilter,
+  sidePanelPosition,
+  sidePanelWidth,
+  isSidePanelCollapsed,
+  onSidePanelCollapse,
+}) => {
   const [density, setDensity] = useState<'standard' | 'compact'>('standard');
   const [isHeaderCollapsed, setHeaderCollapsed] = useState(false);
   const { activeAgents, agentMap } = useAgents();
@@ -159,7 +171,15 @@ export const ChatWorkspace: React.FC<ChatWorkspaceProps> = ({ sidePanel, actorFi
         </div>
       </div>
 
-      <div className="bottom-section">
+      <div
+        className={`bottom-section side-panel-${sidePanelPosition} ${
+          isSidePanelCollapsed ? 'is-panel-collapsed' : 'is-panel-expanded'
+        }`}
+        style={{
+          // eslint-disable-next-line @typescript-eslint/consistent-type-assertions
+          '--side-panel-width': `${Math.round(sidePanelWidth)}px`,
+        } as React.CSSProperties}
+      >
         <div className="visual-stage">
           <div className={`visual-wrapper chat-visual-wrapper chat-density-${density}`}>
             <div className={`chat-stage chat-density-${density}`}>
@@ -281,6 +301,25 @@ export const ChatWorkspace: React.FC<ChatWorkspaceProps> = ({ sidePanel, actorFi
         </div>
 
         {sidePanel}
+
+        <button
+          type="button"
+          className={`side-panel-toggle-button ${isSidePanelCollapsed ? 'is-visible' : ''}`.trim()}
+          onClick={() => onSidePanelCollapse(false)}
+          aria-expanded={!isSidePanelCollapsed}
+        >
+          Abrir panel
+        </button>
+
+        <button
+          type="button"
+          className="side-panel-overlay"
+          hidden={isSidePanelCollapsed}
+          aria-hidden={isSidePanelCollapsed}
+          tabIndex={isSidePanelCollapsed ? -1 : 0}
+          onClick={() => onSidePanelCollapse(true)}
+          aria-label="Cerrar panel lateral"
+        />
       </div>
     </>
   );

--- a/src/components/chat/__tests__/SidePanel.test.tsx
+++ b/src/components/chat/__tests__/SidePanel.test.tsx
@@ -1,0 +1,142 @@
+import React from 'react';
+import { describe, expect, it, beforeEach, vi } from 'vitest';
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import '@testing-library/jest-dom/vitest';
+import { SidePanel } from '../SidePanel';
+import type { SidePanelPreferences } from '../../../types/globalSettings';
+
+vi.mock('../../models/ModelGallery', () => ({
+  ModelGallery: () => <div data-testid="model-gallery">Model gallery</div>,
+}));
+
+vi.mock('../../agents/AgentPresenceList', () => ({
+  AgentPresenceList: () => <div data-testid="agent-presence">Agent list</div>,
+}));
+
+vi.mock('../../quality/QualityDashboard', () => ({
+  QualityDashboard: () => <div data-testid="quality-dashboard">Quality dashboard</div>,
+}));
+
+vi.mock('../../orchestration/AgentConversationPanel', () => ({
+  AgentConversationPanel: () => <div data-testid="agent-conversation">Conversation panel</div>,
+}));
+
+vi.mock('../../../core/agents/AgentContext', () => ({
+  useAgents: () => ({
+    agents: [
+      {
+        id: 'agent-1',
+        name: 'Agent One',
+        channel: 'gpt',
+        kind: 'cloud',
+        provider: 'openai',
+        accent: '#ff6600',
+        active: true,
+        status: 'Listo',
+      },
+    ],
+    agentMap: new Map([
+      [
+        'agent-1',
+        {
+          id: 'agent-1',
+          name: 'Agent One',
+          channel: 'gpt',
+          kind: 'cloud',
+          provider: 'openai',
+          accent: '#ff6600',
+          active: true,
+          status: 'Listo',
+        },
+      ],
+    ]),
+    toggleAgent: vi.fn(),
+    assignAgentRole: vi.fn(),
+  }),
+}));
+
+vi.mock('../../../core/messages/MessageContext', () => ({
+  useMessages: () => ({
+    quickCommands: ['Hola'],
+    appendToDraft: vi.fn(),
+    messages: [],
+    pendingResponses: 0,
+    agentResponses: [],
+    formatTimestamp: (value: number | string) => String(value),
+    toPlainText: () => '',
+    feedbackByMessage: {},
+    markMessageFeedback: vi.fn(),
+    submitCorrection: vi.fn(),
+    correctionHistory: [],
+    coordinationStrategy: 'parallel',
+    setCoordinationStrategy: vi.fn(),
+    sharedSnapshot: null,
+    orchestrationTraces: [],
+  }),
+}));
+
+vi.mock('../../../hooks/useSidePanelSlots', () => ({
+  useSidePanelSlots: () => [
+    {
+      id: 'alpha:panel',
+      pluginId: 'alpha',
+      label: 'Panel plugin',
+      Component: () => <div>Contenido plugin</div>,
+    },
+  ],
+}));
+
+vi.mock('../../../utils/secrets', () => ({
+  providerSecretExists: () => Promise.resolve(false),
+  storeProviderSecret: vi.fn(),
+}));
+
+const createLayout = (overrides: Partial<SidePanelPreferences> = {}): SidePanelPreferences => ({
+  position: 'right',
+  width: 420,
+  collapsed: false,
+  activeSectionId: 'channels',
+  ...overrides,
+});
+
+const Wrapper: React.FC<{ initialLayout?: Partial<SidePanelPreferences> }> = ({ initialLayout }) => {
+  const [layout, setLayout] = React.useState<SidePanelPreferences>(createLayout(initialLayout));
+
+  return (
+    <SidePanel
+      apiKeys={{ openai: '', anthropic: '', groq: '' }}
+      onApiKeyChange={vi.fn()}
+      presenceMap={new Map()}
+      onRefreshAgentPresence={vi.fn()}
+      layout={layout}
+      onLayoutChange={updater => setLayout(prev => updater(prev))}
+    />
+  );
+};
+
+describe('SidePanel', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('shows the default core section in tab mode and hides inactive ones', () => {
+    render(<Wrapper />);
+
+    expect(screen.getByText('Estado en tiempo real de tus proveedores.')).toBeInTheDocument();
+    expect(
+      screen.queryByText('Guarda instrucciones recurrentes para dispararlas en el chat.'),
+    ).not.toBeInTheDocument();
+  });
+
+  it('allows switching to plugin panels', async () => {
+    render(<Wrapper />);
+
+    const [pluginTab] = screen.getAllByRole('tab', { name: 'Panel plugin' });
+    fireEvent.click(pluginTab);
+
+    expect(await screen.findByText('Contenido plugin')).toBeInTheDocument();
+    await waitFor(() => {
+      expect(pluginTab).toHaveAttribute('aria-selected', 'true');
+    });
+  });
+});

--- a/src/components/chat/panel/PanelContainer.tsx
+++ b/src/components/chat/panel/PanelContainer.tsx
@@ -1,0 +1,98 @@
+import React, { useMemo } from 'react';
+import { PanelSection } from './PanelSection';
+
+export interface PanelSectionDefinition {
+  id: string;
+  title: string;
+  description?: React.ReactNode;
+  content: React.ReactNode;
+  meta?: React.ReactNode;
+}
+
+export interface PanelContainerProps {
+  sections: PanelSectionDefinition[];
+  mode: 'tabs' | 'accordion';
+  activeSectionId: string | null;
+  onActiveSectionChange: (id: string) => void;
+}
+
+export const PanelContainer: React.FC<PanelContainerProps> = ({
+  sections,
+  mode,
+  activeSectionId,
+  onActiveSectionChange,
+}) => {
+  const sectionIds = useMemo(() => sections.map(section => section.id), [sections]);
+  const resolvedActiveId = useMemo(() => {
+    if (!sectionIds.length) {
+      return null;
+    }
+    if (activeSectionId && sectionIds.includes(activeSectionId)) {
+      return activeSectionId;
+    }
+    return sectionIds[0];
+  }, [activeSectionId, sectionIds]);
+
+  if (!sections.length) {
+    return null;
+  }
+
+  if (mode === 'tabs') {
+    const activeSection = sections.find(section => section.id === resolvedActiveId) ?? sections[0];
+
+    return (
+      <div className="panel-container panel-container-tabs">
+        <div className="panel-tablist" role="tablist" aria-orientation="horizontal">
+          {sections.map(section => {
+            const isSelected = section.id === resolvedActiveId;
+            return (
+              <button
+                key={section.id}
+                type="button"
+                role="tab"
+                aria-selected={isSelected}
+                className={`panel-tab ${isSelected ? 'is-active' : ''}`.trim()}
+                onClick={() => onActiveSectionChange(section.id)}
+              >
+                {section.title}
+              </button>
+            );
+          })}
+        </div>
+        <div className="panel-tabpanel" role="tabpanel">
+          <PanelSection
+            id={activeSection.id}
+            title={activeSection.title}
+            description={activeSection.description}
+            isOpen
+            collapsible={false}
+            meta={activeSection.meta}
+          >
+            {activeSection.content}
+          </PanelSection>
+        </div>
+      </div>
+    );
+  }
+
+  return (
+    <div className="panel-container panel-container-accordion">
+      {sections.map(section => {
+        const isOpen = section.id === resolvedActiveId;
+        return (
+          <PanelSection
+            key={section.id}
+            id={section.id}
+            title={section.title}
+            description={section.description}
+            isOpen={isOpen}
+            onToggle={onActiveSectionChange}
+            meta={section.meta}
+          >
+            {section.content}
+          </PanelSection>
+        );
+      })}
+    </div>
+  );
+};

--- a/src/components/chat/panel/PanelSection.tsx
+++ b/src/components/chat/panel/PanelSection.tsx
@@ -1,0 +1,59 @@
+import React from 'react';
+
+interface PanelSectionProps {
+  id: string;
+  title: string;
+  description?: React.ReactNode;
+  children: React.ReactNode;
+  isOpen: boolean;
+  collapsible?: boolean;
+  onToggle?: (id: string) => void;
+  meta?: React.ReactNode;
+}
+
+export const PanelSection: React.FC<PanelSectionProps> = ({
+  id,
+  title,
+  description,
+  children,
+  isOpen,
+  collapsible = true,
+  onToggle,
+  meta,
+}) => {
+  const handleToggle = () => {
+    if (collapsible && onToggle) {
+      onToggle(id);
+    }
+  };
+
+  return (
+    <section
+      className={`panel-section ${collapsible ? 'is-collapsible' : 'is-static'} ${isOpen ? 'is-open' : 'is-collapsed'}`.trim()}
+      data-panel-section={id}
+    >
+      <header className="panel-section-header">
+        {collapsible ? (
+          <button
+            type="button"
+            className="panel-section-toggle"
+            aria-expanded={isOpen}
+            onClick={handleToggle}
+          >
+            <span className="panel-section-title">{title}</span>
+            {meta && <span className="panel-section-meta">{meta}</span>}
+          </button>
+        ) : (
+          <div className="panel-section-heading">
+            <span className="panel-section-title">{title}</span>
+            {meta && <span className="panel-section-meta">{meta}</span>}
+          </div>
+        )}
+        {description && <p className="panel-section-description">{description}</p>}
+      </header>
+      <div className="panel-section-body" hidden={!isOpen}>
+        {children}
+      </div>
+    </section>
+  );
+};

--- a/src/components/chat/panel/index.ts
+++ b/src/components/chat/panel/index.ts
@@ -1,0 +1,3 @@
+export { PanelContainer } from './PanelContainer';
+export type { PanelContainerProps, PanelSectionDefinition } from './PanelContainer';
+export { PanelSection } from './PanelSection';

--- a/src/hooks/useSidePanelSlots.ts
+++ b/src/hooks/useSidePanelSlots.ts
@@ -1,0 +1,24 @@
+import { useMemo } from 'react';
+import { usePluginHost } from '../core/plugins/PluginHostProvider';
+
+export interface SidePanelSlotEntry {
+  id: string;
+  pluginId: string;
+  label: string;
+  Component: React.ComponentType;
+}
+
+export const useSidePanelSlots = (): SidePanelSlotEntry[] => {
+  const { sidePanels } = usePluginHost();
+
+  return useMemo(
+    () =>
+      sidePanels.map(panel => ({
+        id: `${panel.pluginId}:${panel.id}`,
+        pluginId: panel.pluginId,
+        label: panel.label,
+        Component: panel.Component,
+      })),
+    [sidePanels],
+  );
+};

--- a/src/types/globalSettings.ts
+++ b/src/types/globalSettings.ts
@@ -31,6 +31,19 @@ export interface RoutingRule {
 
 export type DefaultRoutingRules = Record<string, RoutingRule>;
 
+export type SidePanelPosition = 'left' | 'right';
+
+export interface SidePanelPreferences {
+  position: SidePanelPosition;
+  width: number;
+  collapsed: boolean;
+  activeSectionId: string | null;
+}
+
+export interface WorkspacePreferences {
+  sidePanel: SidePanelPreferences;
+}
+
 export interface GlobalSettings {
   version: number;
   apiKeys: ApiKeySettings;
@@ -39,6 +52,7 @@ export interface GlobalSettings {
   enabledPlugins: string[];
   approvedManifests: AgentManifestCache;
   pluginSettings: PluginSettingsMap;
+  workspacePreferences: WorkspacePreferences;
 }
 
 export interface PluginSettingsEntry {


### PR DESCRIPTION
## Summary
- extract the side panel content into reusable PanelContainer/PanelSection components and expose plugin slots through a new hook
- rebuild the SidePanel with layout controls for position, width and collapse while persisting the state in global settings
- update ChatWorkspace and styling to support collapsible/overlay behavior and add rendering tests that cover core and plugin sections

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68ceb381a1948333a0653bd3a44eebcf