### PR TITLE
feat: add project-aware workflows and settings

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -23,6 +23,7 @@ import { GlobalSettingsDialog } from './components/settings/GlobalSettingsDialog
 import { OverlayModal } from './components/common/OverlayModal';
 import { PluginSummary } from './components/settings/PluginSummary';
 import { McpSummary } from './components/settings/McpSummary';
+import { ProjectProvider } from './core/projects/ProjectContext';
 
 interface AppContentProps {
   apiKeys: ApiKeySettings;
@@ -174,22 +175,24 @@ const App: React.FC = () => {
 
   return (
     <PluginHostProvider settings={globalSettings} onSettingsChange={setGlobalSettings}>
-      <AgentProvider
-        apiKeys={globalSettings.apiKeys}
-        enabledPlugins={globalSettings.enabledPlugins}
-        approvedManifests={globalSettings.approvedManifests}
-      >
-        <MessageProvider apiKeys={globalSettings.apiKeys}>
-          <RepoWorkflowProvider>
-            <AppContent
-              apiKeys={globalSettings.apiKeys}
-              settings={globalSettings}
-              onApiKeyChange={handleApiKeyChange}
-              onSettingsChange={setGlobalSettings}
-            />
-          </RepoWorkflowProvider>
-        </MessageProvider>
-      </AgentProvider>
+      <ProjectProvider settings={globalSettings} onSettingsChange={setGlobalSettings}>
+        <AgentProvider
+          apiKeys={globalSettings.apiKeys}
+          enabledPlugins={globalSettings.enabledPlugins}
+          approvedManifests={globalSettings.approvedManifests}
+        >
+          <MessageProvider apiKeys={globalSettings.apiKeys}>
+            <RepoWorkflowProvider>
+              <AppContent
+                apiKeys={globalSettings.apiKeys}
+                settings={globalSettings}
+                onApiKeyChange={handleApiKeyChange}
+                onSettingsChange={setGlobalSettings}
+              />
+            </RepoWorkflowProvider>
+          </MessageProvider>
+        </AgentProvider>
+      </ProjectProvider>
     </PluginHostProvider>
   );
 };

--- a/src/components/chat/ChatInterface.css
+++ b/src/components/chat/ChatInterface.css
@@ -1972,6 +1972,34 @@
   font-size: 12px;
 }
 
