### PR TITLE
Add MCP profiles to global settings schema and UI

### DIFF
--- a/src/components/GlobalSettingsModal.tsx
+++ b/src/components/GlobalSettingsModal.tsx
@@ -189,6 +189,7 @@ const GlobalSettingsModal: React.FC<GlobalSettingsModalProps> = ({
               { id: 'fullscreen', label: 'Monitors', icon: '🖥️' },
               { id: 'visual', label: 'Visuals', icon: '🎨' },
               { id: 'system', label: 'System', icon: '🔧' },
+              { id: 'integrations', label: 'Integrations', icon: '🧠' },
             ].map((tab) => (
               <button
                 key={tab.id}
@@ -258,6 +259,18 @@ const GlobalSettingsModal: React.FC<GlobalSettingsModalProps> = ({
                 onQueryChange={onVideoQueryChange}
                 onClearCache={onVideoCacheClear}
               />
+            )}
+
+            {activeTab === 'integrations' && (
+              <div className="settings-section">
+                <h3>Plugins y perfiles MCP</h3>
+                <p>
+                  La gestión avanzada de integraciones vive en el panel «Ajustes globales de IA».
+                  Desde allí puedes habilitar plugins, configurar sus credenciales y crear perfiles MCP
+                  personalizados. Abre ese panel desde la barra lateral principal para acceder a todas
+                  las opciones.
+                </p>
+              </div>
             )}
 
             {activeTab === 'fullscreen' && (

--- a/src/core/plugins/PluginHostProvider.tsx
+++ b/src/core/plugins/PluginHostProvider.tsx
@@ -430,7 +430,7 @@ export const PluginHostProvider: React.FC<PluginHostProviderProps> = ({
     return () => {
       cancelled = true;
     };
-  }, [runtimePlugins, settings.pluginSettings, transport]);
+  }, [runtimePlugins, settings.pluginSettings, settings.enabledPlugins, settings.approvedManifests, transport]);
 
   const updatePluginSettings = useCallback(
     (pluginId: string, updater: (entry: PluginSettingsEntry | undefined) => PluginSettingsEntry) => {

--- a/src/types/globalSettings.ts
+++ b/src/types/globalSettings.ts
@@ -8,6 +8,23 @@ export const BUILTIN_PROVIDERS: BuiltinProvider[] = ['openai', 'anthropic', 'gro
 
 export type ApiKeySettings = Record<string, string>;
 
+export type McpTransport = 'ws' | 'osc' | 'rest';
+
+export interface McpProfileEndpoint {
+  id: string;
+  transport: McpTransport;
+  url: string;
+}
+
+export interface McpProfile {
+  id: string;
+  label: string;
+  description?: string;
+  autoConnect: boolean;
+  token?: string;
+  endpoints: McpProfileEndpoint[];
+}
+
 export interface CommandPresetSettings {
   temperature?: number;
   maxTokens?: number;
@@ -52,6 +69,7 @@ export interface GlobalSettings {
   enabledPlugins: string[];
   approvedManifests: AgentManifestCache;
   pluginSettings: PluginSettingsMap;
+  mcpProfiles: McpProfile[];
   workspacePreferences: WorkspacePreferences;
 }
 

--- a/src/utils/__tests__/globalSettings.test.ts
+++ b/src/utils/__tests__/globalSettings.test.ts
@@ -1,0 +1,52 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+  CURRENT_SCHEMA_VERSION,
+  DEFAULT_GLOBAL_SETTINGS,
+  migratePersistedGlobalSettings,
+  validateGlobalSettingsPayload,
+} from '../globalSettings';
+
+import type { GlobalSettings } from '../../types/globalSettings';
+
+describe('globalSettings schema validation', () => {
+  it('acepta la configuración por defecto', () => {
+    expect(validateGlobalSettingsPayload(DEFAULT_GLOBAL_SETTINGS)).toBe(true);
+  });
+
+  it('migra configuraciones legacy preservando API keys', () => {
+    const legacy = {
+      version: 3,
+      apiKeys: {
+        openai: 'sk-legacy-token ',
+      },
+    } as Partial<GlobalSettings>;
+
+    const migrated = migratePersistedGlobalSettings(legacy);
+
+    expect(migrated.version).toBe(CURRENT_SCHEMA_VERSION);
+    expect(migrated.apiKeys.openai).toBe('sk-legacy-token');
+    expect(migrated.mcpProfiles).toEqual([]);
+  });
+
+  it('valida configuraciones con perfiles MCP', () => {
+    const candidate: GlobalSettings = {
+      ...DEFAULT_GLOBAL_SETTINGS,
+      mcpProfiles: [
+        {
+          id: 'studio',
+          label: 'Servidor creativo',
+          description: 'Sesión local para Ableton',
+          autoConnect: true,
+          token: 'secret-token',
+          endpoints: [
+            { id: 'ws-primary', transport: 'ws', url: 'ws://localhost:5005' },
+            { id: 'status', transport: 'rest', url: 'http://localhost:5005/status' },
+          ],
+        },
+      ],
+    };
+
+    expect(validateGlobalSettingsPayload(candidate)).toBe(true);
+  });
+});


### PR DESCRIPTION
## Summary
- extend global settings schema to version 6 with MCP profile support and export validation helpers
- add a management tab for MCP profiles alongside plugin controls in the global settings panel and link from legacy modal
- ensure providers react to setting changes and cover legacy/new configurations with AJV tests

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68cebe1c2e388333af7c5e01d3ce9eb1