### PR TITLE
Refactor model catalog metadata for gallery

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,12 @@ Al iniciar la versión de escritorio se detectan instalaciones previas en el dir
 - Puedes seguir utilizando **Añadir al compositor** para insertar fragmentos específicos sin reemplazar el borrador actual.
 - El dashboard de calidad incorpora una sección **Mensajes compartidos** con el histórico de hand-offs más recientes.
 
+## Catálogo de modelos locales
+
+- La galería integrada lista los modelos cuantizados más habituales para asistentes de código y conversación, incluyendo Phi-3 Mini, Mistral Instruct (Q4/Q5), WizardCoder 15B y DeepSeek Coder 6.7B.
+- Cada ficha muestra el proveedor de origen y las etiquetas principales para ayudarte a elegir el modelo adecuado antes de descargarlo o activarlo.
+- Para descargar modelos alojados en Hugging Face es necesario aceptar previamente la licencia de cada repositorio y exponer un token de acceso mediante las variables de entorno `HF_TOKEN` o `HUGGINGFACE_TOKEN` antes de iniciar la aplicación (por ejemplo, `export HF_TOKEN=hf_xxx && npm run dev`).
+
 ## Pruebas
 
 Ejecuta toda la batería de tests con:

--- a/src/components/models/ModelGallery.css
+++ b/src/components/models/ModelGallery.css
@@ -84,6 +84,39 @@
   font-size: 1.1rem;
 }
 
+.model-card__source {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  flex-wrap: wrap;
+  font-size: 0.8rem;
+  color: rgba(255, 255, 255, 0.7);
+}
+
+.model-card__provider {
+  font-weight: 600;
+  color: rgba(255, 255, 255, 0.85);
+}
+
+.model-card__tags {
+  list-style: none;
+  display: flex;
+  gap: 0.35rem;
+  margin: 0;
+  padding: 0;
+}
+
+.model-card__tags li {
+  padding: 0.2rem 0.55rem;
+  border-radius: 999px;
+  background: rgba(255, 255, 255, 0.08);
+  border: 1px solid rgba(255, 255, 255, 0.12);
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+  font-size: 0.7rem;
+  color: rgba(255, 255, 255, 0.75);
+}
+
 .model-card__status {
   display: inline-block;
   margin-top: 0.35rem;

--- a/src/components/models/ModelGallery.tsx
+++ b/src/components/models/ModelGallery.tsx
@@ -52,6 +52,17 @@ export const ModelGallery: React.FC = () => {
                 {model.active && <span className="model-card__pill">Activo</span>}
               </header>
 
+              <div className="model-card__source">
+                <span className="model-card__provider">{model.provider}</span>
+                {!!model.tags.length && (
+                  <ul className="model-card__tags">
+                    {model.tags.map(tag => (
+                      <li key={tag}>{tag}</li>
+                    ))}
+                  </ul>
+                )}
+              </div>
+
               <p className="model-card__description">{model.description}</p>
 
               <dl className="model-card__meta">

--- a/src/hooks/useLocalModels.ts
+++ b/src/hooks/useLocalModels.ts
@@ -7,6 +7,8 @@ export interface LocalModel {
   id: string;
   name: string;
   description: string;
+  provider: string;
+  tags: string[];
   size: number;
   checksum: string;
   status: LocalModelStatus;
@@ -19,6 +21,8 @@ interface BackendModelSummary {
   id: string;
   name: string;
   description: string;
+  provider: string;
+  tags: string[];
   size: number;
   checksum: string;
   status: LocalModelStatus;
@@ -82,6 +86,8 @@ export const useLocalModels = (): UseLocalModelsResult => {
           id: agent.id,
           name: agent.name,
           description: agent.description,
+          provider: 'Catálogo local',
+          tags: [],
           size: 0,
           checksum: agent.model,
           status: agent.status === 'Cargando' ? 'downloading' : agent.status === 'Disponible' ? 'ready' : 'not_installed',
@@ -102,6 +108,8 @@ export const useLocalModels = (): UseLocalModelsResult => {
           id: model.id,
           name: model.name,
           description: model.description,
+          provider: model.provider,
+          tags: model.tags,
           size: model.size,
           checksum: model.checksum,
           status: model.status,


### PR DESCRIPTION
## Summary
- enrich the Tauri model catalog with provider metadata, optional direct URLs, and additional curated Hugging Face models while honoring SHA-256/size validation
- expose the new provider and tag fields in the list_models response and render them in the Model Gallery UI
- document the Hugging Face token requirement to fetch/download gated models from the desktop app

## Testing
- npm run test -- --run
- cargo test --manifest-path src-tauri/Cargo.toml *(fails: missing system library glib-2.0 required by glib-sys)*

------
https://chatgpt.com/codex/tasks/task_e_68cefa28c4408333a67c89eb0fc48931