### PR TITLE
Refine plugin and MCP summaries with compact icon controls

### DIFF
--- a/src/components/settings/McpSummary.css
+++ b/src/components/settings/McpSummary.css
@@ -7,44 +7,47 @@
 .mcp-summary {
   display: flex;
   flex-direction: column;
-  gap: 16px;
+  gap: 12px;
 }
 
 .mcp-summary ul {
   list-style: none;
   display: flex;
   flex-direction: column;
-  gap: 12px;
+  gap: 8px;
 }
 
 .mcp-summary li {
-  padding: 14px;
-  border-radius: 14px;
+  padding: 10px 12px;
+  border-radius: 12px;
   background: rgba(255, 255, 255, 0.04);
   border: 1px solid rgba(255, 255, 255, 0.08);
   display: flex;
   flex-direction: column;
-  gap: 10px;
+  gap: 8px;
 }
 
 .mcp-summary li header {
   display: flex;
   justify-content: space-between;
   align-items: flex-start;
-  gap: 12px;
+  gap: 8px;
 }
 
 .mcp-summary li header strong {
-  font-size: 14px;
+  font-size: 13px;
   display: block;
 }
 
-.mcp-summary li header span {
-  font-size: 12px;
+.mcp-summary li header > div span {
+  font-size: 11px;
   color: rgba(255, 255, 255, 0.6);
 }
 
 .badge {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
   border-radius: 999px;
   padding: 4px 10px;
   border: 1px solid rgba(255, 255, 255, 0.18);
@@ -60,26 +63,42 @@
   color: #66ff66;
 }
 
+.badge__icon {
+  font-size: 14px;
+  line-height: 1;
+}
+
+.badge__text {
+  font-size: 10px;
+}
+
 .mcp-summary__endpoints {
   list-style: none;
   display: flex;
   flex-direction: column;
-  gap: 8px;
+  gap: 6px;
 }
 
 .mcp-summary__endpoints li {
   display: flex;
-  gap: 10px;
+  gap: 6px;
   font-size: 12px;
-  align-items: baseline;
+  align-items: center;
+}
+
+.endpoint-icon {
+  font-size: 14px;
+  line-height: 1;
 }
 
 .endpoint-transport {
   font-weight: 600;
   color: rgba(255, 255, 255, 0.75);
+  font-size: 11px;
 }
 
 .endpoint-url {
   color: rgba(255, 255, 255, 0.6);
   word-break: break-word;
+  font-size: 11px;
 }

--- a/src/components/settings/McpSummary.tsx
+++ b/src/components/settings/McpSummary.tsx
@@ -24,13 +24,21 @@ export const McpSummary: React.FC<McpSummaryProps> = ({ settings }) => {
                 <strong>{profile.label}</strong>
                 {profile.description && <span>{profile.description}</span>}
               </div>
-              <span className={profile.autoConnect ? 'badge badge-active' : 'badge'}>
-                {profile.autoConnect ? 'Auto-connect' : 'Manual'}
+              <span
+                className={profile.autoConnect ? 'badge badge-active' : 'badge'}
+                aria-label={`Modo ${profile.autoConnect ? 'automático' : 'manual'}`}
+                title={`Modo ${profile.autoConnect ? 'automático' : 'manual'}`}
+              >
+                <span className="badge__icon" aria-hidden="true">
+                  {profile.autoConnect ? '🔌' : '⛓'}
+                </span>
+                <span className="badge__text">{profile.autoConnect ? 'Auto-connect' : 'Manual'}</span>
               </span>
             </header>
             <ul className="mcp-summary__endpoints">
               {profile.endpoints.map(endpoint => (
-                <li key={endpoint.id}>
+                <li key={endpoint.id} title={`Endpoint ${endpoint.transport.toUpperCase()}`}>
+                  <span className="endpoint-icon" aria-hidden="true">🔗</span>
                   <span className="endpoint-transport">{endpoint.transport.toUpperCase()}</span>
                   <span className="endpoint-url">{endpoint.url}</span>
                 </li>

--- a/src/components/settings/PluginSummary.css
+++ b/src/components/settings/PluginSummary.css
@@ -1,7 +1,7 @@
 .plugin-summary {
   display: flex;
   flex-direction: column;
-  gap: 16px;
+  gap: 12px;
 }
 
 .plugin-summary > p {
@@ -13,37 +13,36 @@
   list-style: none;
   display: flex;
   flex-direction: column;
-  gap: 12px;
+  gap: 8px;
 }
 
 .plugin-summary li {
-  padding: 14px;
-  border-radius: 14px;
+  padding: 10px 12px;
+  border-radius: 12px;
   background: rgba(255, 255, 255, 0.04);
   border: 1px solid rgba(255, 255, 255, 0.08);
   display: flex;
   flex-direction: column;
-  gap: 8px;
+  gap: 6px;
 }
 
 .plugin-summary li header {
   display: flex;
   align-items: center;
   justify-content: space-between;
-  gap: 12px;
+  gap: 8px;
 }
 
 .plugin-summary li header strong {
   display: block;
-  font-size: 14px;
+  font-size: 13px;
 }
 
-.plugin-summary li header span {
-  font-size: 12px;
+.plugin-summary li header > div span {
+  font-size: 11px;
   color: rgba(255, 255, 255, 0.6);
 }
 
-.plugin-summary li header button,
 .plugin-summary > button {
   border: none;
   border-radius: 999px;
@@ -54,6 +53,42 @@
   font-size: 12px;
   letter-spacing: 0.6px;
   text-transform: uppercase;
+}
+
+.plugin-toggle {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  border-radius: 999px;
+  border: 1px solid rgba(255, 255, 255, 0.18);
+  background: rgba(142, 141, 255, 0.25);
+  color: #fff;
+  cursor: pointer;
+  padding: 4px 10px;
+  font-size: 11px;
+  letter-spacing: 0.5px;
+  text-transform: uppercase;
+  transition: background 0.2s ease, border-color 0.2s ease;
+}
+
+.plugin-toggle--on {
+  background: rgba(80, 200, 120, 0.2);
+  border-color: rgba(80, 200, 120, 0.45);
+}
+
+.plugin-toggle:focus-visible {
+  outline: 2px solid rgba(255, 255, 255, 0.7);
+  outline-offset: 2px;
+}
+
+.plugin-toggle__icon {
+  font-size: 14px;
+  line-height: 1;
+}
+
+.plugin-toggle__text {
+  font-size: 10px;
+  letter-spacing: 0.8px;
 }
 
 .plugin-summary li p {

--- a/src/components/settings/PluginSummary.tsx
+++ b/src/components/settings/PluginSummary.tsx
@@ -61,8 +61,18 @@ export const PluginSummary: React.FC<PluginSummaryProps> = ({ settings, onSettin
                   <strong>{manifest.name}</strong>
                   <span>{manifest.version}</span>
                 </div>
-                <button type="button" onClick={() => handleToggle(pluginId, !enabled)}>
-                  {enabled ? 'Desactivar' : 'Activar'}
+                <button
+                  type="button"
+                  className={`plugin-toggle${enabled ? ' plugin-toggle--on' : ''}`}
+                  onClick={() => handleToggle(pluginId, !enabled)}
+                  aria-pressed={enabled}
+                  aria-label={`${enabled ? 'Desactivar' : 'Activar'} el plugin ${manifest.name}`}
+                  title={`${enabled ? 'Desactivar' : 'Activar'} el plugin`}
+                >
+                  <span className="plugin-toggle__icon" aria-hidden="true">
+                    {enabled ? '✓' : '✕'}
+                  </span>
+                  <span className="plugin-toggle__text">{enabled ? 'Activo' : 'Inactivo'}</span>
                 </button>
               </header>
               {manifest.description && <p>{manifest.description}</p>}


### PR DESCRIPTION
## Summary
- replace plugin activation buttons with compact toggle controls that include icons and accessibility labels
- add visual icons for MCP auto-connect badges and endpoints without increasing typography
- tighten layout spacing in both summaries to reduce item height and align the new iconography

## Testing
- CI=1 npm exec vitest run --reporter=basic

------
https://chatgpt.com/codex/tasks/task_e_68ced9821f0083338d40d95b0b64932f