### PR TITLE
Simplify chat feed header and layout

### DIFF
--- a/src/components/chat/ChatInterface.css
+++ b/src/components/chat/ChatInterface.css
@@ -492,16 +492,22 @@
 .chat-feed {
   display: flex;
   flex-direction: column;
+  flex: 1 1 auto;
   min-height: 0;
+  padding: 0;
+  border-radius: 12px;
+  border: 1px solid rgba(255, 255, 255, 0.04);
+  background: rgba(10, 10, 10, 0.55);
 }
 
 .message-feed {
-  flex: 1;
+  flex: 1 1 auto;
+  min-height: 0;
   overflow-y: auto;
   display: flex;
   flex-direction: column;
-  gap: var(--chat-vertical-gap);
-  padding-right: clamp(8px, 2vw, 18px);
+  gap: calc(var(--chat-vertical-gap) * 0.85);
+  padding: 16px 20px 20px;
 }
 
 .message-feed-empty {
@@ -1960,90 +1966,31 @@
 }
 
 .chat-feed-header {
-  display: flex;
-  align-items: center;
-  justify-content: space-between;
-  gap: 24px;
-}
-
-.chat-feed-info h1 {
-  font-size: 22px;
+  padding: 6px 10px;
   margin-bottom: 6px;
-}
-
-.chat-feed-info p {
   font-size: 13px;
-  color: rgba(255, 255, 255, 0.65);
-}
-
-.chat-feed-tools {
-  display: flex;
-  align-items: center;
-  gap: 16px;
-}
-
-.chat-density-toggle {
-  display: inline-flex;
-  border-radius: 999px;
-  background: rgba(255, 255, 255, 0.05);
-  border: 1px solid rgba(255, 255, 255, 0.08);
-  overflow: hidden;
-}
-
-.chat-density-toggle button {
-  border: none;
-  background: transparent;
-  color: rgba(255, 255, 255, 0.8);
-  padding: 6px 14px;
-  font-size: 12px;
-  cursor: pointer;
-}
-
-.chat-density-toggle button.is-active {
-  background: rgba(142, 141, 255, 0.45);
-  color: #fff;
-}
-
-.chat-session-metrics {
-  display: inline-flex;
-  align-items: center;
-  gap: 10px;
-}
-
-.metric-pill {
-  display: flex;
-  flex-direction: column;
-  gap: 4px;
-  padding: 6px 12px;
-  border-radius: 10px;
-  background: rgba(255, 255, 255, 0.05);
-  border: 1px solid rgba(255, 255, 255, 0.08);
-}
-
-.metric-pill.metric-warning {
-  border-color: rgba(255, 148, 77, 0.6);
-  background: rgba(255, 148, 77, 0.18);
+  color: rgba(255, 255, 255, 0.7);
+  border-radius: 8px;
+  background: rgba(10, 10, 10, 0.45);
 }
 
 .chat-feed {
   flex: 1 1 auto;
-  overflow-y: auto;
-  padding: 0 4px;
-  border-radius: 18px;
-  background: rgba(10, 10, 10, 0.75);
-  border: 1px solid rgba(255, 255, 255, 0.05);
+  overflow: hidden;
+  padding: 0;
+  border-radius: 12px;
+  background: rgba(10, 10, 10, 0.55);
+  border: 1px solid rgba(255, 255, 255, 0.04);
 }
 
 .message-feed {
   display: flex;
   flex-direction: column;
-  gap: 16px;
-  padding: 24px;
-  min-height: 100%;
-}
-
-.message-feed.chat-density-compact {
-  gap: 10px;
+  gap: 14px;
+  padding: 16px 20px 20px;
+  min-height: 0;
+  flex: 1 1 auto;
+  overflow-y: auto;
 }
 
 .message-feed-empty {
@@ -2210,12 +2157,7 @@
   }
 
   .chat-feed-header {
-    flex-direction: column;
-    align-items: flex-start;
-  }
-
-  .chat-feed-tools {
     width: 100%;
-    justify-content: space-between;
+    text-align: left;
   }
 }

