### PR TITLE
feat: update local model metadata from Hugging Face

### DIFF
--- a/src-tauri/src/models/mod.rs
+++ b/src-tauri/src/models/mod.rs
@@ -10,16 +10,17 @@ use std::sync::{Mutex, RwLock};
 use tauri::{State, Window};
 use tokio::fs::File;
 use tokio::io::AsyncWriteExt;
+use tokio::sync::OnceCell;
 
 #[derive(Debug, Clone, Serialize)]
 pub struct ModelAsset {
-    pub id: &'static str,
-    pub name: &'static str,
-    pub description: &'static str,
-    pub download_url: &'static str,
-    pub checksum: &'static str,
+    pub id: String,
+    pub name: String,
+    pub description: String,
+    pub download_url: String,
+    pub checksum: String,
     pub size: u64,
-    pub file_name: &'static str,
+    pub file_name: String,
 }
 
 #[derive(Debug, Clone, Serialize)]
@@ -144,57 +145,153 @@ impl<'a> Drop for DownloadGuard<'a> {
     }
 }
 
-pub static AVAILABLE_MODELS: Lazy<Vec<ModelAsset>> = Lazy::new(|| {
-    vec![
-        ModelAsset {
-            id: "local-phi3",
-            name: "Phi-3 Mini",
-            description: "Modelo pequeño optimizado para ejecución local y prototipado rápido.",
-            download_url: "https://raw.githubusercontent.com/rust-lang/rust/master/.editorconfig",
-            checksum: "0205ec4e77200b398489fb3670f0cc40cfd12e2ded709be38c33d5f030d2274f",
-            size: 955,
-            file_name: "phi3-mini.bin",
-        },
-        ModelAsset {
-            id: "local-mistral",
-            name: "Mistral 7B",
-            description: "Modelo generalista capaz de cubrir tareas creativas y analíticas.",
-            download_url: "https://raw.githubusercontent.com/rust-lang/rust/master/LICENSE-MIT",
-            checksum: "b71bd43a069ca0641a9ecfe585ca7b3c53b5cc1608f8b68321168698e28b5ea1",
-            size: 1068,
-            file_name: "mistral-7b.bin",
-        },
-    ]
-});
+#[derive(Debug)]
+struct ModelSource {
+    id: &'static str,
+    name: &'static str,
+    description: &'static str,
+    repo: &'static str,
+    file_name: &'static str,
+}
+
+static MODEL_SOURCES: &[ModelSource] = &[
+    ModelSource {
+        id: "local-phi3",
+        name: "Phi-3 Mini 4K Instruct Q4",
+        description:
+            "Modelo orientado a asistentes locales basado en Phi-3 Mini con cuantización Q4.",
+        repo: "microsoft/Phi-3-mini-4k-instruct-gguf",
+        file_name: "Phi-3-mini-4k-instruct-q4.gguf",
+    },
+    ModelSource {
+        id: "local-mistral",
+        name: "Mistral 7B Instruct v0.2 Q4_K_M",
+        description: "Modelo generalista cuantizado Q4_K_M para tareas de conversación y análisis.",
+        repo: "mistralai/Mistral-7B-Instruct-v0.2-GGUF",
+        file_name: "Mistral-7B-Instruct-v0.2.Q4_K_M.gguf",
+    },
+];
+
+static AVAILABLE_MODELS: Lazy<OnceCell<Vec<ModelAsset>>> = Lazy::new(OnceCell::const_new);
+
+#[derive(Debug, Deserialize)]
+struct HuggingFaceResponse {
+    siblings: Vec<HuggingFaceSibling>,
+}
+
+#[derive(Debug, Deserialize)]
+struct HuggingFaceSibling {
+    #[serde(rename = "rfilename")]
+    file_name: String,
+    size: Option<u64>,
+    sha256: Option<String>,
+}
+
+async fn fetch_model_asset(
+    client: &reqwest::Client,
+    source: &ModelSource,
+) -> anyhow::Result<ModelAsset> {
+    let api_url = format!("https://huggingface.co/api/models/{}", source.repo);
+    let response = client
+        .get(api_url)
+        .header(reqwest::header::USER_AGENT, "JungleMonkAI/1.0")
+        .send()
+        .await?;
+
+    let response = response.error_for_status()?;
+    let payload: HuggingFaceResponse = response.json().await?;
+
+    let sibling = payload
+        .siblings
+        .into_iter()
+        .find(|item| item.file_name == source.file_name)
+        .ok_or_else(|| {
+            anyhow!(
+                "No se encontró el archivo {} en {}",
+                source.file_name,
+                source.repo
+            )
+        })?;
+
+    let size = sibling.size.ok_or_else(|| {
+        anyhow!(
+            "No se pudo obtener el tamaño del archivo {} en {}",
+            source.file_name,
+            source.repo
+        )
+    })?;
+
+    let checksum = sibling.sha256.ok_or_else(|| {
+        anyhow!(
+            "No se pudo obtener el checksum SHA-256 del archivo {} en {}",
+            source.file_name,
+            source.repo
+        )
+    })?;
+
+    let download_url = format!(
+        "https://huggingface.co/{}/resolve/main/{}?download=1",
+        source.repo, source.file_name
+    );
+
+    Ok(ModelAsset {
+        id: source.id.to_string(),
+        name: source.name.to_string(),
+        description: source.description.to_string(),
+        download_url,
+        checksum,
+        size,
+        file_name: source.file_name.to_string(),
+    })
+}
+
+async fn ensure_model_manifest() -> anyhow::Result<Vec<ModelAsset>> {
+    let manifest = AVAILABLE_MODELS
+        .get_or_try_init(|| async {
+            let client = reqwest::Client::new();
+            let mut assets = Vec::with_capacity(MODEL_SOURCES.len());
+            for source in MODEL_SOURCES {
+                let asset = fetch_model_asset(&client, source).await?;
+                assets.push(asset);
+            }
+            Ok::<_, anyhow::Error>(assets)
+        })
+        .await?;
+
+    Ok(manifest.clone())
+}
 
 #[tauri::command]
 pub async fn list_models(state: State<'_, ModelRegistry>) -> Result<Vec<ModelSummary>, String> {
+    let assets = ensure_model_manifest()
+        .await
+        .map_err(|err| format!("No se pudo cargar el catálogo de modelos: {err}"))?;
     let (data, downloading) = state.list();
-    let summaries = AVAILABLE_MODELS
+    let summaries = assets
         .iter()
         .map(|asset| {
-            let (status, local_path) = if downloading.contains(asset.id) {
+            let (status, local_path) = if downloading.contains(&asset.id) {
                 (
                     "downloading".to_string(),
                     data.models
-                        .get(asset.id)
+                        .get(&asset.id)
                         .map(|m| state.model_path(&m.file_name)),
                 )
-            } else if let Some(meta) = data.models.get(asset.id) {
+            } else if let Some(meta) = data.models.get(&asset.id) {
                 ("ready".to_string(), Some(state.model_path(&meta.file_name)))
             } else {
                 ("not_installed".to_string(), None)
             };
 
             ModelSummary {
-                id: asset.id.to_string(),
-                name: asset.name.to_string(),
-                description: asset.description.to_string(),
+                id: asset.id.clone(),
+                name: asset.name.clone(),
+                description: asset.description.clone(),
                 size: asset.size,
-                checksum: asset.checksum.to_string(),
+                checksum: asset.checksum.clone(),
                 status,
                 local_path: local_path.and_then(|p| p.to_str().map(|s| s.to_string())),
-                active: data.active_model.as_deref() == Some(asset.id),
+                active: data.active_model.as_deref() == Some(asset.id.as_str()),
             }
         })
         .collect();
@@ -208,10 +305,23 @@ pub async fn download_model(
     model_id: String,
     state: State<'_, ModelRegistry>,
 ) -> Result<(), String> {
-    let asset = AVAILABLE_MODELS
-        .iter()
+    let assets = ensure_model_manifest()
+        .await
+        .map_err(|err| format!("No se pudo cargar el catálogo de modelos: {err}"))?;
+
+    let asset = assets
+        .into_iter()
         .find(|item| item.id == model_id)
         .ok_or_else(|| format!("Modelo desconocido: {model_id}"))?;
+
+    let ModelAsset {
+        id,
+        download_url,
+        checksum,
+        size,
+        file_name,
+        ..
+    } = asset;
 
     let _guard = state
         .begin_download(&model_id)
@@ -219,7 +329,7 @@ pub async fn download_model(
 
     let client = reqwest::Client::new();
     let response = client
-        .get(asset.download_url)
+        .get(&download_url)
         .send()
         .await
         .map_err(|err| err.to_string())?;
@@ -231,9 +341,9 @@ pub async fn download_model(
         ));
     }
 
-    let total = response.content_length().unwrap_or(asset.size);
+    let total = response.content_length().unwrap_or(size);
     let mut stream = response.bytes_stream();
-    let dest_path = state.model_path(asset.file_name);
+    let dest_path = state.model_path(&file_name);
     let tmp_path = dest_path.with_extension("download");
 
     let mut file = File::create(&tmp_path)
@@ -259,7 +369,7 @@ pub async fn download_model(
         let _ = window.emit(
             "model-download-progress",
             serde_json::json!({
-                "id": asset.id,
+                "id": &id,
                 "downloaded": downloaded,
                 "total": total,
                 "progress": progress,
@@ -271,15 +381,15 @@ pub async fn download_model(
     drop(file);
 
     let hash = format!("{:x}", hasher.finalize());
-    if !hash.eq_ignore_ascii_case(asset.checksum) {
+    if !hash.eq_ignore_ascii_case(&checksum) {
         let _ = tokio::fs::remove_file(&tmp_path).await;
         let message = format!(
             "La verificación de integridad falló para {model_id}: esperado {} pero se obtuvo {hash}",
-            asset.checksum
+            checksum
         );
         let _ = window.emit(
             "model-download-error",
-            serde_json::json!({ "id": asset.id, "error": message }),
+            serde_json::json!({ "id": id, "error": message }),
         );
         return Err(message);
     }
@@ -290,10 +400,10 @@ pub async fn download_model(
 
     state
         .store_model(
-            asset.id,
+            &id,
             LocalModelMetadata {
-                file_name: asset.file_name.to_string(),
-                checksum: asset.checksum.to_string(),
+                file_name: file_name.clone(),
+                checksum: checksum.clone(),
             },
         )
         .map_err(|err| err.to_string())?;
@@ -301,9 +411,9 @@ pub async fn download_model(
     let _ = window.emit(
         "model-download-complete",
         serde_json::json!({
-            "id": asset.id,
+            "id": id,
             "path": dest_path.to_string_lossy(),
-            "checksum": asset.checksum,
+            "checksum": checksum,
         }),
     );
 


### PR DESCRIPTION
## Summary
- replace the hard-coded demo artifacts with Microsoft Phi-3 Mini and Mistral 7B GGUF entries
- fetch model size and SHA-256 dynamically from the Hugging Face API before exposing them to the UI
- reuse the fetched manifest during listing and downloads so integrity verification uses real metadata

## Testing
- cargo fmt
- cargo test *(fails: missing system dependency `glib-2.0` required by glib-sys)*

------
https://chatgpt.com/codex/tasks/task_e_68cedaaac7508333b7f898bcf3e8eec7