### PR TITLE
Refine chat composer layout and controls

### DIFF
--- a/src/components/chat/ChatInterface.css
+++ b/src/components/chat/ChatInterface.css
@@ -1941,6 +1941,28 @@
   background: rgba(142, 141, 255, 0.35);
 }
 
+.icon-button:disabled {
+  opacity: 0.45;
+  cursor: not-allowed;
+  transform: none;
+}
+
+.icon-button.compact {
+  width: 30px;
+  height: 30px;
+  border-radius: 10px;
+  font-size: 14px;
+}
+
+.icon-button.subtle {
+  background: rgba(255, 255, 255, 0.06);
+  color: rgba(255, 255, 255, 0.85);
+}
+
+.icon-button.subtle:hover {
+  background: rgba(255, 255, 255, 0.12);
+}
+
 .filter-pill select {
   border: none;
   border-radius: 999px;
@@ -2003,76 +2025,69 @@
 .chat-composer-area {
   display: flex;
   flex-direction: column;
-  gap: 16px;
-  padding: 20px;
-  border-radius: 18px;
-  background: rgba(12, 12, 12, 0.85);
-  border: 1px solid rgba(255, 255, 255, 0.06);
-}
-
-.chat-suggestions {
-  display: flex;
-  align-items: center;
-  gap: 10px;
-}
-
-.suggestions-label {
-  font-size: 12px;
-  text-transform: uppercase;
-  letter-spacing: 0.6px;
-  color: rgba(255, 255, 255, 0.55);
-}
-
-.suggestion-chip {
-  border: none;
-  border-radius: 999px;
-  padding: 6px 12px;
-  background: rgba(255, 255, 255, 0.08);
-  color: #fff;
-  cursor: pointer;
-  font-size: 12px;
+  gap: 12px;
+  padding: 12px;
+  border-radius: 14px;
+  background: rgba(12, 12, 12, 0.82);
+  border: 1px solid rgba(255, 255, 255, 0.05);
 }
 
 .chat-composer {
   display: flex;
   flex-direction: column;
-  gap: 16px;
+  gap: 8px;
 }
 
-.chat-input {
-  width: 100%;
-  border: 1px solid rgba(255, 255, 255, 0.12);
-  border-radius: 16px;
-  padding: 16px;
-  min-height: 96px;
-  resize: vertical;
-  background: rgba(0, 0, 0, 0.4);
-  color: #fff;
-  font-size: 14px;
-}
-
-.composer-extensions {
+.composer-header {
   display: flex;
+  flex-direction: column;
+  gap: 6px;
+}
+
+.chat-suggestions {
+  display: flex;
+  align-items: center;
   flex-wrap: wrap;
-  gap: 16px;
-  align-items: flex-start;
+  gap: 6px;
+  row-gap: 4px;
+}
+
+.suggestions-label {
+  font-size: 11px;
+  text-transform: uppercase;
+  letter-spacing: 0.5px;
+  color: rgba(255, 255, 255, 0.55);
+}
+
+.suggestion-chip {
+  border: 1px solid rgba(255, 255, 255, 0.08);
+  border-radius: 999px;
+  padding: 4px 10px;
+  background: rgba(255, 255, 255, 0.05);
+  color: #fff;
+  cursor: pointer;
+  font-size: 11px;
+}
+
+.suggestion-chip:hover {
+  background: rgba(255, 183, 77, 0.16);
+  border-color: rgba(255, 183, 77, 0.35);
 }
 
 .composer-transcriptions {
-  flex: 1 1 100%;
   display: flex;
-  flex-direction: column;
-  gap: 8px;
+  flex-wrap: wrap;
+  gap: 6px;
 }
 
 .transcription-preview {
   display: flex;
   align-items: center;
-  gap: 10px;
-  padding: 8px 10px;
-  border-radius: 10px;
+  gap: 6px;
+  padding: 4px 8px;
+  border-radius: 8px;
   background: rgba(255, 255, 255, 0.05);
-  font-size: 12px;
+  font-size: 11px;
 }
 
 .transcription-label {
@@ -2086,34 +2101,46 @@
   color: rgba(255, 255, 255, 0.75);
 }
 
-.attachment-remove {
-  border: none;
-  background: rgba(255, 255, 255, 0.12);
+.composer-extensions {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 8px;
+}
+
+.chat-input {
+  width: 100%;
+  border: 1px solid rgba(255, 255, 255, 0.1);
+  border-radius: 12px;
+  padding: 12px;
+  min-height: 72px;
+  resize: vertical;
+  background: rgba(0, 0, 0, 0.55);
   color: #fff;
-  border-radius: 50%;
-  width: 24px;
-  height: 24px;
-  cursor: pointer;
+  font-size: 14px;
+  line-height: 1.5;
 }
 
 .composer-toolbar {
   display: flex;
-  flex-direction: column;
-  gap: 12px;
+  align-items: flex-end;
+  justify-content: space-between;
+  gap: 8px;
+  flex-wrap: wrap;
 }
 
 .composer-hints {
   display: flex;
-  flex-wrap: wrap;
-  gap: 10px;
-  font-size: 12px;
+  flex-direction: column;
+  gap: 4px;
+  font-size: 11px;
   color: rgba(255, 255, 255, 0.65);
 }
 
 .composer-actions {
   display: flex;
-  justify-content: flex-end;
-  gap: 12px;
+  align-items: center;
+  gap: 8px;
 }
 
 .ghost-button,

--- a/src/components/chat/ChatWorkspace.tsx
+++ b/src/components/chat/ChatWorkspace.tsx
@@ -146,35 +146,21 @@ export const ChatWorkspace: React.FC<ChatWorkspaceProps> = ({ actorFilter }) => 
       </section>
 
       <section className="chat-composer-area" aria-label="Redactor de mensajes">
-        <div className="chat-suggestions">
-          <span className="suggestions-label">Sugerencias</span>
-          {quickCommands.slice(0, 3).map(command => (
-            <button
-              key={command}
-              type="button"
-              className="suggestion-chip"
-              onClick={() => appendToDraft(command)}
-            >
-              {command}
-            </button>
-          ))}
-        </div>
-
         <div className="chat-composer">
-          <textarea
-            value={draft}
-            onChange={event => setDraft(event.target.value)}
-            placeholder="Habla con varios agentes a la vez: por ejemplo “gpt, genera un esquema de estilos”"
-            className="chat-input"
-            rows={3}
-          />
-          <div className="composer-extensions">
-            <AttachmentPicker
-              attachments={composerAttachments}
-              onAdd={handleAddAttachments}
-              onRemove={handleRemoveAttachment}
-            />
-            <AudioRecorder onRecordingComplete={handleRecordingComplete} />
+          <div className="composer-header">
+            <div className="chat-suggestions">
+              <span className="suggestions-label">Sugerencias</span>
+              {quickCommands.slice(0, 3).map(command => (
+                <button
+                  key={command}
+                  type="button"
+                  className="suggestion-chip"
+                  onClick={() => appendToDraft(command)}
+                >
+                  {command}
+                </button>
+              ))}
+            </div>
             {composerTranscriptions.length > 0 && (
               <div className="composer-transcriptions">
                 {composerTranscriptions.map(transcription => (
@@ -183,16 +169,38 @@ export const ChatWorkspace: React.FC<ChatWorkspaceProps> = ({ actorFilter }) => 
                     <span className="transcription-text">{transcription.text}</span>
                     <button
                       type="button"
-                      className="attachment-remove"
+                      className="icon-button compact subtle"
                       onClick={() => removeTranscription(transcription.id)}
+                      aria-label={`Eliminar transcripción ${transcription.modality ?? 'audio'}`}
+                      title="Eliminar transcripción"
                     >
-                      ×
+                      <span aria-hidden="true">✕</span>
                     </button>
                   </div>
                 ))}
               </div>
             )}
           </div>
+
+          <div className="composer-extensions">
+            <AttachmentPicker
+              attachments={composerAttachments}
+              onAdd={handleAddAttachments}
+              onRemove={handleRemoveAttachment}
+              triggerAriaLabel="Adjuntar archivos"
+              triggerTooltip="Adjuntar archivos"
+            />
+            <AudioRecorder onRecordingComplete={handleRecordingComplete} />
+          </div>
+
+          <textarea
+            value={draft}
+            onChange={event => setDraft(event.target.value)}
+            placeholder="Habla con varios agentes a la vez: por ejemplo “gpt, genera un esquema de estilos”"
+            className="chat-input"
+            rows={3}
+          />
+
           <div className="composer-toolbar">
             <div className="composer-hints">
               <span>Inicia la línea con «nombre:» o «nombre,» para dirigirla a un proveedor</span>
@@ -204,8 +212,15 @@ export const ChatWorkspace: React.FC<ChatWorkspaceProps> = ({ actorFilter }) => 
               )}
             </div>
             <div className="composer-actions">
-              <button type="button" className="ghost-button" onClick={() => setDraft('')} disabled={!draft.trim()}>
-                Limpiar
+              <button
+                type="button"
+                className="icon-button compact subtle"
+                onClick={() => setDraft('')}
+                disabled={!draft.trim()}
+                aria-label="Limpiar borrador"
+                title="Limpiar borrador"
+              >
+                <span aria-hidden="true">🧹</span>
               </button>
               <button
                 type="button"

--- a/src/components/chat/composer/AttachmentPicker.tsx
+++ b/src/components/chat/composer/AttachmentPicker.tsx
@@ -5,6 +5,8 @@ interface AttachmentPickerProps {
   attachments: ChatAttachment[];
   onAdd: (attachments: ChatAttachment[]) => void;
   onRemove: (attachmentId: string) => void;
+  triggerAriaLabel?: string;
+  triggerTooltip?: string;
 }
 
 const inferAttachmentType = (file: File): ChatAttachment['type'] => {
@@ -30,7 +32,13 @@ const formatFileSize = (bytes?: number): string => {
   return `${(bytes / (1024 * 1024)).toFixed(1)} MB`;
 };
 
-export const AttachmentPicker: React.FC<AttachmentPickerProps> = ({ attachments, onAdd, onRemove }) => {
+export const AttachmentPicker: React.FC<AttachmentPickerProps> = ({
+  attachments,
+  onAdd,
+  onRemove,
+  triggerAriaLabel,
+  triggerTooltip,
+}) => {
   const inputRef = useRef<HTMLInputElement | null>(null);
 
   const handleClick = useCallback(() => {
@@ -67,8 +75,14 @@ export const AttachmentPicker: React.FC<AttachmentPickerProps> = ({ attachments,
 
   return (
     <div className="attachment-picker">
-      <button type="button" className="ghost-button" onClick={handleClick}>
-        Adjuntar archivos
+      <button
+        type="button"
+        className="icon-button compact"
+        onClick={handleClick}
+        aria-label={triggerAriaLabel ?? 'Adjuntar archivos'}
+        title={triggerTooltip ?? triggerAriaLabel ?? 'Adjuntar archivos'}
+      >
+        <span aria-hidden="true">📎</span>
       </button>
       <input
         ref={inputRef}
@@ -92,11 +106,12 @@ export const AttachmentPicker: React.FC<AttachmentPickerProps> = ({ attachments,
               </div>
               <button
                 type="button"
-                className="attachment-remove"
+                className="icon-button compact subtle"
                 onClick={() => onRemove(attachment.id)}
                 aria-label={`Eliminar adjunto ${attachment.name ?? attachment.id}`}
+                title="Eliminar adjunto"
               >
-                ×
+                <span aria-hidden="true">✕</span>
               </button>
             </li>
           ))}


### PR DESCRIPTION
## Summary
- reorganized the chat composer so suggestions, transcriptions, and controls sit above the input while secondary actions use icon buttons
- replaced the attachment picker text button with an icon trigger and optional accessibility labels
- tightened chat composer spacing, padding, and icon button styles so the message feed gains vertical room without harming legibility

## Testing
- npm run test -- --run

------
https://chatgpt.com/codex/tasks/task_e_68ced6ec20008333a4d075bfe96ed8ce