### PR TITLE
Ajusta reparto de mensajes y panel lateral

### DIFF
--- a/src/components/chat/ChatWorkspace.tsx
+++ b/src/components/chat/ChatWorkspace.tsx
@@ -225,7 +225,7 @@ export const ChatWorkspace: React.FC<ChatWorkspaceProps> = ({ actorFilter }) => 
           </div>
           <div className="composer-toolbar">
             <div className="composer-hints">
-              <span>Usa @ para mencionar modelos concretos</span>
+              <span>Inicia la línea con «nombre:» o «nombre,» para dirigirla a un proveedor</span>
               {lastUserMessage && (
                 <span className="composer-last">Último mensaje a las {formatTimestamp(lastUserMessage.timestamp)}</span>
               )}
@@ -243,7 +243,7 @@ export const ChatWorkspace: React.FC<ChatWorkspaceProps> = ({ actorFilter }) => 
                 onClick={sendMessage}
                 disabled={!draft.trim() && composerAttachments.length === 0}
               >
-                Enviar a {activeAgents.length || 'ningún'} agente{activeAgents.length === 1 ? '' : 's'}
+                Enviar
               </button>
             </div>
           </div>


### PR DESCRIPTION
## Summary
- dirige los mensajes sin menciones explícitas al agente local Jarvis y endurece el análisis de menciones para proveedores
- actualiza las pistas del compositor y el texto del botón de envío para reflejar el nuevo formato de instrucciones
- muestra en el panel lateral solo los proveedores configurados en los ajustes globales

## Testing
- `npx vitest run --reporter=basic --poolOptions.threads.maxWorkers=1` *(falla por error del worker tras ejecutar la batería; consultar registros adjuntos)*

------
https://chatgpt.com/codex/tasks/task_e_68cecd5677e88333bbadae4135dbd468