### PR TITLE
Replace jsonschema usage with internal validation

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,7 +16,6 @@
     "@noble/hashes": "^1.8.0",
     "@tauri-apps/api": "^1.5.0",
     "@types/three": "^0.179.0",
-    "jsonschema": "^1.5.0",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
     "three": "^0.179.1"


### PR DESCRIPTION
## Summary
- replace the runtime JSON schema validation for global settings with explicit type guards and helper checks
- add local validation helpers for preset configs to remove the jsonschema dependency
- drop the unused jsonschema package from the npm dependencies

## Testing
- npx vite build

------
https://chatgpt.com/codex/tasks/task_e_68cef396cd988333bc55bbe719808b97