### PR TITLE
Redesign chat layout and centralize settings

### DIFF
--- a/src/AppLayout.css
+++ b/src/AppLayout.css
@@ -218,3 +218,63 @@
   text-align: center;
   margin-top: 20px;
 }
+
+/* Nuevo layout principal */
+.app-container {
+  display: flex;
+  flex-direction: column;
+}
+
+.app-body {
+  flex: 1 1 auto;
+  display: flex;
+  min-height: 0;
+  overflow: hidden;
+}
+
+.chat-main {
+  flex: 1 1 80%;
+  min-width: 0;
+  display: flex;
+  flex-direction: column;
+  background: radial-gradient(circle at top right, rgba(142, 141, 255, 0.18), transparent 55%),
+    #030303;
+}
+
+.app-sidebar {
+  flex: 0 0 20%;
+  min-width: 260px;
+  max-width: 380px;
+  border-left: 1px solid rgba(255, 255, 255, 0.08);
+  background: rgba(5, 5, 5, 0.92);
+}
+
+.app-body.sidebar-left .app-sidebar {
+  border-left: none;
+  border-right: 1px solid rgba(255, 255, 255, 0.08);
+}
+
+.repo-main {
+  flex: 1 1 auto;
+  min-width: 0;
+  overflow-y: auto;
+  padding: 32px;
+}
+
+@media (max-width: 1440px) {
+  .app-sidebar {
+    min-width: 240px;
+  }
+}
+
+@media (max-width: 1280px) {
+  .app-body {
+    flex-direction: column;
+  }
+
+  .app-sidebar {
+    flex: 0 0 auto;
+    max-width: none;
+    min-height: 320px;
+  }
+}

--- a/src/components/chat/ChatInterface.css
+++ b/src/components/chat/ChatInterface.css
@@ -1775,3 +1775,447 @@
     max-width: 60%;
   }
 }