--- a/src/components/chat/ChatWorkspace.tsx
+++ b/src/components/chat/ChatWorkspace.tsx
@@ -1,4 +1,4 @@
-import React, { useCallback, useMemo, useState } from 'react';
+import React, { useCallback, useMemo } from 'react';
 import { useAgents } from '../../core/agents/AgentContext';
 import { useMessages } from '../../core/messages/MessageContext';
 import { AttachmentPicker } from './composer/AttachmentPicker';
@@ -13,7 +13,6 @@ interface ChatWorkspaceProps {
 }
 
 export const ChatWorkspace: React.FC<ChatWorkspaceProps> = ({ actorFilter }) => {
-  const [density, setDensity] = useState<'standard' | 'compact'>('standard');
   const { activeAgents, agentMap } = useAgents();
   const {
     messages,
@@ -28,7 +27,6 @@ export const ChatWorkspace: React.FC<ChatWorkspaceProps> = ({ actorFilter }) => 
     removeTranscription,
     composerModalities,
     sendMessage,
-    pendingResponses,
     lastUserMessage,
     quickCommands,
     formatTimestamp,
@@ -101,47 +99,19 @@ export const ChatWorkspace: React.FC<ChatWorkspaceProps> = ({ actorFilter }) => 
     return publicMessages;
   }, [actorFilter, agentMap, publicMessages]);
 
+  const activeAgentsStatus = useMemo(() => {
+    const base = `${activeAgents.length} agente${activeAgents.length === 1 ? '' : 's'}`;
+    return `${base} coordinando la conversación.`;
+  }, [activeAgents.length]);
+
   return (
-    <div className={`chat-workspace chat-density-${density}`}>
-      <div className="chat-feed-header">
-        <div className="chat-feed-info">
-          <h1>Control Hub</h1>
-          <p>
-            {activeAgents.length} agente{activeAgents.length === 1 ? '' : 's'} coordinando la conversación.
-          </p>
-        </div>
-        <div className="chat-feed-tools">
-          <div className="chat-density-toggle" role="group" aria-label="Densidad del feed">
-            <button
-              type="button"
-              className={density === 'standard' ? 'is-active' : ''}
-              onClick={() => setDensity('standard')}
-            >
-              Estándar
-            </button>
-            <button
-              type="button"
-              className={density === 'compact' ? 'is-active' : ''}
-              onClick={() => setDensity('compact')}
-            >
-              Compacta
-            </button>
-          </div>
-          <div className="chat-session-metrics" aria-label="Estado de la conversación">
-            <span className="metric-pill">
-              <span className="metric-label">Mensajes</span>
-              <span className="metric-value">{messages.length}</span>
-            </span>
-            <span className={`metric-pill ${pendingResponses ? 'metric-warning' : ''}`}>
-              <span className="metric-label">Pendientes</span>
-              <span className="metric-value">{pendingResponses}</span>
-            </span>
-          </div>
-        </div>
+    <div className="chat-workspace">
+      <div className="chat-feed-header" role="status" aria-live="polite">
+        {activeAgentsStatus}
       </div>
 
       <section className="chat-feed" aria-label="Historial de mensajes">
-        <div className={`message-feed chat-density-${density}`}>
+        <div className="message-feed">
           {filteredMessages.length === 0 ? (
             <div className="message-feed-empty">No hay mensajes para el filtro seleccionado.</div>
           ) : (


### PR DESCRIPTION
## Summary
- replace the chat feed header with a lightweight status message and remove unused density handling
- tighten chat feed and message feed styling to minimize padding while keeping accessibility metadata intact
- ensure the workspace feed flexes to occupy available height without blank space

## Testing
- npm test -- --run

------
https://chatgpt.com/codex/tasks/task_e_68ced3f561c083338a7f95e16ec44987