+.project-pill {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  background: rgba(255, 255, 255, 0.06);
+  border-radius: 999px;
+  padding: 6px 14px;
+  color: #fff;
+}
+
+.project-pill select {
+  border: none;
+  background: transparent;
+  color: inherit;
+  font-size: 12px;
+  padding: 0;
+}
+
+.project-pill select:disabled {
+  opacity: 0.6;
+}
+
+.project-pill .project-meta {
+  font-size: 12px;
+  opacity: 0.75;
+  white-space: nowrap;
+}
+
 .topbar-actions {
   display: flex;
   align-items: center;

--- a/src/components/chat/ChatTopBar.tsx
+++ b/src/components/chat/ChatTopBar.tsx
@@ -3,6 +3,7 @@ import { AgentDefinition, AgentKind } from '../../core/agents/agentRegistry';
 import { AgentPresenceSummary, AgentPresenceStatus } from '../../core/agents/presence';
 import { ChatActorFilter } from '../../types/chat';
 import { getAgentDisplayName } from '../../utils/agentDisplay';
+import { useProjects } from '../../core/projects/ProjectContext';
 
 interface ChatTopBarProps {
   agents: AgentDefinition[];
@@ -62,6 +63,21 @@ export const ChatTopBar: React.FC<ChatTopBarProps> = ({
 }) => {
   const hasPending = pendingResponses > 0;
   const overallStatus = resolveStatus(presenceSummary);
+  const { projects, activeProjectId, activeProject, selectProject } = useProjects();
+
+  const handleProjectChange = (event: React.ChangeEvent<HTMLSelectElement>) => {
+    const nextId = event.target.value || null;
+    selectProject(nextId);
+  };
+
+  const projectOptions = useMemo(
+    () =>
+      projects.map(project => ({
+        id: project.id,
+        label: project.name,
+      })),
+    [projects],
+  );
 
   const filterOptions = useMemo(() => {
     const base: { value: ChatActorFilter; label: string }[] = [
@@ -154,6 +170,29 @@ export const ChatTopBar: React.FC<ChatTopBarProps> = ({
           >
             ↻
           </button>
+        </div>
+
+        <div className="project-pill">
+          <select
+            aria-label="Seleccionar proyecto activo"
+            value={activeProjectId ?? ''}
+            onChange={handleProjectChange}
+            disabled={!projectOptions.length}
+          >
+            {projectOptions.map(option => (
+              <option key={option.id} value={option.id}>
+                {option.label}
+              </option>
+            ))}
+            {!projectOptions.length && <option value="">Sin proyectos configurados</option>}
+          </select>
+          <div className="project-meta" aria-live="polite">
+            {activeProject
+              ? `${activeProject.repositoryPath}${
+                  activeProject.defaultBranch ? `@${activeProject.defaultBranch}` : ''
+                }`
+              : 'Sin proyecto activo'}
+          </div>
         </div>
 
         <div className="filter-pill">

--- a/src/components/chat/SidePanel.css
+++ b/src/components/chat/SidePanel.css
@@ -31,6 +31,73 @@
   box-shadow: 0 8px 20px rgba(0, 0, 0, 0.45);
 }
 
+.project-manager {
+  display: grid;
+  grid-template-columns: 1fr;
+  gap: 8px;
+}
+
+.project-manager label {
+  font-size: 12px;
+  text-transform: uppercase;
+  letter-spacing: 0.6px;
+  color: rgba(255, 255, 255, 0.6);
+}
+
+.project-manager input,
+.project-manager select,
+.project-manager textarea {
+  width: 100%;
+  border: 1px solid rgba(255, 255, 255, 0.12);
+  border-radius: 8px;
+  background: rgba(0, 0, 0, 0.3);
+  color: #fff;
+  padding: 8px 10px;
+  font-size: 13px;
+}
+
+.project-manager select {
+  background: rgba(0, 0, 0, 0.4);
+}
+
+.project-manager textarea {
+  resize: vertical;
+  min-height: 72px;
+}
+
+.project-manager .project-error {
+  margin-top: 4px;
+  font-size: 12px;
+  color: #ff8a80;
+}
+
+.project-actions {
+  display: flex;
+  gap: 8px;
+  justify-content: flex-end;
+}
+
+.project-actions button {
+  border: none;
+  border-radius: 8px;
+  padding: 6px 12px;
+  font-size: 12px;
+  cursor: pointer;
+  background: rgba(255, 255, 255, 0.12);
+  color: #fff;
+  text-transform: uppercase;
+  letter-spacing: 0.6px;
+}
+
+.project-actions button:disabled {
+  opacity: 0.5;
+  cursor: default;
+}
+
+.project-actions button.danger {
+  background: rgba(255, 82, 82, 0.35);
+}
+
 .sidebar-section header h2 {
   font-size: 16px;
   font-weight: 600;

--- a/src/components/chat/messages/__tests__/MessageContent.test.tsx
+++ b/src/components/chat/messages/__tests__/MessageContent.test.tsx
@@ -7,6 +7,7 @@ import { MessageProvider } from '../../../../core/messages/MessageContext';
 import { RepoWorkflowProvider } from '../../../../core/codex';
 import { PluginHostProvider } from '../../../../core/plugins/PluginHostProvider';
 import { DEFAULT_GLOBAL_SETTINGS } from '../../../../utils/globalSettings';
+import { ProjectProvider } from '../../../../core/projects/ProjectContext';
 
 const noop = vi.fn();
 
@@ -16,13 +17,15 @@ const ProviderHarness: React.FC<{ children: React.ReactNode }> = ({ children }) 
   }));
 
   return (
-    <AgentProvider apiKeys={{}}>
-      <PluginHostProvider settings={settings} onSettingsChange={setSettings}>
-        <MessageProvider apiKeys={{}}>
-          <RepoWorkflowProvider>{children}</RepoWorkflowProvider>
-        </MessageProvider>
-      </PluginHostProvider>
-    </AgentProvider>
+    <ProjectProvider settings={settings} onSettingsChange={setSettings}>
+      <AgentProvider apiKeys={{}}>
+        <PluginHostProvider settings={settings} onSettingsChange={setSettings}>
+          <MessageProvider apiKeys={{}}>
+            <RepoWorkflowProvider>{children}</RepoWorkflowProvider>
+          </MessageProvider>
+        </PluginHostProvider>
+      </AgentProvider>
+    </ProjectProvider>
   );
 };
 

--- a/src/core/codex/__tests__/RepoWorkflowContext.test.tsx
+++ b/src/core/codex/__tests__/RepoWorkflowContext.test.tsx
@@ -1,0 +1,65 @@
+import React from 'react';
+import { describe, expect, it, beforeEach, vi } from 'vitest';
+import { renderHook, act } from '@testing-library/react';
+import { RepoWorkflowProvider, useRepoWorkflow } from '../RepoWorkflowContext';
+import { ProjectProvider } from '../../projects/ProjectContext';
+import { DEFAULT_GLOBAL_SETTINGS } from '../../../utils/globalSettings';
+
+const messageTimestamp = new Date().toISOString();
+
+vi.mock('../../messages/MessageContext', () => ({
+  useMessages: () => ({
+    messages: [
+      {
+        id: 'msg-1',
+        author: 'agent',
+        content: 'Analiza la tarea pendiente',
+        timestamp: messageTimestamp,
+        agentId: 'jarvis',
+      },
+    ],
+  }),
+}));
+
+const ProjectWrapper: React.FC<{ children: React.ReactNode }> = ({ children }) => {
+  const [settings, setSettings] = React.useState(() => ({
+    ...DEFAULT_GLOBAL_SETTINGS,
+    projectProfiles: [
+      {
+        id: 'toolkit',
+        name: 'Toolkit',
+        repositoryPath: '/workbench/app',
+        defaultBranch: 'develop',
+        preferredProvider: 'openai',
+        preferredModel: 'gpt-4',
+      },
+    ],
+    activeProjectId: 'toolkit',
+  }));
+
+  return (
+    <ProjectProvider settings={settings} onSettingsChange={setSettings}>
+      <RepoWorkflowProvider>{children}</RepoWorkflowProvider>
+    </ProjectProvider>
+  );
+};
+
+describe('RepoWorkflowContext', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('propaga la configuración del proyecto activo al generar solicitudes', () => {
+    const { result } = renderHook(() => useRepoWorkflow(), { wrapper: ProjectWrapper });
+
+    act(() => {
+      result.current.queueRequest({ messageId: 'msg-1' });
+    });
+
+    const pending = result.current.pendingRequest;
+    expect(pending).not.toBeNull();
+    expect(pending?.request.context.repositoryPath).toBe('/workbench/app');
+    expect(pending?.request.context.branch).toBe('develop');
+    expect(pending?.request.context.actor).toBe('openai:gpt-4');
+  });
+});

--- a/src/core/messages/__tests__/MessageContext.test.tsx
+++ b/src/core/messages/__tests__/MessageContext.test.tsx
@@ -3,12 +3,20 @@ import { renderHook, act } from '@testing-library/react';
 import { describe, expect, it } from 'vitest';
 import { AgentProvider } from '../../agents/AgentContext';
 import { MessageProvider, useMessages } from '../MessageContext';
+import { ProjectProvider } from '../../projects/ProjectContext';
+import { DEFAULT_GLOBAL_SETTINGS } from '../../../utils/globalSettings';
 
-const Wrapper: React.FC<{ children: React.ReactNode }> = ({ children }) => (
-  <AgentProvider apiKeys={{}}>
-    <MessageProvider apiKeys={{}}>{children}</MessageProvider>
-  </AgentProvider>
-);
+const Wrapper: React.FC<{ children: React.ReactNode }> = ({ children }) => {
+  const [settings, setSettings] = React.useState(() => ({ ...DEFAULT_GLOBAL_SETTINGS }));
+
+  return (
+    <ProjectProvider settings={settings} onSettingsChange={setSettings}>
+      <AgentProvider apiKeys={{}}>
+        <MessageProvider apiKeys={{}}>{children}</MessageProvider>
+      </AgentProvider>
+    </ProjectProvider>
+  );
+};
 
 describe('MessageContext', () => {
   it('carga el contenido del mensaje en el borrador', () => {

--- a/src/core/orchestration/index.ts
+++ b/src/core/orchestration/index.ts
@@ -85,4 +85,5 @@ export type {
   MultiAgentContext,
   OrchestrationPlan,
   OrchestrationTraceEntry,
+  OrchestrationProjectContext,
 } from './types';

--- a/src/core/orchestration/strategies/criticReviewer.ts
+++ b/src/core/orchestration/strategies/criticReviewer.ts
@@ -3,6 +3,7 @@ import {
   AgentRoleAssignment,
   InternalBridgeMessage,
   MultiAgentContext,
+  OrchestrationProjectContext,
   SharedConversationSnapshot,
 } from '../types';
 import { AgentDefinition } from '../../agents/agentRegistry';
@@ -100,19 +101,21 @@ const buildContext = (
   snapshot: SharedConversationSnapshot,
   userPrompt: string,
   instructions: string[],
+  project: OrchestrationProjectContext | undefined,
 ): MultiAgentContext => ({
   strategyId: 'critic-reviewer',
   snapshot,
   role,
   instructions,
   userPrompt,
+  project,
 });
 
 export const criticReviewerStrategy: CoordinationStrategy = {
   id: 'critic-reviewer',
   label: 'Productor + crítico',
   description: 'Un agente genera propuestas y otro(s) las audita antes de publicarlas.',
-  buildPlan: ({ userPrompt, agents, snapshot, roles, agentPrompts }): OrchestrationPlan => {
+  buildPlan: ({ userPrompt, agents, snapshot, roles, agentPrompts, project }): OrchestrationPlan => {
     const timestamp = new Date().toISOString();
     const { producers, reviewers } = splitRoles(agents, roles);
     const sharedMessages: InternalBridgeMessage[] = [
@@ -136,6 +139,7 @@ export const criticReviewerStrategy: CoordinationStrategy = {
             snapshot,
             promptForAgent,
             buildProducerInstructions(agent, roles[agent.id], snapshot, promptForAgent),
+            project,
           ),
         };
       }),
@@ -150,6 +154,7 @@ export const criticReviewerStrategy: CoordinationStrategy = {
             snapshot,
             promptForAgent,
             buildReviewerInstructions(agent, roles[agent.id], snapshot, promptForAgent),
+            project,
           ),
         };
       }),

--- a/src/core/orchestration/types.ts
+++ b/src/core/orchestration/types.ts
@@ -28,6 +28,16 @@ export interface InternalBridgeMessage {
   timestamp: string;
 }
 
+export interface OrchestrationProjectContext {
+  id: string;
+  name: string;
+  repositoryPath: string;
+  defaultBranch?: string;
+  instructions?: string;
+  preferredProvider?: string;
+  preferredModel?: string;
+}
+
 export interface MultiAgentContext {
   strategyId: CoordinationStrategyId;
   snapshot: SharedConversationSnapshot;
@@ -35,6 +45,7 @@ export interface MultiAgentContext {
   instructions?: string[];
   bridgeMessages?: InternalBridgeMessage[];
   userPrompt: string;
+  project?: OrchestrationProjectContext;
 }
 
 export interface OrchestrationStepPlan {
@@ -70,6 +81,7 @@ export interface CoordinationStrategy {
     snapshot: SharedConversationSnapshot;
     roles: Record<string, AgentRoleAssignment | undefined>;
     agentPrompts?: Record<string, string | undefined>;
+    project?: OrchestrationProjectContext;
   }) => OrchestrationPlan;
 }
 

--- a/src/core/projects/ProjectContext.tsx
+++ b/src/core/projects/ProjectContext.tsx
@@ -1,0 +1,208 @@
+import React, { createContext, useCallback, useContext, useMemo } from 'react';
+import type { GlobalSettings, ProjectProfile } from '../../types/globalSettings';
+
+interface ProjectProviderProps {
+  settings: GlobalSettings;
+  onSettingsChange: (updater: (previous: GlobalSettings) => GlobalSettings) => void;
+  children: React.ReactNode;
+}
+
+export interface ProjectDraft {
+  id?: string;
+  name: string;
+  repositoryPath: string;
+  defaultBranch?: string;
+  instructions?: string;
+  preferredProvider?: string;
+  preferredModel?: string;
+}
+
+interface ProjectContextValue {
+  projects: ProjectProfile[];
+  activeProjectId: string | null;
+  activeProject: ProjectProfile | null;
+  selectProject: (projectId: string | null) => void;
+  upsertProject: (draft: ProjectDraft, options?: { activate?: boolean }) => ProjectProfile;
+  removeProject: (projectId: string) => void;
+}
+
+const ProjectContext = createContext<ProjectContextValue | undefined>(undefined);
+
+const slugify = (value: string): string => {
+  return value
+    .toLowerCase()
+    .trim()
+    .replace(/[^a-z0-9]+/g, '-')
+    .replace(/^-+|-+$/g, '')
+    .slice(0, 48);
+};
+
+const ensureProjectId = (draft: ProjectDraft, projects: ProjectProfile[]): string => {
+  const baseId = draft.id?.trim() || slugify(draft.name) || `project-${Date.now().toString(36)}`;
+
+  if (!projects.some(project => project.id === baseId)) {
+    return baseId;
+  }
+
+  if (draft.id?.trim()) {
+    return draft.id.trim();
+  }
+
+  let suffix = 2;
+  let candidate = `${baseId}-${suffix}`;
+  while (projects.some(project => project.id === candidate)) {
+    suffix += 1;
+    candidate = `${baseId}-${suffix}`;
+  }
+  return candidate;
+};
+
+const sanitizeDraft = (draft: ProjectDraft): ProjectDraft => {
+  return {
+    ...draft,
+    name: draft.name.trim(),
+    repositoryPath: draft.repositoryPath.trim(),
+    defaultBranch: draft.defaultBranch?.trim() || undefined,
+    instructions: draft.instructions?.trim() || undefined,
+    preferredProvider: draft.preferredProvider?.trim() || undefined,
+    preferredModel: draft.preferredModel?.trim() || undefined,
+  };
+};
+
+export const ProjectProvider: React.FC<ProjectProviderProps> = ({
+  settings,
+  onSettingsChange,
+  children,
+}) => {
+  const projects = settings.projectProfiles;
+  const activeProjectId = settings.activeProjectId;
+
+  const activeProject = useMemo(() => {
+    if (!activeProjectId) {
+      return projects.length ? projects[0] : null;
+    }
+    return projects.find(project => project.id === activeProjectId) ?? projects[0] ?? null;
+  }, [projects, activeProjectId]);
+
+  const selectProject = useCallback(
+    (projectId: string | null) => {
+      onSettingsChange(previous => {
+        const nextProjects = previous.projectProfiles;
+        if (!projectId) {
+          return {
+            ...previous,
+            activeProjectId: nextProjects.length ? nextProjects[0].id : null,
+          };
+        }
+
+        const exists = nextProjects.some(project => project.id === projectId);
+        return {
+          ...previous,
+          activeProjectId: exists ? projectId : nextProjects[0]?.id ?? null,
+        };
+      });
+    },
+    [onSettingsChange],
+  );
+
+  const upsertProject = useCallback<
+    (draft: ProjectDraft, options?: { activate?: boolean }) => ProjectProfile
+  >(
+    (draft, options) => {
+      const sanitized = sanitizeDraft(draft);
+      if (!sanitized.name || !sanitized.repositoryPath) {
+        throw new Error('El proyecto debe incluir nombre y ruta.');
+      }
+
+      let createdProfile: ProjectProfile | null = null;
+
+      onSettingsChange(previous => {
+        const existingProjects = previous.projectProfiles;
+        const id = ensureProjectId(sanitized, existingProjects);
+
+        createdProfile = {
+          id,
+          name: sanitized.name,
+          repositoryPath: sanitized.repositoryPath,
+          defaultBranch: sanitized.defaultBranch,
+          instructions: sanitized.instructions,
+          preferredProvider: sanitized.preferredProvider,
+          preferredModel: sanitized.preferredModel,
+        };
+
+        const projectIndex = existingProjects.findIndex(project => project.id === id);
+        const nextProjects = [...existingProjects];
+
+        if (projectIndex >= 0) {
+          nextProjects[projectIndex] = createdProfile;
+        } else {
+          nextProjects.push(createdProfile);
+        }
+
+        nextProjects.sort((a, b) => a.name.localeCompare(b.name, 'es'));
+
+        const shouldActivate = options?.activate ?? projectIndex < 0;
+        const currentActiveId = previous.activeProjectId;
+        const stillValid = currentActiveId && nextProjects.some(project => project.id === currentActiveId);
+
+        return {
+          ...previous,
+          projectProfiles: nextProjects,
+          activeProjectId: shouldActivate
+            ? createdProfile.id
+            : stillValid
+            ? currentActiveId
+            : nextProjects[0]?.id ?? null,
+        };
+      });
+
+      if (!createdProfile) {
+        throw new Error('No se pudo actualizar el proyecto.');
+      }
+
+      return createdProfile;
+    },
+    [onSettingsChange],
+  );
+
+  const removeProject = useCallback(
+    (projectId: string) => {
+      onSettingsChange(previous => {
+        const remaining = previous.projectProfiles.filter(project => project.id !== projectId);
+        const nextActive =
+          previous.activeProjectId && previous.activeProjectId !== projectId
+            ? previous.activeProjectId
+            : remaining[0]?.id ?? null;
+
+        return {
+          ...previous,
+          projectProfiles: remaining,
+          activeProjectId: nextActive,
+        };
+      });
+    },
+    [onSettingsChange],
+  );
+
+  const value = useMemo<ProjectContextValue>(
+    () => ({
+      projects,
+      activeProjectId: activeProject?.id ?? null,
+      activeProject,
+      selectProject,
+      upsertProject,
+      removeProject,
+    }),
+    [projects, activeProject, selectProject, upsertProject, removeProject],
+  );
+
+  return <ProjectContext.Provider value={value}>{children}</ProjectContext.Provider>;
+};
+
+export const useProjects = (): ProjectContextValue => {
+  const context = useContext(ProjectContext);
+  if (!context) {
+    throw new Error('useProjects debe utilizarse dentro de un ProjectProvider');
+  }
+  return context;
+};

--- a/src/types/globalSettings.ts
+++ b/src/types/globalSettings.ts
@@ -61,6 +61,16 @@ export interface WorkspacePreferences {
   sidePanel: SidePanelPreferences;
 }
 
+export interface ProjectProfile {
+  id: string;
+  name: string;
+  repositoryPath: string;
+  defaultBranch?: string;
+  instructions?: string;
+  preferredProvider?: string;
+  preferredModel?: string;
+}
+
 export interface DataLocationSettings {
   useCustomPath: boolean;
   customPath?: string;
@@ -81,6 +91,8 @@ export interface GlobalSettings {
   mcpProfiles: McpProfile[];
   workspacePreferences: WorkspacePreferences;
   dataLocation: DataLocationSettings;
+  projectProfiles: ProjectProfile[];
+  activeProjectId: string | null;
 }
 
 export interface PluginSettingsEntry {

--- a/src/utils/__tests__/globalSettings.test.ts
+++ b/src/utils/__tests__/globalSettings.test.ts
@@ -57,4 +57,31 @@ describe('globalSettings schema validation', () => {
 
     expect(validateGlobalSettingsPayload(candidate)).toBe(true);
   });
+
+  it('normaliza proyectos y selecciona el activo más reciente al migrar', () => {
+    const migrated = migratePersistedGlobalSettings({
+      version: CURRENT_SCHEMA_VERSION - 1,
+      projectProfiles: [
+        {
+          id: 'demo',
+          name: ' Demo Workspace ',
+          repositoryPath: ' /projects/demo ',
+          defaultBranch: ' develop ',
+          instructions: 'Revisar CI antes de desplegar.\n ',
+          preferredProvider: ' OpenAI ',
+          preferredModel: ' gpt-4 ',
+        },
+      ],
+      activeProjectId: 'unknown',
+    } as Partial<GlobalSettings>);
+
+    expect(migrated.projectProfiles).toHaveLength(1);
+    const [project] = migrated.projectProfiles;
+    expect(project.repositoryPath).toBe('/projects/demo');
+    expect(project.defaultBranch).toBe('develop');
+    expect(project.preferredProvider).toBe('OpenAI');
+    expect(project.preferredModel).toBe('gpt-4');
+    expect(project.instructions).toBe('Revisar CI antes de desplegar.');
+    expect(migrated.activeProjectId).toBe('demo');
+  });
 });


### PR DESCRIPTION
## Summary
- extend global settings with versioned project profiles and migrate legacy payloads
- add a ProjectProvider to share active project state across chat, orchestration, and repo workflows
- update UI controls and agent prompts to surface the active repository context and manage project profiles
- expand unit, integration, and component tests to cover project selection and repo defaults

## Testing
- npm test -- run

------
https://chatgpt.com/codex/tasks/task_e_68cee98c73f48333a75c674eb86bdf36