+
+/* === Nuevo layout compacto del hub de chat === */
+.chat-top-bar {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 24px;
+  padding: 20px 28px;
+  background: rgba(5, 5, 5, 0.92);
+  border-bottom: 1px solid rgba(255, 255, 255, 0.08);
+  min-height: 96px;
+}
+
+.topbar-left {
+  display: flex;
+  align-items: center;
+  gap: 18px;
+}
+
+.brand-mark {
+  width: 40px;
+  height: 40px;
+  border-radius: 14px;
+  display: grid;
+  place-items: center;
+  font-size: 18px;
+  background: linear-gradient(135deg, rgba(255, 183, 77, 0.65), rgba(142, 141, 255, 0.4));
+  box-shadow: 0 12px 24px rgba(255, 183, 77, 0.2);
+}
+
+.brand-meta {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+}
+
+.brand-title {
+  font-size: 16px;
+  font-weight: 600;
+  letter-spacing: 0.6px;
+}
+
+.brand-status {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  font-size: 12px;
+  color: rgba(255, 255, 255, 0.7);
+  text-transform: uppercase;
+  letter-spacing: 0.6px;
+}
+
+.status-dot {
+  width: 10px;
+  height: 10px;
+  border-radius: 50%;
+  background: rgba(255, 255, 255, 0.4);
+}
+
+.status-dot.status-online {
+  background: #66ff66;
+  box-shadow: 0 0 8px rgba(102, 255, 102, 0.7);
+}
+
+.status-dot.status-error {
+  background: #ff6666;
+  box-shadow: 0 0 8px rgba(255, 102, 102, 0.6);
+}
+
+.status-dot.status-loading {
+  background: #ffd966;
+  box-shadow: 0 0 8px rgba(255, 217, 102, 0.6);
+}
+
+.mode-switcher {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  padding: 6px;
+  border-radius: 999px;
+  background: rgba(255, 255, 255, 0.06);
+}
+
+.mode-switcher button {
+  border: none;
+  width: 32px;
+  height: 32px;
+  border-radius: 50%;
+  background: transparent;
+  cursor: pointer;
+  font-size: 16px;
+  transition: background 0.2s ease;
+}
+
+.mode-switcher button.is-active {
+  background: rgba(142, 141, 255, 0.35);
+}
+
+.topbar-center {
+  flex: 1 1 auto;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 24px;
+}
+
+.metric-group {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+}
+
+.metric-chip {
+  display: flex;
+  flex-direction: column;
+  align-items: flex-start;
+  gap: 4px;
+  padding: 8px 12px;
+  border-radius: 12px;
+  background: rgba(255, 255, 255, 0.05);
+  border: 1px solid rgba(255, 255, 255, 0.08);
+  font-size: 12px;
+}
+
+.metric-chip.is-warning {
+  border-color: rgba(255, 148, 77, 0.6);
+  background: rgba(255, 148, 77, 0.18);
+}
+
+.metric-chip .metric-label {
+  font-size: 10px;
+  text-transform: uppercase;
+  letter-spacing: 0.6px;
+  color: rgba(255, 255, 255, 0.6);
+}
+
+.metric-chip .metric-value {
+  font-size: 15px;
+  font-weight: 600;
+}
+
+.icon-button {
+  border: none;
+  width: 36px;
+  height: 36px;
+  border-radius: 12px;
+  display: grid;
+  place-items: center;
+  background: rgba(255, 255, 255, 0.08);
+  color: #fff;
+  cursor: pointer;
+  transition: transform 0.2s ease, background 0.2s ease;
+  font-size: 16px;
+}
+
+.icon-button:hover {
+  transform: translateY(-1px);
+  background: rgba(142, 141, 255, 0.35);
+}
+
+.filter-pill select {
+  border: none;
+  border-radius: 999px;
+  padding: 8px 14px;
+  background: rgba(255, 255, 255, 0.06);
+  color: #fff;
+  font-size: 12px;
+}
+
+.topbar-actions {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+}
+
+.chat-workspace {
+  display: flex;
+  flex-direction: column;
+  height: 100%;
+  padding: 24px 32px;
+  gap: 24px;
+  overflow: hidden;
+}
+
+.chat-feed-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 24px;
+}
+
+.chat-feed-info h1 {
+  font-size: 22px;
+  margin-bottom: 6px;
+}
+
+.chat-feed-info p {
+  font-size: 13px;
+  color: rgba(255, 255, 255, 0.65);
+}
+
+.chat-feed-tools {
+  display: flex;
+  align-items: center;
+  gap: 16px;
+}
+
+.chat-density-toggle {
+  display: inline-flex;
+  border-radius: 999px;
+  background: rgba(255, 255, 255, 0.05);
+  border: 1px solid rgba(255, 255, 255, 0.08);
+  overflow: hidden;
+}
+
+.chat-density-toggle button {
+  border: none;
+  background: transparent;
+  color: rgba(255, 255, 255, 0.8);
+  padding: 6px 14px;
+  font-size: 12px;
+  cursor: pointer;
+}
+
+.chat-density-toggle button.is-active {
+  background: rgba(142, 141, 255, 0.45);
+  color: #fff;
+}
+
+.chat-session-metrics {
+  display: inline-flex;
+  align-items: center;
+  gap: 10px;
+}
+
+.metric-pill {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+  padding: 6px 12px;
+  border-radius: 10px;
+  background: rgba(255, 255, 255, 0.05);
+  border: 1px solid rgba(255, 255, 255, 0.08);
+}
+
+.metric-pill.metric-warning {
+  border-color: rgba(255, 148, 77, 0.6);
+  background: rgba(255, 148, 77, 0.18);
+}
+
+.chat-feed {
+  flex: 1 1 auto;
+  overflow-y: auto;
+  padding: 0 4px;
+  border-radius: 18px;
+  background: rgba(10, 10, 10, 0.75);
+  border: 1px solid rgba(255, 255, 255, 0.05);
+}
+
+.message-feed {
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+  padding: 24px;
+  min-height: 100%;
+}
+
+.message-feed.chat-density-compact {
+  gap: 10px;
+}
+
+.message-feed-empty {
+  text-align: center;
+  padding: 60px 20px;
+  color: rgba(255, 255, 255, 0.6);
+  font-size: 14px;
+}
+
+.chat-composer-area {
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+  padding: 20px;
+  border-radius: 18px;
+  background: rgba(12, 12, 12, 0.85);
+  border: 1px solid rgba(255, 255, 255, 0.06);
+}
+
+.chat-suggestions {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+}
+
+.suggestions-label {
+  font-size: 12px;
+  text-transform: uppercase;
+  letter-spacing: 0.6px;
+  color: rgba(255, 255, 255, 0.55);
+}
+
+.suggestion-chip {
+  border: none;
+  border-radius: 999px;
+  padding: 6px 12px;
+  background: rgba(255, 255, 255, 0.08);
+  color: #fff;
+  cursor: pointer;
+  font-size: 12px;
+}
+
+.chat-composer {
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+}
+
+.chat-input {
+  width: 100%;
+  border: 1px solid rgba(255, 255, 255, 0.12);
+  border-radius: 16px;
+  padding: 16px;
+  min-height: 96px;
+  resize: vertical;
+  background: rgba(0, 0, 0, 0.4);
+  color: #fff;
+  font-size: 14px;
+}
+
+.composer-extensions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 16px;
+  align-items: flex-start;
+}
+
+.composer-transcriptions {
+  flex: 1 1 100%;
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+
+.transcription-preview {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  padding: 8px 10px;
+  border-radius: 10px;
+  background: rgba(255, 255, 255, 0.05);
+  font-size: 12px;
+}
+
+.transcription-label {
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.4px;
+}
+
+.transcription-text {
+  flex: 1 1 auto;
+  color: rgba(255, 255, 255, 0.75);
+}
+
+.attachment-remove {
+  border: none;
+  background: rgba(255, 255, 255, 0.12);
+  color: #fff;
+  border-radius: 50%;
+  width: 24px;
+  height: 24px;
+  cursor: pointer;
+}
+
+.composer-toolbar {
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+}
+
+.composer-hints {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 10px;
+  font-size: 12px;
+  color: rgba(255, 255, 255, 0.65);
+}
+
+.composer-actions {
+  display: flex;
+  justify-content: flex-end;
+  gap: 12px;
+}
+
+.ghost-button,
+.primary-button {
+  padding: 10px 18px;
+  border-radius: 999px;
+  border: 1px solid rgba(255, 255, 255, 0.12);
+  background: transparent;
+  color: #fff;
+  font-size: 13px;
+  cursor: pointer;
+  letter-spacing: 0.6px;
+  text-transform: uppercase;
+}
+
+.primary-button {
+  background: linear-gradient(135deg, rgba(255, 183, 77, 0.9), rgba(142, 141, 255, 0.85));
+  border: none;
+}
+
+.primary-button:disabled {
+  opacity: 0.45;
+  cursor: not-allowed;
+}
+
+.ghost-button:disabled {
+  opacity: 0.45;
+  cursor: not-allowed;
+}
+
+@media (max-width: 1280px) {
+  .chat-top-bar {
+    flex-wrap: wrap;
+    gap: 16px;
+  }
+
+  .topbar-center {
+    flex-direction: column;
+    align-items: flex-start;
+    gap: 16px;
+  }
+
+  .chat-feed-header {
+    flex-direction: column;
+    align-items: flex-start;
+  }
+
+  .chat-feed-tools {
+    width: 100%;
+    justify-content: space-between;
+  }
+}

--- a/src/components/chat/ChatWorkspace.tsx
+++ b/src/components/chat/ChatWorkspace.tsx
@@ -8,27 +8,12 @@ import { ChatActorFilter } from '../../types/chat';
 import { AgentKind } from '../../core/agents/agentRegistry';
 import { getAgentDisplayName, getAgentVersionLabel } from '../../utils/agentDisplay';
 import { MessageCard } from './messages/MessageCard';
-import { SidePanelPosition } from '../../types/globalSettings';
-
 interface ChatWorkspaceProps {
-  sidePanel: React.ReactNode;
   actorFilter: ChatActorFilter;
-  sidePanelPosition: SidePanelPosition;
-  sidePanelWidth: number;
-  isSidePanelCollapsed: boolean;
-  onSidePanelCollapse: (collapsed: boolean) => void;
 }
 
-export const ChatWorkspace: React.FC<ChatWorkspaceProps> = ({
-  sidePanel,
-  actorFilter,
-  sidePanelPosition,
-  sidePanelWidth,
-  isSidePanelCollapsed,
-  onSidePanelCollapse,
-}) => {
+export const ChatWorkspace: React.FC<ChatWorkspaceProps> = ({ actorFilter }) => {
   const [density, setDensity] = useState<'standard' | 'compact'>('standard');
-  const [isHeaderCollapsed, setHeaderCollapsed] = useState(false);
   const { activeAgents, agentMap } = useAgents();
   const {
     messages,
@@ -117,210 +102,153 @@ export const ChatWorkspace: React.FC<ChatWorkspaceProps> = ({
   }, [actorFilter, agentMap, publicMessages]);
 
   return (
-    <>
-      <div className={`layer-grid-container chat-layer-grid ${isHeaderCollapsed ? 'is-collapsed' : ''}`}>
-        <div className={`chat-header ${isHeaderCollapsed ? 'is-collapsed' : ''}`}>
-          <div className="chat-header-main">
+    <div className={`chat-workspace chat-density-${density}`}>
+      <div className="chat-feed-header">
+        <div className="chat-feed-info">
+          <h1>Control Hub</h1>
+          <p>
+            {activeAgents.length} agente{activeAgents.length === 1 ? '' : 's'} coordinando la conversación.
+          </p>
+        </div>
+        <div className="chat-feed-tools">
+          <div className="chat-density-toggle" role="group" aria-label="Densidad del feed">
             <button
               type="button"
-              className="chat-header-toggle"
-              aria-expanded={!isHeaderCollapsed}
-              onClick={() => setHeaderCollapsed(previous => !previous)}
+              className={density === 'standard' ? 'is-active' : ''}
+              onClick={() => setDensity('standard')}
             >
-              {isHeaderCollapsed ? 'Mostrar cabecera' : 'Ocultar cabecera'}
+              Estándar
             </button>
-            <div className="chat-header-text" aria-hidden={isHeaderCollapsed}>
-              <h1 className="chat-title">JungleMonk.AI · Control Hub</h1>
-              <p className="chat-subtitle">
-                Orquesta múltiples agentes en paralelo manteniendo la estética original del entorno.
-              </p>
-            </div>
+            <button
+              type="button"
+              className={density === 'compact' ? 'is-active' : ''}
+              onClick={() => setDensity('compact')}
+            >
+              Compacta
+            </button>
           </div>
-          <div className="chat-header-right">
-            <div className="chat-density-toggle" role="group" aria-label="Densidad del feed">
-              <button
-                type="button"
-                className={density === 'standard' ? 'is-active' : ''}
-                onClick={() => setDensity('standard')}
-              >
-                Estándar
-              </button>
-              <button
-                type="button"
-                className={density === 'compact' ? 'is-active' : ''}
-                onClick={() => setDensity('compact')}
-              >
-                Compacta
-              </button>
-            </div>
-            <div className="chat-metrics" aria-label="Estado de la sesión">
-              <span className="metric-badge">
-                <span className="metric-label">Agentes activos</span>
-                <span className="metric-value">{activeAgents.length}</span>
-              </span>
-              <span className="metric-badge">
-                <span className="metric-label">Mensajes totales</span>
-                <span className="metric-value">{messages.length}</span>
-              </span>
-              <span className={`metric-badge ${pendingResponses ? 'metric-warning' : ''}`}>
-                <span className="metric-label">Respuestas pendientes</span>
-                <span className="metric-value">{pendingResponses}</span>
-              </span>
-            </div>
+          <div className="chat-session-metrics" aria-label="Estado de la conversación">
+            <span className="metric-pill">
+              <span className="metric-label">Mensajes</span>
+              <span className="metric-value">{messages.length}</span>
+            </span>
+            <span className={`metric-pill ${pendingResponses ? 'metric-warning' : ''}`}>
+              <span className="metric-label">Pendientes</span>
+              <span className="metric-value">{pendingResponses}</span>
+            </span>
           </div>
         </div>
       </div>
 
-      <div
-        className={`bottom-section side-panel-${sidePanelPosition} ${
-          isSidePanelCollapsed ? 'is-panel-collapsed' : 'is-panel-expanded'
-        }`}
-        style={{
-          // eslint-disable-next-line @typescript-eslint/consistent-type-assertions
-          '--side-panel-width': `${Math.round(sidePanelWidth)}px`,
-        } as React.CSSProperties}
-      >
-        <div className="visual-stage">
-          <div className={`visual-wrapper chat-visual-wrapper chat-density-${density}`}>
-            <div className={`chat-stage chat-density-${density}`}>
-              <div className="chat-grid">
-                <section className="chat-feed" aria-label="Historial de mensajes">
-                  <div className="message-feed">
-                    {filteredMessages.length === 0 ? (
-                      <div className="message-feed-empty">
-                        No hay mensajes para el filtro seleccionado.
-                      </div>
-                    ) : (
-                      filteredMessages.map(message => {
-                        const agent = message.agentId ? agentMap.get(message.agentId) : undefined;
-                        const chipColor = agent?.accent || 'var(--accent-color)';
-                        const agentDisplayName = agent ? getAgentDisplayName(agent) : undefined;
-                        const providerLabel = agent
-                          ? agent.kind === 'local'
-                            ? getAgentVersionLabel(agent)
-                            : agent.provider
-                          : undefined;
+      <section className="chat-feed" aria-label="Historial de mensajes">
+        <div className={`message-feed chat-density-${density}`}>
+          {filteredMessages.length === 0 ? (
+            <div className="message-feed-empty">No hay mensajes para el filtro seleccionado.</div>
+          ) : (
+            filteredMessages.map(message => {
+              const agent = message.agentId ? agentMap.get(message.agentId) : undefined;
+              const chipColor = agent?.accent || 'var(--accent-color)';
+              const agentDisplayName = agent ? getAgentDisplayName(agent) : undefined;
+              const providerLabel = agent
+                ? agent.kind === 'local'
+                  ? getAgentVersionLabel(agent)
+                  : agent.provider
+                : undefined;
 
-                        return (
-                          <MessageCard
-                            key={message.id}
-                            message={message}
-                            chipColor={chipColor}
-                            agentDisplayName={agentDisplayName}
-                            providerLabel={providerLabel}
-                            formatTimestamp={formatTimestamp}
-                            onAppendToComposer={appendToDraft}
-                            onShareMessage={(agentId, messageId, canonicalCode) =>
-                              shareMessageWithAgent(agentId, messageId, { canonicalCode })
-                            }
-                            onLoadIntoDraft={loadMessageIntoDraft}
-                          />
-                        );
-                      })
-                    )}
-                  </div>
-                </section>
+              return (
+                <MessageCard
+                  key={message.id}
+                  message={message}
+                  chipColor={chipColor}
+                  agentDisplayName={agentDisplayName}
+                  providerLabel={providerLabel}
+                  formatTimestamp={formatTimestamp}
+                  onAppendToComposer={appendToDraft}
+                  onShareMessage={(agentId, messageId, canonicalCode) =>
+                    shareMessageWithAgent(agentId, messageId, { canonicalCode })
+                  }
+                  onLoadIntoDraft={loadMessageIntoDraft}
+                />
+              );
+            })
+          )}
+        </div>
+      </section>
 
-                <aside className="chat-composer-panel" aria-label="Redactor de mensajes">
-                  <div className="chat-suggestions">
-                    <span className="suggestions-label">Sugerencias:</span>
-                    {quickCommands.slice(0, 3).map(command => (
-                      <button
-                        key={command}
-                        type="button"
-                        className="suggestion-chip"
-                        onClick={() => appendToDraft(command)}
-                      >
-                        {command}
-                      </button>
-                    ))}
-                  </div>
+      <section className="chat-composer-area" aria-label="Redactor de mensajes">
+        <div className="chat-suggestions">
+          <span className="suggestions-label">Sugerencias</span>
+          {quickCommands.slice(0, 3).map(command => (
+            <button
+              key={command}
+              type="button"
+              className="suggestion-chip"
+              onClick={() => appendToDraft(command)}
+            >
+              {command}
+            </button>
+          ))}
+        </div>
 
-                  <div className="chat-composer">
-                    <textarea
-                      value={draft}
-                      onChange={event => setDraft(event.target.value)}
-                      placeholder="Habla con varios agentes a la vez: por ejemplo “gpt, genera un esquema de estilos”"
-                      className="chat-input"
-                      rows={3}
-                    />
-                    <div className="composer-extensions">
-                      <AttachmentPicker
-                        attachments={composerAttachments}
-                        onAdd={handleAddAttachments}
-                        onRemove={handleRemoveAttachment}
-                      />
-                      <AudioRecorder onRecordingComplete={handleRecordingComplete} />
-                      {composerTranscriptions.length > 0 && (
-                        <div className="composer-transcriptions">
-                          {composerTranscriptions.map(transcription => (
-                            <div key={transcription.id} className="transcription-preview">
-                              <span className="transcription-label">{transcription.modality ?? 'audio'}</span>
-                              <span className="transcription-text">{transcription.text}</span>
-                              <button
-                                type="button"
-                                className="attachment-remove"
-                                onClick={() => removeTranscription(transcription.id)}
-                              >
-                                ×
-                              </button>
-                            </div>
-                          ))}
-                        </div>
-                      )}
-                    </div>
-                    <div className="composer-toolbar">
-                      <div className="composer-hints">
-                        <span>Usa @ para mencionar modelos concretos</span>
-                        {lastUserMessage && (
-                          <span className="composer-last">Último mensaje a las {formatTimestamp(lastUserMessage.timestamp)}</span>
-                        )}
-                        {composerModalities.length > 0 && (
-                          <span className="composer-modalities">Modalidades: {composerModalities.join(', ')}</span>
-                        )}
-                      </div>
-                      <div className="composer-actions">
-                        <button type="button" className="ghost-button" onClick={() => setDraft('')} disabled={!draft.trim()}>
-                          Limpiar
-                        </button>
-                        <button
-                          type="button"
-                          className="primary-button"
-                          onClick={sendMessage}
-                          disabled={!draft.trim() && composerAttachments.length === 0}
-                        >
-                          Enviar a {activeAgents.length || 'ningún'} agente{activeAgents.length === 1 ? '' : 's'}
-                        </button>
-                      </div>
-                    </div>
+        <div className="chat-composer">
+          <textarea
+            value={draft}
+            onChange={event => setDraft(event.target.value)}
+            placeholder="Habla con varios agentes a la vez: por ejemplo “gpt, genera un esquema de estilos”"
+            className="chat-input"
+            rows={3}
+          />
+          <div className="composer-extensions">
+            <AttachmentPicker
+              attachments={composerAttachments}
+              onAdd={handleAddAttachments}
+              onRemove={handleRemoveAttachment}
+            />
+            <AudioRecorder onRecordingComplete={handleRecordingComplete} />
+            {composerTranscriptions.length > 0 && (
+              <div className="composer-transcriptions">
+                {composerTranscriptions.map(transcription => (
+                  <div key={transcription.id} className="transcription-preview">
+                    <span className="transcription-label">{transcription.modality ?? 'audio'}</span>
+                    <span className="transcription-text">{transcription.text}</span>
+                    <button
+                      type="button"
+                      className="attachment-remove"
+                      onClick={() => removeTranscription(transcription.id)}
+                    >
+                      ×
+                    </button>
                   </div>
-                </aside>
+                ))}
               </div>
+            )}
+          </div>
+          <div className="composer-toolbar">
+            <div className="composer-hints">
+              <span>Usa @ para mencionar modelos concretos</span>
+              {lastUserMessage && (
+                <span className="composer-last">Último mensaje a las {formatTimestamp(lastUserMessage.timestamp)}</span>
+              )}
+              {composerModalities.length > 0 && (
+                <span className="composer-modalities">Modalidades: {composerModalities.join(', ')}</span>
+              )}
+            </div>
+            <div className="composer-actions">
+              <button type="button" className="ghost-button" onClick={() => setDraft('')} disabled={!draft.trim()}>
+                Limpiar
+              </button>
+              <button
+                type="button"
+                className="primary-button"
+                onClick={sendMessage}
+                disabled={!draft.trim() && composerAttachments.length === 0}
+              >
+                Enviar a {activeAgents.length || 'ningún'} agente{activeAgents.length === 1 ? '' : 's'}
+              </button>
             </div>
           </div>
         </div>
-
-        {sidePanel}
-
-        <button
-          type="button"
-          className={`side-panel-toggle-button ${isSidePanelCollapsed ? 'is-visible' : ''}`.trim()}
-          onClick={() => onSidePanelCollapse(false)}
-          aria-expanded={!isSidePanelCollapsed}
-        >
-          Abrir panel
-        </button>
-
-        <button
-          type="button"
-          className="side-panel-overlay"
-          hidden={isSidePanelCollapsed}
-          aria-hidden={isSidePanelCollapsed}
-          tabIndex={isSidePanelCollapsed ? -1 : 0}
-          onClick={() => onSidePanelCollapse(true)}
-          aria-label="Cerrar panel lateral"
-        />
-      </div>
-    </>
+      </section>
+    </div>
   );
 };

--- a/src/components/chat/SidePanel.css
+++ b/src/components/chat/SidePanel.css
@@ -1,0 +1,236 @@
+.sidebar {
+  display: flex;
+  flex-direction: column;
+  height: 100%;
+  padding: 24px;
+  gap: 24px;
+  background: rgba(10, 10, 10, 0.92);
+  border-left: 1px solid rgba(255, 255, 255, 0.08);
+  overflow-y: auto;
+  scrollbar-width: thin;
+  scrollbar-color: rgba(255, 255, 255, 0.3) transparent;
+}
+
+.sidebar::-webkit-scrollbar {
+  width: 6px;
+}
+
+.sidebar::-webkit-scrollbar-thumb {
+  background: rgba(255, 255, 255, 0.3);
+  border-radius: 999px;
+}
+
+.sidebar-section {
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+  padding: 18px;
+  border-radius: 18px;
+  background: rgba(18, 18, 18, 0.85);
+  border: 1px solid rgba(255, 255, 255, 0.06);
+  box-shadow: 0 8px 20px rgba(0, 0, 0, 0.45);
+}
+
+.sidebar-section header h2 {
+  font-size: 16px;
+  font-weight: 600;
+  letter-spacing: 0.5px;
+}
+
+.sidebar-section header p {
+  margin-top: 4px;
+  font-size: 12px;
+  color: rgba(255, 255, 255, 0.6);
+}
+
+.provider-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(160px, 1fr));
+  gap: 12px;
+}
+
+.provider-card {
+  padding: 14px;
+  border-radius: 14px;
+  border: 1px solid rgba(255, 255, 255, 0.08);
+  background: rgba(255, 255, 255, 0.04);
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+  transition: border 0.2s ease, background 0.2s ease;
+}
+
+.provider-card header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  font-size: 13px;
+}
+
+.provider-name {
+  font-weight: 600;
+}
+
+.provider-status {
+  font-size: 12px;
+  text-transform: uppercase;
+  letter-spacing: 0.6px;
+  color: rgba(255, 255, 255, 0.6);
+}
+
+.provider-card.status-online {
+  border-color: rgba(102, 255, 102, 0.4);
+  background: rgba(102, 255, 102, 0.12);
+}
+
+.provider-card.status-loading {
+  border-color: rgba(255, 217, 102, 0.3);
+}
+
+.provider-card.status-error {
+  border-color: rgba(255, 102, 102, 0.45);
+  background: rgba(255, 102, 102, 0.16);
+}
+
+.provider-body {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+  font-size: 12px;
+  color: rgba(255, 255, 255, 0.7);
+}
+
+.local-model-card {
+  margin-top: 8px;
+  padding: 16px;
+  border-radius: 14px;
+  background: linear-gradient(135deg, rgba(77, 208, 225, 0.15), rgba(142, 141, 255, 0.12));
+  border: 1px solid rgba(142, 141, 255, 0.35);
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  gap: 12px;
+}
+
+.local-model-card h3 {
+  font-size: 14px;
+  font-weight: 600;
+  margin-bottom: 4px;
+}
+
+.local-model-card p {
+  font-size: 12px;
+  color: rgba(255, 255, 255, 0.75);
+}
+
+.local-model-card button {
+  border: none;
+  border-radius: 999px;
+  padding: 6px 14px;
+  background: rgba(142, 141, 255, 0.45);
+  color: #fff;
+  cursor: pointer;
+  font-size: 12px;
+  letter-spacing: 0.6px;
+  text-transform: uppercase;
+}
+
+.sidebar-stats {
+  list-style: none;
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(120px, 1fr));
+  gap: 10px;
+}
+
+.sidebar-stats li {
+  padding: 10px 12px;
+  border-radius: 12px;
+  background: rgba(255, 255, 255, 0.04);
+  border: 1px solid rgba(255, 255, 255, 0.05);
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+}
+
+.stat-label {
+  font-size: 11px;
+  letter-spacing: 0.5px;
+  text-transform: uppercase;
+  color: rgba(255, 255, 255, 0.55);
+}
+
+.stat-value {
+  font-size: 18px;
+  font-weight: 600;
+}
+
+.suggestion-list {
+  list-style: none;
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+}
+
+.suggestion-list li button {
+  width: 100%;
+  text-align: left;
+  background: rgba(255, 255, 255, 0.04);
+  border: 1px solid rgba(255, 255, 255, 0.06);
+  border-radius: 12px;
+  padding: 12px 14px;
+  color: #fff;
+  cursor: pointer;
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+  transition: border 0.2s ease, transform 0.2s ease;
+}
+
+.suggestion-list li button:hover:not(:disabled) {
+  border-color: rgba(255, 183, 77, 0.6);
+  transform: translateY(-1px);
+}
+
+.suggestion-list li button:disabled {
+  opacity: 0.6;
+  cursor: default;
+}
+
+.suggestion-list strong {
+  font-size: 13px;
+  font-weight: 600;
+}
+
+.suggestion-list span {
+  font-size: 12px;
+  color: rgba(255, 255, 255, 0.65);
+}
+
+.command-list {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+
+.command-list button {
+  text-align: left;
+  border: 1px solid rgba(255, 255, 255, 0.06);
+  border-radius: 999px;
+  padding: 8px 14px;
+  background: rgba(255, 255, 255, 0.05);
+  color: #fff;
+  font-size: 12px;
+  letter-spacing: 0.4px;
+  cursor: pointer;
+  transition: border 0.2s ease, transform 0.2s ease;
+}
+
+.command-list button:hover {
+  border-color: rgba(255, 183, 77, 0.55);
+  transform: translateY(-1px);
+}
+
+.command-empty {
+  font-size: 12px;
+  color: rgba(255, 255, 255, 0.6);
+}

--- a/src/components/chat/SidePanel.tsx
+++ b/src/components/chat/SidePanel.tsx
@@ -1,247 +1,118 @@
-import React, { useCallback, useEffect, useMemo, useState } from 'react';
+import React, { useMemo } from 'react';
+import './SidePanel.css';
 import { useAgents } from '../../core/agents/AgentContext';
 import { AgentPresenceEntry, AgentPresenceStatus } from '../../core/agents/presence';
 import { useMessages } from '../../core/messages/MessageContext';
-import { ApiKeySettings, SidePanelPreferences } from '../../types/globalSettings';
-import { ModelGallery } from '../models/ModelGallery';
-import { AgentPresenceList } from '../agents/AgentPresenceList';
-import { ChatMessage } from '../../core/messages/messageTypes';
-import { QualityDashboard } from '../quality/QualityDashboard';
-import { AgentConversationPanel } from '../orchestration/AgentConversationPanel';
-import { providerSecretExists, storeProviderSecret } from '../../utils/secrets';
-import {
-  getAgentChannelLabel,
-  getAgentDisplayName,
-  getAgentVersionLabel,
-} from '../../utils/agentDisplay';
-import { PanelContainer, PanelSectionDefinition } from './panel';
-import { useSidePanelSlots } from '../../hooks/useSidePanelSlots';
+import { ApiKeySettings } from '../../types/globalSettings';
+import { useLocalModels } from '../../hooks/useLocalModels';
+import { getAgentDisplayName, getAgentVersionLabel } from '../../utils/agentDisplay';
+
+interface ProviderSummary {
+  id: string;
+  label: string;
+  status: AgentPresenceStatus;
+  active: number;
+  total: number;
+  hasKey: boolean;
+}
+
+interface SuggestionItem {
+  id: string;
+  title: string;
+  description: string;
+  action?: () => void;
+}
+
+const PROVIDER_LABELS: Record<string, string> = {
+  openai: 'OpenAI',
+  anthropic: 'Anthropic',
+  groq: 'Groq',
+};
 
 interface SidePanelProps {
   apiKeys: ApiKeySettings;
-  onApiKeyChange: (provider: string, value: string) => void;
   presenceMap: Map<string, AgentPresenceEntry>;
   onRefreshAgentPresence: (agentId?: string) => void | Promise<void>;
-  layout: SidePanelPreferences;
-  onLayoutChange: (updater: (previous: SidePanelPreferences) => SidePanelPreferences) => void;
-  className?: string;
-  style?: React.CSSProperties;
+  onOpenGlobalSettings: () => void;
 }
-
-const CHANNEL_STATUS_LABELS: Record<AgentPresenceStatus, string> = {
-  online: 'Operativo',
-  offline: 'En espera',
-  error: 'Con incidencias',
-  loading: 'Verificando…',
-};
-
-const getChannelStatusClass = (status: AgentPresenceStatus): string => {
-  switch (status) {
-    case 'online':
-      return 'is-online';
-    case 'error':
-      return 'is-error';
-    case 'loading':
-      return 'is-loading';
-    default:
-      return 'is-offline';
-  }
-};
-
-interface ChannelStatusView {
-  key: string;
-  label: string;
-  version: string;
-  status: AgentPresenceStatus;
-  accent: string;
-  message?: string;
-  active: boolean;
-}
-
-const MIN_PANEL_WIDTH = 240;
-const MAX_PANEL_WIDTH = 520;
-const ACCORDION_BREAKPOINT = 340;
 
 export const SidePanel: React.FC<SidePanelProps> = ({
   apiKeys,
-  onApiKeyChange,
   presenceMap,
   onRefreshAgentPresence,
-  layout,
-  onLayoutChange,
-  className,
-  style,
+  onOpenGlobalSettings,
 }) => {
-  const [githubInput, setGithubInput] = useState('');
-  const [gitlabInput, setGitlabInput] = useState('');
-  const [githubStored, setGithubStored] = useState(false);
-  const [gitlabStored, setGitlabStored] = useState(false);
-
-  const { agents, agentMap, toggleAgent, assignAgentRole } = useAgents();
+  const { agents } = useAgents();
   const {
+    messages,
     quickCommands,
     appendToDraft,
-    messages,
     pendingResponses,
     agentResponses,
     formatTimestamp,
-    toPlainText,
-    feedbackByMessage,
-    markMessageFeedback,
-    submitCorrection,
-    correctionHistory,
-    coordinationStrategy,
-    setCoordinationStrategy,
-    sharedSnapshot,
-    orchestrationTraces,
   } = useMessages();
-  const pluginSlots = useSidePanelSlots();
+  const { models } = useLocalModels();
 
-  const recentActivity = useMemo(
-    () =>
-      agentResponses
-        .slice(-6)
-        .reverse()
-        .map(message => ({ message, agent: message.agentId ? agentMap.get(message.agentId) : undefined })),
-    [agentMap, agentResponses],
-  );
+  const providerSummaries = useMemo<ProviderSummary[]>(() => {
+    const grouped = new Map<
+      string,
+      ProviderSummary & { statusCounts: Record<AgentPresenceStatus, number> }
+    >();
 
-  const handleMarkIncorrect = useCallback(
-    (message: ChatMessage) => {
-      const currentFeedback = feedbackByMessage[message.id];
+    agents
+      .filter(agent => agent.kind === 'cloud')
+      .forEach(agent => {
+        const providerId = agent.provider || agent.channel || agent.id;
+        const summary = grouped.get(providerId) ?? {
+          id: providerId,
+          label: PROVIDER_LABELS[providerId] ?? providerId.toUpperCase(),
+          status: 'offline' as AgentPresenceStatus,
+          active: 0,
+          total: 0,
+          hasKey: Boolean(apiKeys[providerId]),
+          statusCounts: {
+            online: 0,
+            offline: 0,
+            loading: 0,
+            error: 0,
+          } as Record<AgentPresenceStatus, number>,
+        };
 
-      if (currentFeedback?.hasError) {
-        const shouldClear = window.confirm('La respuesta ya está marcada como incorrecta. ¿Quieres retirar la marca?');
-        if (shouldClear) {
-          markMessageFeedback(message.id, { hasError: false });
-        }
-        return;
-      }
-
-      const reason = window.prompt('Describe el problema detectado en la respuesta', currentFeedback?.notes ?? '');
-      if (reason === null) {
-        return;
-      }
-
-      const tagsInput = window.prompt(
-        'Asigna etiquetas de seguimiento (separadas por comas)',
-        currentFeedback?.tags?.join(', ') ?? '',
-      );
-      const tags =
-        tagsInput !== null ? tagsInput.split(',').map(tag => tag.trim()).filter(Boolean) : currentFeedback?.tags;
-
-      markMessageFeedback(message.id, {
-        hasError: true,
-        notes: reason.trim() ? reason.trim() : undefined,
-        tags,
+        const presence = presenceMap.get(agent.id);
+        const status = presence?.status ?? (agent.active ? 'loading' : 'offline');
+        summary.total += 1;
+        summary.active += agent.active ? 1 : 0;
+        summary.statusCounts[status] += 1;
+        summary.hasKey = summary.hasKey || Boolean(apiKeys[providerId]);
+        grouped.set(providerId, summary);
       });
-    },
-    [feedbackByMessage, markMessageFeedback],
-  );
 
-  const handleEditAndResend = useCallback(
-    (message: ChatMessage) => {
-      const plain = toPlainText(message.content);
-      const proposal = window.prompt('Edita la respuesta antes de reenviarla al agente o revisor', plain);
-      if (proposal === null) {
-        return;
-      }
+    return Array.from(grouped.values())
+      .map(entry => {
+        const status: AgentPresenceStatus =
+          entry.statusCounts.error > 0
+            ? 'error'
+            : entry.statusCounts.online > 0
+            ? 'online'
+            : entry.statusCounts.loading > 0
+            ? 'loading'
+            : 'offline';
 
-      const trimmedProposal = proposal.trim();
-      if (!trimmedProposal) {
-        alert('La corrección no puede estar vacía.');
-        return;
-      }
+        return {
+          id: entry.id,
+          label: entry.label,
+          status,
+          active: entry.active,
+          total: entry.total,
+          hasKey: entry.hasKey,
+        };
+      })
+      .sort((a, b) => a.label.localeCompare(b.label));
+  }, [agents, apiKeys, presenceMap]);
 
-      const currentFeedback = feedbackByMessage[message.id];
-      const notes = window.prompt('Notas adicionales para contextualizar la corrección', currentFeedback?.notes ?? '') ?? '';
-      const tagsInput = window.prompt(
-        'Etiquetas asociadas (separadas por comas)',
-        currentFeedback?.tags?.join(', ') ?? '',
-      );
-      const tags = tagsInput ? tagsInput.split(',').map(tag => tag.trim()).filter(Boolean) : currentFeedback?.tags;
+  const activeModel = useMemo(() => models.find(model => model.active), [models]);
 
-      void submitCorrection(message.id, trimmedProposal, notes.trim() ? notes.trim() : undefined, tags);
-    },
-    [feedbackByMessage, submitCorrection, toPlainText],
-  );
-
-  useEffect(() => {
-    void providerSecretExists('github').then(setGithubStored).catch(() => setGithubStored(false));
-    void providerSecretExists('gitlab').then(setGitlabStored).catch(() => setGitlabStored(false));
-  }, []);
-
-  const handleSecureKeySave = useCallback(
-    async (provider: 'github' | 'gitlab', value: string) => {
-      const trimmed = value.trim();
-      await storeProviderSecret(provider, trimmed);
-      onApiKeyChange(provider, trimmed ? '__secure__' : '');
-      if (provider === 'github') {
-        setGithubStored(Boolean(trimmed));
-        setGithubInput('');
-      } else {
-        setGitlabStored(Boolean(trimmed));
-        setGitlabInput('');
-      }
-    },
-    [onApiKeyChange],
-  );
-
-  const channelStatuses = useMemo<ChannelStatusView[]>(() => {
-    const entries: ChannelStatusView[] = [];
-    const baseChannels: Array<{ id: string; fallback: string }> = [
-      { id: 'claude', fallback: 'Claude' },
-      { id: 'gpt', fallback: 'GPT' },
-      { id: 'groq', fallback: 'Groq' },
-    ];
-
-    baseChannels.forEach(({ id, fallback }) => {
-      const agent = agents.find(candidate => candidate.channel === id);
-      if (!agent) {
-        entries.push({
-          key: id,
-          label: fallback,
-          version: 'No disponible',
-          status: 'offline',
-          accent: 'rgba(255, 255, 255, 0.35)',
-          message: 'Activa el agente en la consola.',
-          active: false,
-        });
-        return;
-      }
-
-      const presenceEntry = presenceMap.get(agent.id);
-      entries.push({
-        key: id,
-        label: getAgentChannelLabel(agent),
-        version: getAgentVersionLabel(agent),
-        status: presenceEntry?.status ?? (agent.active ? 'loading' : 'offline'),
-        accent: agent.accent,
-        message: presenceEntry?.message,
-        active: agent.active,
-      });
-    });
-
-    const localAgents = agents.filter(agent => agent.kind === 'local');
-    const activeLocal = localAgents.find(agent => agent.active) ?? localAgents[0];
-    const localPresence = activeLocal ? presenceMap.get(activeLocal.id) : undefined;
-    const localStatus: AgentPresenceStatus = localPresence?.status
-      ?? (activeLocal ? (activeLocal.status === 'Cargando' ? 'loading' : 'offline') : 'offline');
-
-    entries.push({
-      key: 'jarvis',
-      label: 'Jarvis',
-      version: activeLocal ? getAgentVersionLabel(activeLocal) : 'Sin modelo activo',
-      status: localStatus,
-      accent: activeLocal?.accent ?? '#4DD0E1',
-      message: activeLocal ? localPresence?.message : 'Carga un modelo local para habilitar Jarvis.',
-      active: Boolean(activeLocal?.active),
-    });
-
-    return entries;
-  }, [agents, presenceMap]);
-
-  const usageStats = useMemo(
+  const messageStats = useMemo(
     () => {
       const userCount = messages.filter(message => message.author === 'user').length;
       const agentCount = messages.filter(message => message.author === 'agent').length;
@@ -257,439 +128,143 @@ export const SidePanel: React.FC<SidePanelProps> = ({
     [messages, pendingResponses],
   );
 
-  const dataStats = useMemo(
-    () => {
-      const configuredProviders = (['openai', 'anthropic', 'groq'] as Array<keyof ApiKeySettings>).filter(
-        provider => Boolean(apiKeys[provider]),
-      );
-      const secureTokens = (githubStored ? 1 : 0) + (gitlabStored ? 1 : 0);
-
-      return [
-        { label: 'API keys activas', value: configuredProviders.length },
-        { label: 'Tokens seguros', value: secureTokens },
-        { label: 'Correcciones', value: correctionHistory.length },
-        { label: 'Comandos rápidos', value: quickCommands.length },
-      ];
-    },
-    [apiKeys, correctionHistory, githubStored, gitlabStored, quickCommands],
-  );
-
-  const panelMode = layout.width <= ACCORDION_BREAKPOINT ? 'accordion' : 'tabs';
-
-  const sections = useMemo<PanelSectionDefinition[]>(() => {
-    const coreSections: PanelSectionDefinition[] = [
-      {
-        id: 'channels',
-        title: 'Canales conectados',
-        description: 'Estado en tiempo real de tus proveedores.',
-        content: (
-          <ul className="channel-status-list">
-            {channelStatuses.map(entry => (
-              <li key={entry.key} className={`channel-status-item ${entry.active ? 'is-active' : 'is-idle'}`}>
-                <span
-                  className={`channel-status-led ${getChannelStatusClass(entry.status)}`}
-                  style={{ background: entry.accent, color: entry.accent }}
-                  aria-hidden
-                />
-                <div className="channel-status-body">
-                  <div className="channel-status-text">
-                    <span className="channel-status-name">{entry.label}</span>
-                    {entry.version && <em className="channel-status-version">{entry.version}</em>}
-                  </div>
-                  <span className="channel-status-state">{CHANNEL_STATUS_LABELS[entry.status]}</span>
-                  {entry.message && <span className="channel-status-hint">{entry.message}</span>}
-                </div>
-              </li>
-            ))}
-          </ul>
-        ),
-      },
-      {
-        id: 'usage',
-        title: 'Estadísticas de uso',
-        description: 'Actividad general de esta sesión.',
-        content: (
-          <ul className="sidebar-metrics">
-            {usageStats.map(stat => (
-              <li key={stat.label}>
-                <span className="sidebar-metric-label">{stat.label}</span>
-                <span className="sidebar-metric-value">{stat.value}</span>
-              </li>
-            ))}
-          </ul>
-        ),
-      },
-      {
-        id: 'data',
-        title: 'Datos guardados',
-        description: 'Resumen del contenido almacenado en local.',
-        content: (
-          <ul className="sidebar-metrics">
-            {dataStats.map(stat => (
-              <li key={stat.label}>
-                <span className="sidebar-metric-label">{stat.label}</span>
-                <span className="sidebar-metric-value">{stat.value}</span>
-              </li>
-            ))}
-          </ul>
-        ),
-      },
-      {
-        id: 'credentials',
-        title: 'Credenciales',
-        description: 'Conecta tus proveedores en caliente.',
-        content: (
-          <>
-            <div className="key-field">
-              <label htmlFor="openai-key">OpenAI</label>
-              <input
-                id="openai-key"
-                type="password"
-                value={apiKeys.openai}
-                onChange={event => onApiKeyChange('openai', event.target.value)}
-                placeholder="sk-..."
-                className={!apiKeys.openai ? 'is-empty' : ''}
-              />
-            </div>
-            <div className="key-field">
-              <label htmlFor="anthropic-key">Anthropic</label>
-              <input
-                id="anthropic-key"
-                type="password"
-                value={apiKeys.anthropic}
-                onChange={event => onApiKeyChange('anthropic', event.target.value)}
-                placeholder="anthropic-..."
-                className={!apiKeys.anthropic ? 'is-empty' : ''}
-              />
-            </div>
-            <div className="key-field">
-              <label htmlFor="groq-key">Groq</label>
-              <input
-                id="groq-key"
-                type="password"
-                value={apiKeys.groq}
-                onChange={event => onApiKeyChange('groq', event.target.value)}
-                placeholder="groq-..."
-                className={!apiKeys.groq ? 'is-empty' : ''}
-              />
-            </div>
-            <div className="key-field">
-              <label htmlFor="github-key">
-                GitHub
-                {githubStored ? <span className="badge">guardado</span> : null}
-              </label>
-              <div className="secure-key-input">
-                <input
-                  id="github-key"
-                  type="password"
-                  value={githubInput}
-                  onChange={event => setGithubInput(event.target.value)}
-                  placeholder={githubStored ? 'token almacenado' : 'ghp_...'}
-                />
-                <button
-                  type="button"
-                  onClick={() => void handleSecureKeySave('github', githubInput)}
-                  disabled={!githubInput.trim() && !githubStored}
-                >
-                  {githubInput.trim() || !githubStored ? 'Guardar' : 'Eliminar'}
-                </button>
-              </div>
-            </div>
-            <div className="key-field">
-              <label htmlFor="gitlab-key">
-                GitLab
-                {gitlabStored ? <span className="badge">guardado</span> : null}
-              </label>
-              <div className="secure-key-input">
-                <input
-                  id="gitlab-key"
-                  type="password"
-                  value={gitlabInput}
-                  onChange={event => setGitlabInput(event.target.value)}
-                  placeholder={gitlabStored ? 'token almacenado' : 'glpat-...'}
-                />
-                <button
-                  type="button"
-                  onClick={() => void handleSecureKeySave('gitlab', gitlabInput)}
-                  disabled={!gitlabInput.trim() && !gitlabStored}
-                >
-                  {gitlabInput.trim() || !gitlabStored ? 'Guardar' : 'Eliminar'}
-                </button>
-              </div>
-            </div>
-          </>
-        ),
-      },
-      {
-        id: 'agents',
-        title: 'Modelos activos',
-        description: 'Activa y desactiva agentes al instante.',
-        content: (
-          <AgentPresenceList
-            agents={agents}
-            presence={presenceMap}
-            onToggleAgent={toggleAgent}
-            onUpdateRole={assignAgentRole}
-            onOpenConsole={agentId => console.log(`Abrir consola interactiva para el agente ${agentId}`)}
-            onRefreshAgent={agentId => onRefreshAgentPresence(agentId)}
-          />
-        ),
-      },
-      {
-        id: 'gallery',
-        title: 'Galería de modelos',
-        description: 'Explora variantes disponibles y activa nuevas configuraciones.',
-        content: <ModelGallery />,
-      },
-      {
-        id: 'orchestration',
-        title: 'Conversa entre agentes',
-        description: 'Visualiza cómo coordinan los modelos antes de responder.',
-        content: (
-          <AgentConversationPanel
-            traces={orchestrationTraces}
-            sharedSnapshot={sharedSnapshot}
-            agents={agents}
-            currentStrategy={coordinationStrategy}
-            onChangeStrategy={setCoordinationStrategy}
-          />
-        ),
-      },
-      {
-        id: 'quality',
-        title: 'Calidad de respuestas',
-        description: 'Evalúa incidencias y controles de calidad por agente.',
-        content: <QualityDashboard />,
-      },
-      {
-        id: 'commands',
-        title: 'Comandos frecuentes',
-        description: 'Guarda instrucciones recurrentes para dispararlas en el chat.',
-        content: (
-          <div className="command-list">
-            {quickCommands.map(command => (
-              <button key={command} type="button" className="command-item" onClick={() => appendToDraft(command)}>
-                <span>{command}</span>
-              </button>
-            ))}
-          </div>
-        ),
-      },
-      {
-        id: 'activity',
-        title: 'Actividad reciente',
-        description: 'Monitoriza cómo responden los agentes.',
-        content: (
-          <ul className="activity-feed">
-            {recentActivity.map(({ message, agent }) => {
-              if (!agent) {
-                return null;
-              }
-
-              const preview = Array.isArray(message.content)
-                ? message.content
-                    .map(part => {
-                      if (typeof part === 'string') {
-                        return part;
-                      }
-                      if (part.type === 'text') {
-                        return part.text;
-                      }
-                      return `[${part.type}]`;
-                    })
-                    .join(' · ')
-                : message.content;
-
-              const displayName = getAgentDisplayName(agent);
-              const variantLabel = agent.kind === 'local' ? getAgentVersionLabel(agent) : undefined;
-
-              return (
-                <li key={message.id} className="activity-item">
-                  <span className="activity-dot" style={{ background: agent.accent }} />
-                  <div className="activity-content">
-                    <div className="activity-title">
-                      <strong>{displayName}</strong>
-                      {variantLabel && <span className="activity-variant">{variantLabel}</span>}
-                      <span>{formatTimestamp(message.timestamp)}</span>
-                      {feedbackByMessage[message.id]?.hasError && (
-                        <span className="activity-flag">Revisión pendiente</span>
-                      )}
-                    </div>
-                    <p>{preview}</p>
-                    {feedbackByMessage[message.id]?.notes && (
-                      <p className="activity-note">{feedbackByMessage[message.id]?.notes}</p>
-                    )}
-                    <div className="activity-actions">
-                      <button type="button" className="activity-action" onClick={() => handleMarkIncorrect(message)}>
-                        {feedbackByMessage[message.id]?.hasError ? 'Desmarcar error' : 'Marcar como incorrecto'}
-                      </button>
-                      <button type="button" className="activity-action" onClick={() => handleEditAndResend(message)}>
-                        Editar y reenviar
-                      </button>
-                    </div>
-                  </div>
-                </li>
-              );
-            })}
-            {!agentResponses.length && <li className="activity-empty">Todavía no hay actividad de los agentes.</li>}
-          </ul>
-        ),
-      },
-    ];
-
-    const pluginSections = pluginSlots.map(slot => ({
-      id: `plugin-${slot.id}`,
-      title: slot.label,
-      description: `Integración proporcionada por el plugin ${slot.pluginId}.`,
-      meta: <span className="panel-plugin-origin">{slot.pluginId}</span>,
-      content: <slot.Component />,
-    }));
-
-    return [...coreSections.slice(0, 6), ...pluginSections, ...coreSections.slice(6)];
-  }, [
-    agentResponses.length,
-    agents,
-    appendToDraft,
-    apiKeys,
-    assignAgentRole,
-    channelStatuses,
-    coordinationStrategy,
-    dataStats,
-    feedbackByMessage,
-    formatTimestamp,
-    gitlabInput,
-    gitlabStored,
-    githubInput,
-    githubStored,
-    handleEditAndResend,
-    handleMarkIncorrect,
-    handleSecureKeySave,
-    onApiKeyChange,
-    onRefreshAgentPresence,
-    pluginSlots,
-    presenceMap,
-    quickCommands,
-    recentActivity,
-    setCoordinationStrategy,
-    sharedSnapshot,
-    toggleAgent,
-    usageStats,
-    orchestrationTraces,
-  ]);
-
-  useEffect(() => {
-    if (!sections.length) {
-      if (layout.activeSectionId !== null) {
-        onLayoutChange(previous => ({ ...previous, activeSectionId: null }));
-      }
-      return;
-    }
-
-    if (!layout.activeSectionId || !sections.some(section => section.id === layout.activeSectionId)) {
-      const fallback = sections[0]?.id ?? null;
-      if (fallback !== layout.activeSectionId) {
-        onLayoutChange(previous => ({ ...previous, activeSectionId: fallback }));
-      }
-    }
-  }, [layout.activeSectionId, onLayoutChange, sections]);
-
-  const handleActiveSectionChange = useCallback(
-    (sectionId: string) => {
-      if (layout.activeSectionId === sectionId) {
-        return;
-      }
-      onLayoutChange(previous => ({ ...previous, activeSectionId: sectionId }));
-    },
-    [layout.activeSectionId, onLayoutChange],
-  );
-
-  const handleToggleCollapse = useCallback(() => {
-    onLayoutChange(previous => ({ ...previous, collapsed: !previous.collapsed }));
-  }, [onLayoutChange]);
-
-  const handlePositionChange = useCallback(
-    (position: 'left' | 'right') => {
-      if (layout.position === position) {
-        return;
-      }
-      onLayoutChange(previous => ({ ...previous, position }));
-    },
-    [layout.position, onLayoutChange],
-  );
-
-  const handleWidthChange = useCallback(
-    (value: number) => {
-      const clamped = Math.min(Math.max(value, MIN_PANEL_WIDTH), MAX_PANEL_WIDTH);
-      if (layout.width === clamped) {
-        return;
-      }
-      onLayoutChange(previous => ({ ...previous, width: clamped }));
-    },
-    [layout.width, onLayoutChange],
-  );
-
-  const resolvedActiveSectionId = sections.length
-    ? sections.find(section => section.id === layout.activeSectionId)?.id ?? sections[0].id
+  const latestAgentResponse = agentResponses.length ? agentResponses[agentResponses.length - 1] : null;
+  const latestAgentSummary = latestAgentResponse
+    ? (() => {
+        const agent = latestAgentResponse.agentId
+          ? agents.find(candidate => candidate.id === latestAgentResponse.agentId)
+          : undefined;
+        if (!agent) {
+          return null;
+        }
+        return {
+          name: getAgentDisplayName(agent),
+          variant: agent.kind === 'local' ? getAgentVersionLabel(agent) : agent.provider,
+          timestamp: formatTimestamp(latestAgentResponse.timestamp),
+        };
+      })()
     : null;
 
-  const rootClassName = [
-    'controls-panel',
-    layout.collapsed ? 'is-collapsed' : 'is-expanded',
-    className,
-  ]
-    .filter(Boolean)
-    .join(' ');
+  const suggestions = useMemo<SuggestionItem[]>(() => {
+    const items: SuggestionItem[] = [];
+
+    if (pendingResponses > 0) {
+      items.push({
+        id: 'pending',
+        title: 'Revisar respuestas pendientes',
+        description: 'Hay agentes pensando todavía, actualiza su estado.',
+        action: () => void onRefreshAgentPresence(),
+      });
+    }
+
+    if (!activeModel) {
+      items.push({
+        id: 'local-model',
+        title: 'Activa un modelo local',
+        description: 'Jarvis está inactivo, gestiona los modelos en los ajustes globales.',
+        action: onOpenGlobalSettings,
+      });
+    }
+
+    if (latestAgentSummary) {
+      items.push({
+        id: 'latest-agent',
+        title: `Última respuesta de ${latestAgentSummary.name}`,
+        description: `${latestAgentSummary.variant ?? ''} · ${latestAgentSummary.timestamp}`.trim(),
+      });
+    }
+
+    if (!items.length) {
+      items.push({
+        id: 'start',
+        title: 'Lanza una nueva instrucción',
+        description: 'Combina @menciones para coordinar varios agentes en la misma orden.',
+      });
+    }
+
+    return items.slice(0, 3);
+  }, [activeModel, latestAgentSummary, onOpenGlobalSettings, onRefreshAgentPresence, pendingResponses]);
 
   return (
-    <aside
-      className={rootClassName}
-      style={style}
-      data-panel-position={layout.position}
-      data-panel-width={layout.width}
-      aria-hidden={layout.collapsed}
-    >
-      <div className="controls-panel-toolbar" role="group" aria-label="Preferencias del panel lateral">
-        <button type="button" className="panel-control" onClick={handleToggleCollapse}>
-          {layout.collapsed ? 'Mostrar panel' : 'Ocultar panel'}
-        </button>
-        <div className="panel-control-group" role="group" aria-label="Posición del panel">
-          <span className="panel-control-label">Ubicación</span>
-          <div className="panel-control-buttons">
-            <button
-              type="button"
-              className={`panel-control ${layout.position === 'left' ? 'is-active' : ''}`.trim()}
-              onClick={() => handlePositionChange('left')}
-            >
-              Izquierda
-            </button>
-            <button
-              type="button"
-              className={`panel-control ${layout.position === 'right' ? 'is-active' : ''}`.trim()}
-              onClick={() => handlePositionChange('right')}
-            >
-              Derecha
-            </button>
-          </div>
+    <div className="sidebar">
+      <section className="sidebar-section">
+        <header>
+          <h2>Proveedores</h2>
+          <p>Resumen rápido del estado de conexión.</p>
+        </header>
+        <div className="provider-grid">
+          {providerSummaries.map(provider => (
+            <article key={provider.id} className={`provider-card status-${provider.status}`}>
+              <header>
+                <span className="provider-name">{provider.label}</span>
+                <span className="provider-status">{provider.status}</span>
+              </header>
+              <div className="provider-body">
+                <span>{provider.active} activos de {provider.total}</span>
+                <span>{provider.hasKey ? 'API key configurada' : 'Configura la API key'}</span>
+              </div>
+            </article>
+          ))}
         </div>
-        <label className="panel-control panel-width-control">
-          <span className="panel-control-label">Ancho · {Math.round(layout.width)}px</span>
-          <input
-            type="range"
-            min={MIN_PANEL_WIDTH}
-            max={MAX_PANEL_WIDTH}
-            value={layout.width}
-            onChange={event => handleWidthChange(Number(event.target.value))}
-          />
-        </label>
-      </div>
-      <div className="controls-panel-content">
-        <PanelContainer
-          sections={sections}
-          mode={panelMode}
-          activeSectionId={resolvedActiveSectionId}
-          onActiveSectionChange={handleActiveSectionChange}
-        />
-      </div>
-    </aside>
+        <div className="local-model-card">
+          <div>
+            <h3>Modelo local</h3>
+            <p>{activeModel ? `${activeModel.name} listo para usar` : 'Ningún modelo activo'}</p>
+          </div>
+          <button type="button" onClick={onOpenGlobalSettings}>
+            Gestionar
+          </button>
+        </div>
+      </section>
+
+      <section className="sidebar-section">
+        <header>
+          <h2>Estadísticas</h2>
+          <p>Actividad en la sesión actual.</p>
+        </header>
+        <ul className="sidebar-stats">
+          {messageStats.map(stat => (
+            <li key={stat.label}>
+              <span className="stat-label">{stat.label}</span>
+              <span className="stat-value">{stat.value}</span>
+            </li>
+          ))}
+        </ul>
+      </section>
+
+      <section className="sidebar-section">
+        <header>
+          <h2>Sugerencias</h2>
+          <p>Acciones rápidas según la actividad.</p>
+        </header>
+        <ul className="suggestion-list">
+          {suggestions.map(item => (
+            <li key={item.id}>
+              <button type="button" onClick={item.action} disabled={!item.action}>
+                <strong>{item.title}</strong>
+                <span>{item.description}</span>
+              </button>
+            </li>
+          ))}
+        </ul>
+      </section>
+
+      <section className="sidebar-section">
+        <header>
+          <h2>Comandos rápidos</h2>
+          <p>Inserta instrucciones guardadas en el chat.</p>
+        </header>
+        <div className="command-list">
+          {quickCommands.length === 0 && <p className="command-empty">No tienes comandos guardados.</p>}
+          {quickCommands.map(command => (
+            <button key={command} type="button" onClick={() => appendToDraft(command)}>
+              {command}
+            </button>
+          ))}
+        </div>
+      </section>
+    </div>
   );
 };
+
+export default SidePanel;

--- a/src/components/common/OverlayModal.css
+++ b/src/components/common/OverlayModal.css
@@ -1,0 +1,59 @@
+.overlay-modal {
+  position: fixed;
+  inset: 0;
+  z-index: 2000;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.overlay-modal__backdrop {
+  position: absolute;
+  inset: 0;
+  background: rgba(0, 0, 0, 0.6);
+  backdrop-filter: blur(4px);
+}
+
+.overlay-modal__panel {
+  position: relative;
+  z-index: 1;
+  width: min(720px, 90vw);
+  max-height: 90vh;
+  background: rgba(8, 8, 8, 0.95);
+  border-radius: 20px;
+  border: 1px solid rgba(255, 255, 255, 0.12);
+  box-shadow: 0 30px 60px rgba(0, 0, 0, 0.45);
+  display: flex;
+  flex-direction: column;
+  overflow: hidden;
+}
+
+.overlay-modal__header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 18px 24px;
+  border-bottom: 1px solid rgba(255, 255, 255, 0.08);
+}
+
+.overlay-modal__header h2 {
+  font-size: 18px;
+  font-weight: 600;
+}
+
+.overlay-modal__header button {
+  border: none;
+  background: rgba(255, 255, 255, 0.08);
+  color: #fff;
+  border-radius: 50%;
+  width: 32px;
+  height: 32px;
+  cursor: pointer;
+  font-size: 18px;
+}
+
+.overlay-modal__content {
+  padding: 24px;
+  overflow-y: auto;
+  max-height: calc(90vh - 72px);
+}

--- a/src/components/common/OverlayModal.tsx
+++ b/src/components/common/OverlayModal.tsx
@@ -1,0 +1,31 @@
+import React from 'react';
+import './OverlayModal.css';
+
+interface OverlayModalProps {
+  title: string;
+  isOpen: boolean;
+  onClose: () => void;
+  children: React.ReactNode;
+  width?: number;
+}
+
+export const OverlayModal: React.FC<OverlayModalProps> = ({ title, isOpen, onClose, children, width }) => {
+  if (!isOpen) {
+    return null;
+  }
+
+  return (
+    <div className="overlay-modal" role="dialog" aria-modal="true" aria-labelledby="modal-title">
+      <div className="overlay-modal__backdrop" onClick={onClose} />
+      <div className="overlay-modal__panel" style={width ? { width } : undefined}>
+        <header className="overlay-modal__header">
+          <h2 id="modal-title">{title}</h2>
+          <button type="button" onClick={onClose} aria-label="Cerrar">×</button>
+        </header>
+        <div className="overlay-modal__content">{children}</div>
+      </div>
+    </div>
+  );
+};
+
+export default OverlayModal;

--- a/src/components/settings/GlobalSettingsDialog.css
+++ b/src/components/settings/GlobalSettingsDialog.css
@@ -1,0 +1,167 @@
+.global-settings-dialog {
+  display: grid;
+  grid-template-columns: 220px 1fr;
+  gap: 24px;
+  min-height: 60vh;
+}
+
+.global-settings-tabs {
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+}
+
+.global-settings-tabs button {
+  border: none;
+  border-radius: 14px;
+  padding: 12px 16px;
+  text-align: left;
+  background: rgba(255, 255, 255, 0.05);
+  color: rgba(255, 255, 255, 0.75);
+  cursor: pointer;
+  font-size: 14px;
+  transition: background 0.2s ease, color 0.2s ease;
+}
+
+.global-settings-tabs button.is-active {
+  background: linear-gradient(135deg, rgba(142, 141, 255, 0.6), rgba(255, 183, 77, 0.6));
+  color: #fff;
+}
+
+.global-settings-content {
+  display: flex;
+  flex-direction: column;
+  gap: 24px;
+  overflow-y: auto;
+  padding-right: 8px;
+}
+
+.settings-section {
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+}
+
+.settings-section h3 {
+  font-size: 18px;
+  font-weight: 600;
+}
+
+.settings-section p {
+  font-size: 13px;
+  color: rgba(255, 255, 255, 0.7);
+}
+
+.provider-form {
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+}
+
+.provider-form label {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+  font-size: 13px;
+}
+
+.provider-form input {
+  border: 1px solid rgba(255, 255, 255, 0.12);
+  border-radius: 12px;
+  padding: 10px 14px;
+  background: rgba(0, 0, 0, 0.4);
+  color: #fff;
+}
+
+.secure-provider {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+
+.secure-provider label {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+}
+
+.secure-input {
+  display: flex;
+  gap: 8px;
+}
+
+.secure-input input {
+  flex: 1 1 auto;
+  border-radius: 12px;
+  border: 1px solid rgba(255, 255, 255, 0.12);
+  padding: 10px 14px;
+  background: rgba(0, 0, 0, 0.4);
+  color: #fff;
+}
+
+.secure-input button {
+  border: none;
+  border-radius: 12px;
+  padding: 10px 14px;
+  background: rgba(142, 141, 255, 0.5);
+  color: #fff;
+  cursor: pointer;
+  font-size: 12px;
+  letter-spacing: 0.6px;
+  text-transform: uppercase;
+}
+
+.settings-error {
+  color: #ff8a65;
+  font-size: 12px;
+}
+
+.preference-card {
+  padding: 16px;
+  border-radius: 16px;
+  background: rgba(255, 255, 255, 0.04);
+  border: 1px solid rgba(255, 255, 255, 0.08);
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+}
+
+.preference-card span {
+  font-size: 14px;
+  font-weight: 600;
+}
+
+.preference-card p {
+  font-size: 12px;
+  color: rgba(255, 255, 255, 0.65);
+}
+
+.preference-options {
+  display: flex;
+  gap: 16px;
+  font-size: 13px;
+}
+
+.badge {
+  border-radius: 999px;
+  padding: 2px 8px;
+  background: rgba(255, 255, 255, 0.12);
+  font-size: 10px;
+  letter-spacing: 0.6px;
+  text-transform: uppercase;
+}
+
+@media (max-width: 960px) {
+  .global-settings-dialog {
+    grid-template-columns: 1fr;
+  }
+
+  .global-settings-tabs {
+    flex-direction: row;
+    flex-wrap: wrap;
+  }
+
+  .global-settings-tabs button {
+    flex: 1 1 calc(33% - 8px);
+  }
+}

--- a/src/components/settings/GlobalSettingsDialog.tsx
+++ b/src/components/settings/GlobalSettingsDialog.tsx
@@ -1,0 +1,262 @@
+import React, { useEffect, useMemo, useState } from 'react';
+import { ApiKeySettings, GlobalSettings } from '../../types/globalSettings';
+import { providerSecretExists, storeProviderSecret } from '../../utils/secrets';
+import { ModelGallery } from '../models/ModelGallery';
+import { OverlayModal } from '../common/OverlayModal';
+import './GlobalSettingsDialog.css';
+
+interface GlobalSettingsDialogProps {
+  isOpen: boolean;
+  onClose: () => void;
+  settings: GlobalSettings;
+  apiKeys: ApiKeySettings;
+  onApiKeyChange: (provider: string, value: string) => void;
+  onSettingsChange: (updater: (previous: GlobalSettings) => GlobalSettings) => void;
+}
+
+type SettingsTab = 'providers' | 'models' | 'preferences';
+
+const PROVIDER_FIELDS: Array<{ id: keyof ApiKeySettings; label: string; placeholder: string }> = [
+  { id: 'openai', label: 'OpenAI', placeholder: 'sk-...' },
+  { id: 'anthropic', label: 'Anthropic', placeholder: 'anthropic-...' },
+  { id: 'groq', label: 'Groq', placeholder: 'groq-...' },
+];
+
+export const GlobalSettingsDialog: React.FC<GlobalSettingsDialogProps> = ({
+  isOpen,
+  onClose,
+  settings,
+  apiKeys,
+  onApiKeyChange,
+  onSettingsChange,
+}) => {
+  const [activeTab, setActiveTab] = useState<SettingsTab>('providers');
+  const [githubStored, setGithubStored] = useState(false);
+  const [gitlabStored, setGitlabStored] = useState(false);
+  const [githubInput, setGithubInput] = useState('');
+  const [gitlabInput, setGitlabInput] = useState('');
+  const [secretError, setSecretError] = useState<string | null>(null);
+
+  useEffect(() => {
+    if (!isOpen) {
+      return;
+    }
+
+    const checkSecrets = async () => {
+      try {
+        const storedGithub = await providerSecretExists('github');
+        setGithubStored(storedGithub);
+      } catch {
+        setGithubStored(false);
+      }
+
+      try {
+        const storedGitlab = await providerSecretExists('gitlab');
+        setGitlabStored(storedGitlab);
+      } catch {
+        setGitlabStored(false);
+      }
+    };
+
+    void checkSecrets();
+  }, [isOpen]);
+
+  const handleSecretSave = async (provider: 'github' | 'gitlab', value: string) => {
+    try {
+      setSecretError(null);
+      await storeProviderSecret(provider, value.trim());
+      if (provider === 'github') {
+        setGithubStored(Boolean(value.trim()));
+        setGithubInput('');
+      } else {
+        setGitlabStored(Boolean(value.trim()));
+        setGitlabInput('');
+      }
+      onApiKeyChange(provider, value.trim() ? '__secure__' : '');
+    } catch (error) {
+      console.error('Error storing secret', error);
+      setSecretError('No se pudo guardar el token seguro.');
+    }
+  };
+
+  useEffect(() => {
+    if (!isOpen) {
+      return;
+    }
+    setActiveTab('providers');
+  }, [isOpen]);
+
+  const sidePanelPosition = settings.workspacePreferences.sidePanel.position;
+
+  const handlePositionChange = (position: 'left' | 'right') => {
+    if (position === sidePanelPosition) {
+      return;
+    }
+    onSettingsChange(prev => ({
+      ...prev,
+      workspacePreferences: {
+        ...prev.workspacePreferences,
+        sidePanel: {
+          ...prev.workspacePreferences.sidePanel,
+          position,
+        },
+      },
+    }));
+  };
+
+  const dataLocationSummary = useMemo(() => {
+    const { dataLocation } = settings;
+    if (dataLocation.useCustomPath && dataLocation.customPath) {
+      return `Carpeta personalizada: ${dataLocation.customPath}`;
+    }
+    return dataLocation.defaultPath
+      ? `Usando la ruta predeterminada (${dataLocation.defaultPath})`
+      : 'Usando la ruta predeterminada del sistema';
+  }, [settings]);
+
+  return (
+    <OverlayModal title="Ajustes globales" isOpen={isOpen} onClose={onClose} width={880}>
+      <div className="global-settings-dialog">
+        <nav className="global-settings-tabs" aria-label="Secciones de ajustes">
+          <button
+            type="button"
+            className={activeTab === 'providers' ? 'is-active' : ''}
+            onClick={() => setActiveTab('providers')}
+          >
+            🔑 Proveedores
+          </button>
+          <button
+            type="button"
+            className={activeTab === 'models' ? 'is-active' : ''}
+            onClick={() => setActiveTab('models')}
+          >
+            💾 Modelos locales
+          </button>
+          <button
+            type="button"
+            className={activeTab === 'preferences' ? 'is-active' : ''}
+            onClick={() => setActiveTab('preferences')}
+          >
+            ⚙️ Preferencias
+          </button>
+        </nav>
+
+        <div className="global-settings-content">
+          {activeTab === 'providers' && (
+            <div className="settings-section">
+              <h3>Conecta proveedores</h3>
+              <p>Guarda tus credenciales para habilitar canales en caliente.</p>
+              <div className="provider-form">
+                {PROVIDER_FIELDS.map(field => (
+                  <label key={field.id}>
+                    <span>{field.label}</span>
+                    <input
+                      type="password"
+                      value={apiKeys[field.id] ?? ''}
+                      placeholder={field.placeholder}
+                      onChange={event => onApiKeyChange(field.id, event.target.value)}
+                    />
+                  </label>
+                ))}
+
+                <div className="secure-provider">
+                  <label htmlFor="github-secret">
+                    GitHub <span className="badge">{githubStored ? 'guardado' : 'pendiente'}</span>
+                  </label>
+                  <div className="secure-input">
+                    <input
+                      id="github-secret"
+                      type="password"
+                      placeholder={githubStored ? 'token almacenado' : 'ghp_...'}
+                      value={githubInput}
+                      onChange={event => setGithubInput(event.target.value)}
+                    />
+                    <button
+                      type="button"
+                      onClick={() => void handleSecretSave('github', githubInput)}
+                      disabled={!githubInput.trim() && !githubStored}
+                    >
+                      {githubInput.trim() || !githubStored ? 'Guardar' : 'Eliminar'}
+                    </button>
+                  </div>
+                </div>
+
+                <div className="secure-provider">
+                  <label htmlFor="gitlab-secret">
+                    GitLab <span className="badge">{gitlabStored ? 'guardado' : 'pendiente'}</span>
+                  </label>
+                  <div className="secure-input">
+                    <input
+                      id="gitlab-secret"
+                      type="password"
+                      placeholder={gitlabStored ? 'token almacenado' : 'glpat-...'}
+                      value={gitlabInput}
+                      onChange={event => setGitlabInput(event.target.value)}
+                    />
+                    <button
+                      type="button"
+                      onClick={() => void handleSecretSave('gitlab', gitlabInput)}
+                      disabled={!gitlabInput.trim() && !gitlabStored}
+                    >
+                      {gitlabInput.trim() || !gitlabStored ? 'Guardar' : 'Eliminar'}
+                    </button>
+                  </div>
+                </div>
+
+                {secretError && <p className="settings-error">{secretError}</p>}
+              </div>
+            </div>
+          )}
+
+          {activeTab === 'models' && (
+            <div className="settings-section">
+              <h3>Modelos locales</h3>
+              <p>Descarga y activa modelos compatibles con la orquestación local.</p>
+              <ModelGallery />
+            </div>
+          )}
+
+          {activeTab === 'preferences' && (
+            <div className="settings-section">
+              <h3>Preferencias generales</h3>
+              <p>Personaliza la interfaz del estudio y revisa la configuración local.</p>
+
+              <div className="preference-card">
+                <span>Posición del panel lateral</span>
+                <div className="preference-options">
+                  <label>
+                    <input
+                      type="radio"
+                      name="sidebar-position"
+                      value="left"
+                      checked={sidePanelPosition === 'left'}
+                      onChange={() => handlePositionChange('left')}
+                    />
+                    Izquierda
+                  </label>
+                  <label>
+                    <input
+                      type="radio"
+                      name="sidebar-position"
+                      value="right"
+                      checked={sidePanelPosition === 'right'}
+                      onChange={() => handlePositionChange('right')}
+                    />
+                    Derecha
+                  </label>
+                </div>
+              </div>
+
+              <div className="preference-card">
+                <span>Ubicación de datos</span>
+                <p>{dataLocationSummary}</p>
+              </div>
+            </div>
+          )}
+        </div>
+      </div>
+    </OverlayModal>
+  );
+};
+
+export default GlobalSettingsDialog;

--- a/src/components/settings/McpSummary.css
+++ b/src/components/settings/McpSummary.css
@@ -1,0 +1,85 @@
+.mcp-summary,
+.mcp-summary__empty {
+  font-size: 13px;
+  color: rgba(255, 255, 255, 0.75);
+}
+
+.mcp-summary {
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+}
+
+.mcp-summary ul {
+  list-style: none;
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+}
+
+.mcp-summary li {
+  padding: 14px;
+  border-radius: 14px;
+  background: rgba(255, 255, 255, 0.04);
+  border: 1px solid rgba(255, 255, 255, 0.08);
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+}
+
+.mcp-summary li header {
+  display: flex;
+  justify-content: space-between;
+  align-items: flex-start;
+  gap: 12px;
+}
+
+.mcp-summary li header strong {
+  font-size: 14px;
+  display: block;
+}
+
+.mcp-summary li header span {
+  font-size: 12px;
+  color: rgba(255, 255, 255, 0.6);
+}
+
+.badge {
+  border-radius: 999px;
+  padding: 4px 10px;
+  border: 1px solid rgba(255, 255, 255, 0.18);
+  text-transform: uppercase;
+  font-size: 10px;
+  letter-spacing: 0.6px;
+  color: rgba(255, 255, 255, 0.7);
+}
+
+.badge-active {
+  background: rgba(102, 255, 102, 0.15);
+  border-color: rgba(102, 255, 102, 0.5);
+  color: #66ff66;
+}
+
+.mcp-summary__endpoints {
+  list-style: none;
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+
+.mcp-summary__endpoints li {
+  display: flex;
+  gap: 10px;
+  font-size: 12px;
+  align-items: baseline;
+}
+
+.endpoint-transport {
+  font-weight: 600;
+  color: rgba(255, 255, 255, 0.75);
+}
+
+.endpoint-url {
+  color: rgba(255, 255, 255, 0.6);
+  word-break: break-word;
+}

--- a/src/components/settings/McpSummary.tsx
+++ b/src/components/settings/McpSummary.tsx
@@ -1,0 +1,46 @@
+import React from 'react';
+import { GlobalSettings } from '../../types/globalSettings';
+import './McpSummary.css';
+
+interface McpSummaryProps {
+  settings: GlobalSettings;
+}
+
+export const McpSummary: React.FC<McpSummaryProps> = ({ settings }) => {
+  const { mcpProfiles } = settings;
+
+  if (!mcpProfiles.length) {
+    return <p className="mcp-summary__empty">No tienes perfiles MCP configurados todavía.</p>;
+  }
+
+  return (
+    <div className="mcp-summary">
+      <p>Gestiona conexiones MCP y consulta rápidamente sus endpoints.</p>
+      <ul>
+        {mcpProfiles.map(profile => (
+          <li key={profile.id}>
+            <header>
+              <div>
+                <strong>{profile.label}</strong>
+                {profile.description && <span>{profile.description}</span>}
+              </div>
+              <span className={profile.autoConnect ? 'badge badge-active' : 'badge'}>
+                {profile.autoConnect ? 'Auto-connect' : 'Manual'}
+              </span>
+            </header>
+            <ul className="mcp-summary__endpoints">
+              {profile.endpoints.map(endpoint => (
+                <li key={endpoint.id}>
+                  <span className="endpoint-transport">{endpoint.transport.toUpperCase()}</span>
+                  <span className="endpoint-url">{endpoint.url}</span>
+                </li>
+              ))}
+            </ul>
+          </li>
+        ))}
+      </ul>
+    </div>
+  );
+};
+
+export default McpSummary;

--- a/src/components/settings/PluginSummary.css
+++ b/src/components/settings/PluginSummary.css
@@ -1,0 +1,62 @@
+.plugin-summary {
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+}
+
+.plugin-summary > p {
+  font-size: 13px;
+  color: rgba(255, 255, 255, 0.7);
+}
+
+.plugin-summary ul {
+  list-style: none;
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+}
+
+.plugin-summary li {
+  padding: 14px;
+  border-radius: 14px;
+  background: rgba(255, 255, 255, 0.04);
+  border: 1px solid rgba(255, 255, 255, 0.08);
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+
+.plugin-summary li header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+}
+
+.plugin-summary li header strong {
+  display: block;
+  font-size: 14px;
+}
+
+.plugin-summary li header span {
+  font-size: 12px;
+  color: rgba(255, 255, 255, 0.6);
+}
+
+.plugin-summary li header button,
+.plugin-summary > button {
+  border: none;
+  border-radius: 999px;
+  padding: 6px 14px;
+  background: rgba(142, 141, 255, 0.45);
+  color: #fff;
+  cursor: pointer;
+  font-size: 12px;
+  letter-spacing: 0.6px;
+  text-transform: uppercase;
+}
+
+.plugin-summary li p {
+  font-size: 12px;
+  color: rgba(255, 255, 255, 0.7);
+}

--- a/src/components/settings/PluginSummary.tsx
+++ b/src/components/settings/PluginSummary.tsx
@@ -1,0 +1,77 @@
+import React from 'react';
+import { GlobalSettings } from '../../types/globalSettings';
+import { usePluginHost } from '../../core/plugins/PluginHostProvider';
+import './PluginSummary.css';
+
+interface PluginSummaryProps {
+  settings: GlobalSettings;
+  onSettingsChange: (updater: (prev: GlobalSettings) => GlobalSettings) => void;
+}
+
+export const PluginSummary: React.FC<PluginSummaryProps> = ({ settings, onSettingsChange }) => {
+  const { plugins, refresh } = usePluginHost();
+
+  const handleToggle = (pluginId: string, enabled: boolean) => {
+    onSettingsChange(prev => {
+      const enabledSet = new Set(prev.enabledPlugins);
+      if (enabled) {
+        enabledSet.add(pluginId);
+      } else {
+        enabledSet.delete(pluginId);
+      }
+
+      const pluginSettings = {
+        ...prev.pluginSettings,
+        [pluginId]: {
+          ...(prev.pluginSettings[pluginId] ?? { credentials: {} }),
+          enabled,
+        },
+      };
+
+      return {
+        ...prev,
+        enabledPlugins: Array.from(enabledSet),
+        pluginSettings,
+      };
+    });
+  };
+
+  if (!plugins.length) {
+    return (
+      <div className="plugin-summary">
+        <p>No se han detectado plugins instalados.</p>
+        <button type="button" onClick={() => void refresh()}>
+          Volver a buscar
+        </button>
+      </div>
+    );
+  }
+
+  return (
+    <div className="plugin-summary">
+      <p>Activa o desactiva rápidamente los plugins detectados.</p>
+      <ul>
+        {plugins.map(entry => {
+          const { manifest, pluginId } = entry;
+          const enabled = settings.enabledPlugins.includes(pluginId);
+          return (
+            <li key={pluginId}>
+              <header>
+                <div>
+                  <strong>{manifest.name}</strong>
+                  <span>{manifest.version}</span>
+                </div>
+                <button type="button" onClick={() => handleToggle(pluginId, !enabled)}>
+                  {enabled ? 'Desactivar' : 'Activar'}
+                </button>
+              </header>
+              {manifest.description && <p>{manifest.description}</p>}
+            </li>
+          );
+        })}
+      </ul>
+    </div>
+  );
+};
+
+export default PluginSummary;


### PR DESCRIPTION
## Summary
- compact the chat header with icon controls and support switching the sidebar between left and right positions
- rebuild the chat workspace to maximise the feed, composer, and provide an always-visible 80/20 layout with a fixed sidebar
- move API keys and local model management into a new global settings modal and add supporting overlays for plugins and MCP profiles

## Testing
- npm run test

------
https://chatgpt.com/codex/tasks/task_e_68cec8a09fc883339f0198be983c2f4f