### PR TITLE
feat: manage per-user data locations

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,17 @@ El panel de conversación ahora permite reenviar respuestas entre agentes para a
 3. Selecciona el agente de destino. Se registrará un apunte interno y se creará una nueva respuesta pendiente con el contexto compartido.
 4. El contenido canónico (si procede de un bloque de código) se copia automáticamente al compositor para que puedas editarlo antes de reenviarlo.
 
-Cada compartición queda registrada en `shared-messages.json` (almacenamiento local o `AppData` en Tauri) junto al historial de correcciones para facilitar la trazabilidad del dashboard de calidad.
+Cada compartición queda registrada en `shared-messages.json` dentro de la carpeta de datos de usuario (por defecto en `%APPDATA%/JungleMonkAI`, `~/Library/Application Support/JungleMonkAI` o `~/.junglemonkai`) junto al historial de correcciones para facilitar la trazabilidad del dashboard de calidad.
+
+## Ubicación de datos de usuario
+
+La aplicación guarda la configuración, los registros de calidad y los modelos locales en una carpeta específica para cada usuario.
+
+- **Windows**: `%APPDATA%/JungleMonkAI/`
+- **macOS**: `~/Library/Application Support/JungleMonkAI/`
+- **Linux**: `~/.junglemonkai/`
+
+Al iniciar la versión de escritorio se detectan instalaciones previas en el directorio de la app y se migra la información al nuevo destino registrando el evento en `migration.log`. Desde los **Ajustes globales → Ubicación de datos** puedes seleccionar una ruta personalizada; la aplicación valida que el directorio sea escribible, mueve los ficheros existentes y actualiza los ajustes persistidos.
 
 ## Controles sobre los mensajes
 

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -28,6 +28,10 @@ urlencoding = "2.1"
 aes-gcm = { version = "0.10", features = ["aes"] }
 rand = "0.8"
 tokio-tungstenite = "0.21"
+dirs = "5.0"
+
+[dev-dependencies]
+tempfile = "3.10"
 
 
 [build-dependencies]

--- a/src-tauri/build.rs
+++ b/src-tauri/build.rs
@@ -1,3 +1,3 @@
 fn main() {
-  tauri_build::build()
+    tauri_build::build()
 }

--- a/src-tauri/src/audio.rs
+++ b/src-tauri/src/audio.rs
@@ -6,7 +6,6 @@ use std::sync::Mutex;
 use tauri::AppHandle;
 use tokio::sync::watch;
 
