### PR TITLE
Replace Ajv with CSP-safe validation

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,26 +13,27 @@
     "test": "vitest"
   },
   "dependencies": {
+    "@noble/hashes": "^1.8.0",
     "@tauri-apps/api": "^1.5.0",
     "@types/three": "^0.179.0",
-    "ajv": "^8.17.1",
+    "jsonschema": "^1.5.0",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
     "three": "^0.179.1"
   },
   "devDependencies": {
     "@tauri-apps/cli": "^1.5.0",
+    "@testing-library/jest-dom": "^6.1.5",
+    "@testing-library/react": "^14.2.1",
     "@types/react": "^18.2.0",
     "@types/react-dom": "^18.2.0",
     "@vitejs/plugin-react": "^4.2.0",
     "electron": "^37.3.1",
     "electron-builder": "^24.6.0",
+    "jsdom": "^24.0.0",
     "typescript": "^5.2.0",
     "vite": "^7.1.3",
-    "vitest": "^1.5.0",
-    "@testing-library/react": "^14.2.1",
-    "@testing-library/jest-dom": "^6.1.5",
-    "jsdom": "^24.0.0"
+    "vitest": "^1.5.0"
   },
   "build": {
     "appId": "com.junglelabstudio.app",

--- a/src/core/plugins/index.ts
+++ b/src/core/plugins/index.ts
@@ -1,3 +1,6 @@
+import { sha256 } from '@noble/hashes/sha256';
+import { bytesToHex } from '@noble/hashes/utils';
+
 import type { AgentManifest } from '../../types/agents';
 
 export type PluginCapability =
@@ -147,8 +150,7 @@ const computeSha256 = async (payload: string): Promise<string> => {
     return bytes.map(byte => byte.toString(16).padStart(2, '0')).join('');
   }
 
-  const { createHash } = await import('crypto');
-  return createHash('sha256').update(payload).digest('hex');
+  return bytesToHex(sha256(data));
 };
 
 const prepareForChecksum = (manifest: PluginManifest): Omit<PluginManifest, 'integrity'> => {


### PR DESCRIPTION
## Summary
- swap Ajv-based schema validation for jsonschema in global settings and preset loading to avoid CSP unsafe-eval errors
- normalize nullable fields with helper schema wrappers and keep validation logic centralized
- replace Node crypto fallback with @noble/hashes SHA-256 implementation to keep hashing CSP-friendly

## Testing
- npm test
- npx vite build

------
https://chatgpt.com/codex/tasks/task_e_68cef19efc508333b7bdb4150384108f