### PR TITLE
Refine side panel spacing

### DIFF
--- a/src/components/chat/SidePanel.css
+++ b/src/components/chat/SidePanel.css
@@ -2,8 +2,8 @@
   display: flex;
   flex-direction: column;
   height: 100%;
-  padding: 24px;
-  gap: 24px;
+  padding: 16px;
+  gap: 16px;
   background: rgba(10, 10, 10, 0.92);
   border-left: 1px solid rgba(255, 255, 255, 0.08);
   overflow-y: auto;
@@ -23,9 +23,9 @@
 .sidebar-section {
   display: flex;
   flex-direction: column;
-  gap: 12px;
-  padding: 18px;
-  border-radius: 18px;
+  gap: 10px;
+  padding: 14px;
+  border-radius: 12px;
   background: rgba(18, 18, 18, 0.85);
   border: 1px solid rgba(255, 255, 255, 0.06);
   box-shadow: 0 8px 20px rgba(0, 0, 0, 0.45);
@@ -38,7 +38,7 @@
 }
 
 .sidebar-section header p {
-  margin-top: 4px;
+  margin-top: 2px;
   font-size: 12px;
   color: rgba(255, 255, 255, 0.6);
 }
@@ -46,17 +46,17 @@
 .provider-grid {
   display: grid;
   grid-template-columns: repeat(auto-fill, minmax(160px, 1fr));
-  gap: 12px;
+  gap: 8px;
 }
 
 .provider-card {
-  padding: 14px;
-  border-radius: 14px;
+  padding: 10px;
+  border-radius: 10px;
   border: 1px solid rgba(255, 255, 255, 0.08);
   background: rgba(255, 255, 255, 0.04);
   display: flex;
   flex-direction: column;
-  gap: 10px;
+  gap: 6px;
   transition: border 0.2s ease, background 0.2s ease;
 }
 
@@ -95,27 +95,27 @@
 .provider-body {
   display: flex;
   flex-direction: column;
-  gap: 4px;
+  gap: 2px;
   font-size: 12px;
   color: rgba(255, 255, 255, 0.7);
 }
 
 .local-model-card {
-  margin-top: 8px;
-  padding: 16px;
-  border-radius: 14px;
+  margin-top: 6px;
+  padding: 12px;
+  border-radius: 10px;
   background: linear-gradient(135deg, rgba(77, 208, 225, 0.15), rgba(142, 141, 255, 0.12));
   border: 1px solid rgba(142, 141, 255, 0.35);
   display: flex;
   justify-content: space-between;
   align-items: center;
-  gap: 12px;
+  gap: 8px;
 }
 
 .local-model-card h3 {
   font-size: 14px;
   font-weight: 600;
-  margin-bottom: 4px;
+  margin-bottom: 2px;
 }
 
 .local-model-card p {
@@ -126,7 +126,7 @@
 .local-model-card button {
   border: none;
   border-radius: 999px;
-  padding: 6px 14px;
+  padding: 6px 12px;
   background: rgba(142, 141, 255, 0.45);
   color: #fff;
   cursor: pointer;
@@ -137,19 +137,21 @@
 
 .sidebar-stats {
   list-style: none;
+  margin: 0;
+  padding: 0;
   display: grid;
   grid-template-columns: repeat(auto-fit, minmax(120px, 1fr));
-  gap: 10px;
+  gap: 8px;
 }
 
 .sidebar-stats li {
-  padding: 10px 12px;
-  border-radius: 12px;
+  padding: 8px 10px;
+  border-radius: 8px;
   background: rgba(255, 255, 255, 0.04);
   border: 1px solid rgba(255, 255, 255, 0.05);
   display: flex;
   flex-direction: column;
-  gap: 6px;
+  gap: 4px;
 }
 
 .stat-label {
@@ -166,9 +168,11 @@
 
 .suggestion-list {
   list-style: none;
+  margin: 0;
+  padding: 0;
   display: flex;
   flex-direction: column;
-  gap: 10px;
+  gap: 8px;
 }
 
 .suggestion-list li button {
@@ -176,13 +180,13 @@
   text-align: left;
   background: rgba(255, 255, 255, 0.04);
   border: 1px solid rgba(255, 255, 255, 0.06);
-  border-radius: 12px;
-  padding: 12px 14px;
+  border-radius: 8px;
+  padding: 10px 12px;
   color: #fff;
   cursor: pointer;
   display: flex;
   flex-direction: column;
-  gap: 6px;
+  gap: 4px;
   transition: border 0.2s ease, transform 0.2s ease;
 }
 
@@ -209,14 +213,14 @@
 .command-list {
   display: flex;
   flex-direction: column;
-  gap: 8px;
+  gap: 6px;
 }
 
 .command-list button {
   text-align: left;
   border: 1px solid rgba(255, 255, 255, 0.06);
   border-radius: 999px;
-  padding: 8px 14px;
+  padding: 6px 12px;
   background: rgba(255, 255, 255, 0.05);
   color: #fff;
   font-size: 12px;


### PR DESCRIPTION
## Summary
- tighten spacing, padding, and border radii across the chat side panel
- reset list margins to keep statistics and suggestions aligned after compression

## Testing
- CI=1 FORCE_COLOR=0 npx vitest run src/components/chat/__tests__/SidePanel.test.tsx --reporter=basic --silent *(fails: worker out of memory)*

------
https://chatgpt.com/codex/tasks/task_e_68ced859d0a88333a0ced8325c5bd604