-
 #[derive(Serialize, Clone)]
 pub struct AudioData {
     pub fft: Vec<f32>,
@@ -23,7 +22,6 @@ pub fn start(app: AppHandle) {
     tauri::async_runtime::spawn(async move {
         if let Err(e) = run(app.clone(), rx).await {
             eprintln!("audio error: {e:?}");
-
         }
     });
     Ok(())

--- a/src-tauri/src/config.rs
+++ b/src-tauri/src/config.rs
@@ -11,7 +11,12 @@ pub struct LayerConfig {
 
 impl Default for LayerConfig {
     fn default() -> Self {
-        Self { opacity: 1.0, fade_ms: 200, thumbnail: String::new(), midi_channel: 0 }
+        Self {
+            opacity: 1.0,
+            fade_ms: 200,
+            thumbnail: String::new(),
+            midi_channel: 0,
+        }
     }
 }
 
@@ -24,10 +29,31 @@ pub struct Config {
 impl Default for Config {
     fn default() -> Self {
         let mut layers = HashMap::new();
-        layers.insert("A".into(), LayerConfig { midi_channel: 14, ..Default::default() });
-        layers.insert("B".into(), LayerConfig { midi_channel: 15, ..Default::default() });
-        layers.insert("C".into(), LayerConfig { midi_channel: 16, ..Default::default() });
-        Self { layers, midi_port: None }
+        layers.insert(
+            "A".into(),
+            LayerConfig {
+                midi_channel: 14,
+                ..Default::default()
+            },
+        );
+        layers.insert(
+            "B".into(),
+            LayerConfig {
+                midi_channel: 15,
+                ..Default::default()
+            },
+        );
+        layers.insert(
+            "C".into(),
+            LayerConfig {
+                midi_channel: 16,
+                ..Default::default()
+            },
+        );
+        Self {
+            layers,
+            midi_port: None,
+        }
     }
 }
 
@@ -62,7 +88,10 @@ mod tests {
 
     #[test]
     fn concurrent_read_write() {
-        let state = Arc::new(ConfigState { path: PathBuf::new(), inner: RwLock::new(Config::default()) });
+        let state = Arc::new(ConfigState {
+            path: PathBuf::new(),
+            inner: RwLock::new(Config::default()),
+        });
 
         let writer_state = state.clone();
         let writer = thread::spawn(move || {

--- a/src-tauri/src/git/secrets.rs
+++ b/src-tauri/src/git/secrets.rs
@@ -91,7 +91,9 @@ impl SecretManager {
         let cipher = self.cipher()?;
         let decrypted = cipher
             .decrypt(Nonce::from_slice(nonce_bytes), payload)
-            .map_err(|err| SecretError::Message(format!("No se pudo descifrar el almacén: {err}")))?;
+            .map_err(|err| {
+                SecretError::Message(format!("No se pudo descifrar el almacén: {err}"))
+            })?;
 
         let store: SecretStore = serde_json::from_slice(&decrypted)
             .map_err(|err| SecretError::Message(format!("No se pudo parsear el almacén: {err}")))?;
@@ -102,8 +104,9 @@ impl SecretManager {
     }
 
     fn write_all(&self, data: &HashMap<String, String>) -> Result<(), SecretError> {
-        let plaintext = serde_json::to_vec(&SecretStore(data.clone()))
-            .map_err(|err| SecretError::Message(format!("No se pudo serializar el almacén: {err}")))?;
+        let plaintext = serde_json::to_vec(&SecretStore(data.clone())).map_err(|err| {
+            SecretError::Message(format!("No se pudo serializar el almacén: {err}"))
+        })?;
 
         let mut nonce_bytes = [0u8; 12];
         rand::rngs::OsRng.fill_bytes(&mut nonce_bytes);

--- a/src-tauri/src/gpu.rs
+++ b/src-tauri/src/gpu.rs
@@ -2,7 +2,12 @@ use wgpu::Instance;
 
 pub async fn init() {
     let instance = Instance::default();
-    if let Some(adapter) = instance.request_adapter(&wgpu::RequestAdapterOptions::default()).await {
-        let _ = adapter.request_device(&wgpu::DeviceDescriptor::default(), None).await;
+    if let Some(adapter) = instance
+        .request_adapter(&wgpu::RequestAdapterOptions::default())
+        .await
+    {
+        let _ = adapter
+            .request_device(&wgpu::DeviceDescriptor::default(), None)
+            .await;
     }
 }

--- a/src-tauri/src/settings.rs
+++ b/src-tauri/src/settings.rs
@@ -1,0 +1,426 @@
+use anyhow::{anyhow, Context, Result};
+use dirs::{data_dir, home_dir};
+use log::{info, warn};
+use serde::{Deserialize, Serialize};
+use std::fs::{self, OpenOptions};
+use std::io::Write;
+use std::path::{Path, PathBuf};
+use std::sync::RwLock;
+use std::time::{SystemTime, UNIX_EPOCH};
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum PlatformKind {
+    Windows,
+    MacOs,
+    Linux,
+}
+
+impl PlatformKind {
+    fn detect() -> Self {
+        if cfg!(target_os = "windows") {
+            Self::Windows
+        } else if cfg!(target_os = "macos") {
+            Self::MacOs
+        } else {
+            Self::Linux
+        }
+    }
+}
+
+#[derive(Debug, Clone, Serialize)]
+pub struct UserDataPathsInfo {
+    pub base_dir: String,
+    pub config_dir: String,
+    pub data_dir: String,
+    pub default_base_dir: String,
+    pub is_using_default: bool,
+    pub legacy_migration_performed: bool,
+    pub last_migrated_from: Option<String>,
+    pub last_migrated_at: Option<u64>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+struct PersistedUserDataConfig {
+    base_dir: PathBuf,
+    #[serde(default)]
+    last_migrated_from: Option<PathBuf>,
+    #[serde(default)]
+    last_migrated_at: Option<u64>,
+}
+
+pub struct UserDataPaths {
+    base_dir: PathBuf,
+    config_dir: PathBuf,
+    data_dir: PathBuf,
+    default_base_dir: PathBuf,
+    legacy_config_dir: PathBuf,
+    legacy_data_dir: PathBuf,
+    metadata_path: PathBuf,
+    last_migrated_from: Option<PathBuf>,
+    last_migrated_at: Option<u64>,
+    legacy_migration_performed: bool,
+}
+
+impl UserDataPaths {
+    pub fn initialize(legacy_config_dir: PathBuf, legacy_data_dir: PathBuf) -> Result<Self> {
+        let default_base_dir = Self::default_base_dir()?;
+        if let Some(parent) = legacy_config_dir.parent() {
+            fs::create_dir_all(parent).ok();
+        }
+
+        let metadata_path = legacy_config_dir.join("user-paths.json");
+        let persisted = Self::load_metadata(&metadata_path)?;
+        let base_dir = persisted
+            .as_ref()
+            .map(|config| config.base_dir.clone())
+            .unwrap_or_else(|| default_base_dir.clone());
+
+        let config_dir = base_dir.join("config");
+        let data_dir = base_dir.join("data");
+
+        fs::create_dir_all(&config_dir).context("failed to create user config directory")?;
+        fs::create_dir_all(&data_dir).context("failed to create user data directory")?;
+
+        let mut instance = Self {
+            base_dir,
+            config_dir,
+            data_dir,
+            default_base_dir,
+            legacy_config_dir: legacy_config_dir.clone(),
+            legacy_data_dir: legacy_data_dir.clone(),
+            metadata_path,
+            last_migrated_from: persisted.and_then(|config| config.last_migrated_from),
+            last_migrated_at: persisted.and_then(|config| config.last_migrated_at),
+            legacy_migration_performed: false,
+        };
+
+        instance.persist_metadata()?;
+        instance.perform_initial_migration()?;
+
+        Ok(instance)
+    }
+
+    pub fn config_dir(&self) -> PathBuf {
+        self.config_dir.clone()
+    }
+
+    pub fn data_dir(&self) -> PathBuf {
+        self.data_dir.clone()
+    }
+
+    pub fn info(&self) -> UserDataPathsInfo {
+        UserDataPathsInfo {
+            base_dir: self.base_dir.to_string_lossy().into_owned(),
+            config_dir: self.config_dir.to_string_lossy().into_owned(),
+            data_dir: self.data_dir.to_string_lossy().into_owned(),
+            default_base_dir: self.default_base_dir.to_string_lossy().into_owned(),
+            is_using_default: self.base_dir == self.default_base_dir,
+            legacy_migration_performed: self.legacy_migration_performed,
+            last_migrated_from: self
+                .last_migrated_from
+                .as_ref()
+                .map(|path| path.to_string_lossy().into_owned()),
+            last_migrated_at: self.last_migrated_at,
+        }
+    }
+
+    pub fn set_base_dir(&mut self, candidate: PathBuf) -> Result<UserDataPathsInfo> {
+        if candidate == self.base_dir {
+            return Ok(self.info());
+        }
+
+        if candidate.as_os_str().is_empty() {
+            return Err(anyhow!("La ruta proporcionada está vacía"));
+        }
+
+        fs::create_dir_all(&candidate)
+            .with_context(|| format!("no se pudo crear el directorio {:?}", candidate))?;
+        Self::validate_destination(&candidate)?;
+
+        let new_config_dir = candidate.join("config");
+        let new_data_dir = candidate.join("data");
+        fs::create_dir_all(&new_config_dir)?;
+        fs::create_dir_all(&new_data_dir)?;
+
+        self.migrate_between(&self.config_dir, &new_config_dir, Some(&self.metadata_path))?;
+        self.migrate_between(&self.data_dir, &new_data_dir, None)?;
+
+        let previous = self.base_dir.clone();
+        self.base_dir = candidate;
+        self.config_dir = new_config_dir;
+        self.data_dir = new_data_dir;
+        self.last_migrated_from = Some(previous.clone());
+        self.last_migrated_at = Some(Self::timestamp_now());
+
+        self.persist_metadata()?;
+        self.append_migration_log("user-change", &previous, &self.base_dir);
+
+        Ok(self.info())
+    }
+
+    fn perform_initial_migration(&mut self) -> Result<()> {
+        if self.legacy_config_dir == self.config_dir && self.legacy_data_dir == self.data_dir {
+            return Ok(());
+        }
+
+        let metadata = self.metadata_path.clone();
+        let had_config = self.legacy_config_dir.exists();
+        let had_data = self.legacy_data_dir.exists();
+
+        self.migrate_between(&self.legacy_config_dir, &self.config_dir, Some(&metadata))?;
+        self.migrate_between(&self.legacy_data_dir, &self.data_dir, None)?;
+
+        if had_config || had_data {
+            self.legacy_migration_performed = true;
+            self.last_migrated_from = Some(self.legacy_config_dir.clone());
+            self.last_migrated_at = Some(Self::timestamp_now());
+            self.persist_metadata()?;
+            self.append_migration_log("initial-migration", &self.legacy_config_dir, &self.base_dir);
+        }
+
+        Ok(())
+    }
+
+    fn migrate_between(
+        &self,
+        source: &Path,
+        destination: &Path,
+        skip: Option<&Path>,
+    ) -> Result<()> {
+        if !source.exists() {
+            return Ok(());
+        }
+
+        fs::create_dir_all(destination)?;
+        for entry in fs::read_dir(source)? {
+            let entry = entry?;
+            let path = entry.path();
+
+            if let Some(skip_path) = skip {
+                if path == *skip_path {
+                    continue;
+                }
+            }
+
+            let file_name = match path.file_name() {
+                Some(name) => name,
+                None => continue,
+            };
+
+            let target = destination.join(file_name);
+            if path.is_dir() {
+                self.migrate_between(&path, &target, None)?;
+                if let Err(error) = fs::remove_dir_all(&path) {
+                    warn!(
+                        "No se pudo eliminar el directorio antiguo {:?}: {error:?}",
+                        path
+                    );
+                }
+            } else {
+                if target.exists() {
+                    fs::remove_file(&target).ok();
+                }
+                match fs::rename(&path, &target) {
+                    Ok(_) => {}
+                    Err(_) => {
+                        fs::copy(&path, &target)?;
+                        fs::remove_file(&path).ok();
+                    }
+                }
+            }
+        }
+        Ok(())
+    }
+
+    fn validate_destination(candidate: &Path) -> Result<()> {
+        if candidate.exists() && !candidate.is_dir() {
+            return Err(anyhow!(
+                "La ruta seleccionada no es un directorio válido: {:?}",
+                candidate
+            ));
+        }
+
+        let probe_path = candidate.join(".__junglemonkai_probe");
+        fs::create_dir_all(candidate)?;
+        fs::write(&probe_path, b"probe").with_context(|| {
+            format!(
+                "no se pudo escribir en el directorio seleccionado {:?}",
+                candidate
+            )
+        })?;
+        fs::remove_file(probe_path).ok();
+        Ok(())
+    }
+
+    fn persist_metadata(&self) -> Result<()> {
+        if let Some(parent) = self.metadata_path.parent() {
+            fs::create_dir_all(parent)?;
+        }
+
+        let payload = PersistedUserDataConfig {
+            base_dir: self.base_dir.clone(),
+            last_migrated_from: self.last_migrated_from.clone(),
+            last_migrated_at: self.last_migrated_at,
+        };
+
+        let json = serde_json::to_vec_pretty(&payload)?;
+        fs::write(&self.metadata_path, json)?;
+        Ok(())
+    }
+
+    fn load_metadata(path: &Path) -> Result<Option<PersistedUserDataConfig>> {
+        if !path.exists() {
+            return Ok(None);
+        }
+
+        let contents = fs::read_to_string(path)?;
+        let data: PersistedUserDataConfig = serde_json::from_str(&contents)?;
+        Ok(Some(data))
+    }
+
+    fn append_migration_log(&self, event: &str, from: &Path, to: &Path) {
+        let log_path = self.base_dir.join("migration.log");
+        if let Some(parent) = log_path.parent() {
+            if fs::create_dir_all(parent).is_err() {
+                return;
+            }
+        }
+
+        let timestamp = Self::timestamp_now();
+        if let Ok(mut file) = OpenOptions::new().create(true).append(true).open(&log_path) {
+            let entry = serde_json::json!({
+                "event": event,
+                "from": from.to_string_lossy(),
+                "to": to.to_string_lossy(),
+                "timestamp": timestamp,
+            });
+            let _ = writeln!(file, "{}", entry);
+        }
+
+        info!(
+            "User data migration event: {} -> {} ({event})",
+            from.to_string_lossy(),
+            to.to_string_lossy()
+        );
+    }
+
+    fn timestamp_now() -> u64 {
+        SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .unwrap_or_default()
+            .as_secs()
+    }
+
+    fn default_base_dir() -> Result<PathBuf> {
+        let platform = PlatformKind::detect();
+        let home =
+            home_dir().ok_or_else(|| anyhow!("no se pudo resolver el directorio de usuario"))?;
+        let appdata = data_dir();
+        Ok(Self::build_default_base_dir(platform, home, appdata))
+    }
+
+    fn build_default_base_dir(
+        platform: PlatformKind,
+        home: PathBuf,
+        appdata: Option<PathBuf>,
+    ) -> PathBuf {
+        match platform {
+            PlatformKind::Windows => appdata.unwrap_or(home).join("JungleMonkAI"),
+            PlatformKind::MacOs => home
+                .join("Library")
+                .join("Application Support")
+                .join("JungleMonkAI"),
+            PlatformKind::Linux => home.join(".junglemonkai"),
+        }
+    }
+}
+
+pub struct UserDataPathsState {
+    inner: RwLock<UserDataPaths>,
+}
+
+impl UserDataPathsState {
+    pub fn new(inner: UserDataPaths) -> Self {
+        Self {
+            inner: RwLock::new(inner),
+        }
+    }
+
+    pub fn info(&self) -> UserDataPathsInfo {
+        self.inner.read().unwrap().info()
+    }
+
+    pub fn update_base_dir(&self, candidate: PathBuf) -> Result<UserDataPathsInfo> {
+        let mut guard = self.inner.write().unwrap();
+        guard.set_base_dir(candidate)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn default_path_windows_uses_appdata() {
+        let home = PathBuf::from("C:/Users/demo");
+        let appdata = Some(PathBuf::from("C:/Users/demo/AppData/Roaming"));
+        let path =
+            UserDataPaths::build_default_base_dir(PlatformKind::Windows, home.clone(), appdata);
+        assert_eq!(
+            path,
+            PathBuf::from("C:/Users/demo/AppData/Roaming/JungleMonkAI")
+        );
+    }
+
+    #[test]
+    fn default_path_macos_uses_application_support() {
+        let home = PathBuf::from("/Users/demo");
+        let path = UserDataPaths::build_default_base_dir(PlatformKind::MacOs, home.clone(), None);
+        assert_eq!(
+            path,
+            PathBuf::from("/Users/demo/Library/Application Support/JungleMonkAI")
+        );
+    }
+
+    #[test]
+    fn default_path_linux_is_hidden_folder() {
+        let home = PathBuf::from("/home/demo");
+        let path = UserDataPaths::build_default_base_dir(PlatformKind::Linux, home.clone(), None);
+        assert_eq!(path, PathBuf::from("/home/demo/.junglemonkai"));
+    }
+
+    #[test]
+    fn migrates_legacy_directories() -> Result<()> {
+        let legacy = tempfile::tempdir()?;
+        let legacy_config = legacy.path().join("config_old");
+        let legacy_data = legacy.path().join("data_old");
+        fs::create_dir_all(&legacy_config)?;
+        fs::create_dir_all(&legacy_data)?;
+        fs::write(legacy_config.join("config.json"), b"{}")?;
+        fs::write(legacy_data.join("models.json"), b"{}")?;
+
+        let base = legacy.path().join("new_base");
+        fs::create_dir_all(&base)?;
+
+        let mut instance = UserDataPaths {
+            base_dir: base.clone(),
+            config_dir: base.join("config"),
+            data_dir: base.join("data"),
+            default_base_dir: base.clone(),
+            legacy_config_dir: legacy_config.clone(),
+            legacy_data_dir: legacy_data.clone(),
+            metadata_path: legacy_config.join("user-paths.json"),
+            last_migrated_from: None,
+            last_migrated_at: None,
+            legacy_migration_performed: false,
+        };
+        fs::create_dir_all(instance.config_dir.clone())?;
+        fs::create_dir_all(instance.data_dir.clone())?;
+
+        instance.perform_initial_migration()?;
+
+        assert!(instance.config_dir.join("config.json").exists());
+        assert!(instance.data_dir.join("models.json").exists());
+        Ok(())
+    }
+}

--- a/src/core/storage/userDataFiles.ts
+++ b/src/core/storage/userDataFiles.ts
@@ -1,0 +1,85 @@
+import {
+  getUserDataPaths,
+  isTauriEnvironment,
+  refreshUserDataPaths,
+  UserDataPathDescriptor,
+} from './userDataPathsClient';
+
+const normalizeErrorCode = (value: unknown): string | undefined => {
+  if (value && typeof value === 'object' && 'code' in value) {
+    const code = (value as { code?: unknown }).code;
+    if (typeof code === 'string') {
+      return code;
+    }
+  }
+  return undefined;
+};
+
+export { isTauriEnvironment } from './userDataPathsClient';
+
+export const ensureUserDataDirectory = async (): Promise<UserDataPathDescriptor | null> => {
+  if (!isTauriEnvironment()) {
+    return null;
+  }
+
+  const [{ createDir }, descriptor] = await Promise.all([
+    import('@tauri-apps/api/fs'),
+    getUserDataPaths(),
+  ]);
+
+  await createDir(descriptor.baseDir, { recursive: true });
+  return descriptor;
+};
+
+export const readUserDataJson = async <T>(
+  relativePath: string,
+): Promise<T | undefined> => {
+  if (!isTauriEnvironment()) {
+    return undefined;
+  }
+
+  try {
+    const [{ readTextFile }, { join }] = await Promise.all([
+      import('@tauri-apps/api/fs'),
+      import('@tauri-apps/api/path'),
+    ]);
+    const descriptor = await getUserDataPaths();
+    const target = await join(descriptor.baseDir, relativePath);
+    const raw = await readTextFile(target);
+    return JSON.parse(raw) as T;
+  } catch (error) {
+    const code = normalizeErrorCode(error);
+    if (code === 'NotFound') {
+      return undefined;
+    }
+    console.warn(`No se pudo leer el archivo de datos de usuario "${relativePath}"`, error);
+    return undefined;
+  }
+};
+
+export const writeUserDataJson = async (
+  relativePath: string,
+  payload: unknown,
+): Promise<void> => {
+  if (!isTauriEnvironment()) {
+    return;
+  }
+
+  try {
+    const [{ writeTextFile, createDir }, { join, dirname }] = await Promise.all([
+      import('@tauri-apps/api/fs'),
+      import('@tauri-apps/api/path'),
+    ]);
+    const descriptor = await getUserDataPaths();
+    const target = await join(descriptor.baseDir, relativePath);
+    const parent = await dirname(target);
+    await createDir(parent, { recursive: true });
+    await writeTextFile({ path: target, contents: JSON.stringify(payload, null, 2) });
+  } catch (error) {
+    console.warn(`No se pudo escribir el archivo de datos de usuario "${relativePath}"`, error);
+  }
+};
+
+export const resetUserDataCache = () => {
+  refreshUserDataPaths();
+};

--- a/src/core/storage/userDataPathsClient.ts
+++ b/src/core/storage/userDataPathsClient.ts
@@ -1,0 +1,78 @@
+export interface UserDataPathDescriptor {
+  baseDir: string;
+  configDir: string;
+  dataDir: string;
+  defaultBaseDir: string;
+  isUsingDefault: boolean;
+  legacyMigrationPerformed: boolean;
+  lastMigratedFrom?: string;
+  lastMigratedAt?: number;
+}
+
+const FALLBACK_BASE_DIR = '~/.junglemonkai';
+
+let cachedDescriptor: Promise<UserDataPathDescriptor> | null = null;
+
+export const isTauriEnvironment = (): boolean =>
+  typeof window !== 'undefined' && Boolean((window as any).__TAURI__);
+
+const fetchDescriptor = async (): Promise<UserDataPathDescriptor> => {
+  if (!isTauriEnvironment()) {
+    return {
+      baseDir: FALLBACK_BASE_DIR,
+      configDir: `${FALLBACK_BASE_DIR}/config`,
+      dataDir: `${FALLBACK_BASE_DIR}/data`,
+      defaultBaseDir: FALLBACK_BASE_DIR,
+      isUsingDefault: true,
+      legacyMigrationPerformed: false,
+      lastMigratedFrom: undefined,
+      lastMigratedAt: undefined,
+    };
+  }
+
+  const { invoke } = await import('@tauri-apps/api/tauri');
+  return invoke<UserDataPathDescriptor>('get_user_data_paths');
+};
+
+export const getUserDataPaths = async (): Promise<UserDataPathDescriptor> => {
+  if (!cachedDescriptor) {
+    cachedDescriptor = fetchDescriptor().catch(error => {
+      cachedDescriptor = null;
+      throw error;
+    });
+  }
+
+  return cachedDescriptor;
+};
+
+export const refreshUserDataPaths = () => {
+  cachedDescriptor = null;
+};
+
+export const setUserDataBaseDir = async (path: string): Promise<UserDataPathDescriptor> => {
+  if (!isTauriEnvironment()) {
+    throw new Error(
+      'La personalización de la ruta de datos solo está disponible en la versión de escritorio.',
+    );
+  }
+
+  const { invoke } = await import('@tauri-apps/api/tauri');
+  const descriptor = await invoke<UserDataPathDescriptor>('set_user_data_base_dir', { path });
+  cachedDescriptor = Promise.resolve(descriptor);
+  return descriptor;
+};
+
+export const openUserDataDirectoryDialog = async (
+  defaultPath?: string,
+): Promise<string | null> => {
+  if (!isTauriEnvironment()) {
+    return null;
+  }
+
+  const { open } = await import('@tauri-apps/api/dialog');
+  const selection = await open({ directory: true, defaultPath });
+  if (typeof selection === 'string') {
+    return selection;
+  }
+  return null;
+};

--- a/src/types/globalSettings.ts
+++ b/src/types/globalSettings.ts
@@ -61,6 +61,15 @@ export interface WorkspacePreferences {
   sidePanel: SidePanelPreferences;
 }
 
+export interface DataLocationSettings {
+  useCustomPath: boolean;
+  customPath?: string;
+  lastKnownBasePath?: string;
+  defaultPath?: string;
+  lastMigrationFrom?: string;
+  lastMigrationAt?: string;
+}
+
 export interface GlobalSettings {
   version: number;
   apiKeys: ApiKeySettings;
@@ -71,6 +80,7 @@ export interface GlobalSettings {
   pluginSettings: PluginSettingsMap;
   mcpProfiles: McpProfile[];
   workspacePreferences: WorkspacePreferences;
+  dataLocation: DataLocationSettings;
 }
 
 export interface PluginSettingsEntry {

--- a/src/utils/__tests__/globalSettings.test.ts
+++ b/src/utils/__tests__/globalSettings.test.ts
@@ -27,6 +27,7 @@ describe('globalSettings schema validation', () => {
     expect(migrated.version).toBe(CURRENT_SCHEMA_VERSION);
     expect(migrated.apiKeys.openai).toBe('sk-legacy-token');
     expect(migrated.mcpProfiles).toEqual([]);
+    expect(migrated.dataLocation.useCustomPath).toBe(false);
   });
 
   it('valida configuraciones con perfiles MCP', () => {
@@ -45,6 +46,13 @@ describe('globalSettings schema validation', () => {
           ],
         },
       ],
+      dataLocation: {
+        ...DEFAULT_GLOBAL_SETTINGS.dataLocation,
+        useCustomPath: true,
+        customPath: '/tmp/jungle',
+        lastKnownBasePath: '/tmp/jungle',
+        defaultPath: '/Users/me/Library/Application Support/JungleMonkAI',
+      },
     };
 
     expect(validateGlobalSettingsPayload(candidate)).toBe(true);


### PR DESCRIPTION
## Summary
- add a Tauri settings layer to resolve per-user data directories and migrate existing files
- expose new storage helpers and update global settings, message history and UI to use the user data paths
- document defaults per OS, add path selection UI and new tests covering migrations

## Testing
- npm test
- cargo test *(fails: missing system library `glib-2.0` in CI image)*

------
https://chatgpt.com/codex/tasks/task_e_68cec2b9e1f48333947297736dbe036e