### PR TITLE
Remove unsafe eval from CSP

### DIFF
--- a/index.html
+++ b/index.html
@@ -4,7 +4,7 @@
     <meta charset="UTF-8" />
     <meta
       http-equiv="Content-Security-Policy"
-      content="default-src 'self'; connect-src 'self' http://127.0.0.1:9888 ws://127.0.0.1:9888 ws://localhost:9888 https://api.pexels.com https://videos.pexels.com https://pixabay.com https://archive.org https://*.archive.org; script-src 'self' 'unsafe-eval'; style-src 'self' 'unsafe-inline'; img-src 'self' data: https://images.pexels.com https://cdn.pixabay.com https://i.vimeocdn.com https://archive.org https://*.archive.org; media-src 'self' blob: data: https://player.vimeo.com https://vod-progressive.akamaized.net https://videos.pexels.com https://pixabay.com https://cdn.pixabay.com https://archive.org https://*.archive.org https://*.vimeocdn.com;"
+      content="default-src 'self'; connect-src 'self' http://127.0.0.1:9888 ws://127.0.0.1:9888 ws://localhost:9888 https://api.pexels.com https://videos.pexels.com https://pixabay.com https://archive.org https://*.archive.org; script-src 'self'; style-src 'self' 'unsafe-inline'; img-src 'self' data: https://images.pexels.com https://cdn.pixabay.com https://i.vimeocdn.com https://archive.org https://*.archive.org; media-src 'self' blob: data: https://player.vimeo.com https://vod-progressive.akamaized.net https://videos.pexels.com https://pixabay.com https://cdn.pixabay.com https://archive.org https://*.archive.org https://*.vimeocdn.com;"
     />
     <title>Jungle Lab Studio</title>
   </head>


### PR DESCRIPTION
## Summary
- tighten the content security policy in index.html by removing the unsafe-eval allowance for scripts

## Testing
- npm run dev *(fails: tauri dev waits for frontend dev server on http://localhost:8080/ in this environment)*
- npm run build *(fails: tauri build requires system glib-2.0 development files which are unavailable in the container)*

------
https://chatgpt.com/codex/tasks/task_e_68cee1641e7c8333b879689d38bb6291