### PR TITLE
Refine console message handling in Electron main process

### DIFF
--- a/console-message-handler.cjs
+++ b/console-message-handler.cjs
@@ -1,0 +1,32 @@
+'use strict';
+
+/**
+ * Logs a console message emitted by the renderer with defensive fallbacks.
+ *
+ * @param {{ log: (...args: any[]) => void }} logger
+ * @param {number} level
+ * @param {string} message
+ * @param {number} line
+ * @param {string} sourceId
+ * @returns {boolean} True if the message was logged, false otherwise.
+ */
+function logConsoleMessage(logger, level, message, line, sourceId) {
+  if (!logger || typeof logger.log !== 'function') {
+    return false;
+  }
+
+  if (typeof message !== 'string' || message.length === 0) {
+    return false;
+  }
+
+  const safeLevel = typeof level === 'number' && Number.isFinite(level) ? level : -1;
+  const safeLine = typeof line === 'number' && Number.isFinite(line) ? line : 0;
+  const safeSourceId = typeof sourceId === 'string' && sourceId.length > 0 ? sourceId : '<anonymous>';
+
+  logger.log(`Console [${safeLevel}] ${safeSourceId}:${safeLine} -`, message);
+  return true;
+}
+
+module.exports = {
+  logConsoleMessage
+};

--- a/electron.cjs
+++ b/electron.cjs
@@ -2,6 +2,7 @@ const { app, BrowserWindow, ipcMain, screen } = require('electron');
 const fs = require('fs');
 const path = require('path');
 const { PluginManager } = require('./plugin-manager.cjs');
+const { logConsoleMessage } = require('./console-message-handler.cjs');
 
 const PROVIDER_CONFIG = {
   groq: {
@@ -224,11 +225,19 @@ function createWindow() {
 
   // Log console errors from the page
   /**
-   * @param {Electron.Event<Electron.WebContentsConsoleMessageEventParams>} event
+   * Maneja los mensajes de consola emitidos por el renderer.
+   * @param {Electron.Event} event
+   * @param {number} level
+   * @param {string} message
+   * @param {number} line
+   * @param {string} sourceId
    */
-  mainWindow.webContents.on('console-message', (event) => {
-    const { level, lineNumber, message, sourceId } = event.params;
-    console.log(`Console [${level}] ${sourceId}:${lineNumber} -`, message);
+  mainWindow.webContents.on('console-message', (event, level, message, line, sourceId) => {
+    if (!event) {
+      return;
+    }
+
+    logConsoleMessage(console, level, message, line, sourceId);
   });
 
   // Si el usuario sale del modo fullscreen manualmente, cerrar las ventanas

--- a/tests/console-message-handler.test.ts
+++ b/tests/console-message-handler.test.ts
@@ -1,0 +1,24 @@
+import { describe, expect, it, vi } from 'vitest';
+import handler from '../console-message-handler.cjs';
+
+const { logConsoleMessage } = handler as { logConsoleMessage: (...args: any[]) => boolean };
+
+describe('logConsoleMessage', () => {
+  it('ignores events without a valid message payload', () => {
+    const logger = { log: vi.fn() };
+
+    const result = logConsoleMessage(logger as any, undefined as any, undefined as any, undefined as any, undefined as any);
+
+    expect(result).toBe(false);
+    expect(logger.log).not.toHaveBeenCalled();
+  });
+
+  it('logs events with valid payload applying defensive defaults', () => {
+    const logger = { log: vi.fn() };
+
+    const result = logConsoleMessage(logger as any, 2, 'Test message', undefined as any, '');
+
+    expect(result).toBe(true);
+    expect(logger.log).toHaveBeenCalledWith('Console [2] <anonymous>:0 -', 'Test message');
+  });
+});


### PR DESCRIPTION
## Summary
- update the Electron `console-message` listener to use the documented event signature and delegate to a defensive logger
- add a reusable console message logger with fallbacks to ignore invalid payloads
- cover the logger with Vitest to ensure events without payloads no longer raise exceptions

## Testing
- `npm test -- --run`


------
https://chatgpt.com/codex/tasks/task_e_68cef068161c83338c445e4d3205c10a