### PR TITLE
Refactor plugin hashing to use native crypto

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,7 +13,6 @@
     "test": "vitest"
   },
   "dependencies": {
-    "@noble/hashes": "^1.8.0",
     "@tauri-apps/api": "^1.5.0",
     "@types/three": "^0.179.0",
     "react": "^18.2.0",


### PR DESCRIPTION
## Summary
- replace the noble hashes dependency with native Web Crypto / Node.js hashing for plugin manifest integrity
- remove the unused `@noble/hashes` package from the project dependencies

## Testing
- npm run test
- npx vite build

------
https://chatgpt.com/codex/tasks/task_e_68cef685273883339fddb41d89db6a5b