### PR TITLE
Move project management to global settings and simplify chat side panel

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -71,12 +71,7 @@ const AppContent: React.FC<AppContentProps> = ({
         <div className={`app-body sidebar-${sidePanelPosition}`}>
           {sidePanelPosition === 'left' && (
             <aside className="app-sidebar">
-              <SidePanel
-                apiKeys={apiKeys}
-                presenceMap={presenceMap}
-                onRefreshAgentPresence={refresh}
-                onOpenGlobalSettings={() => setSettingsOpen(true)}
-              />
+              <SidePanel onOpenGlobalSettings={() => setSettingsOpen(true)} />
             </aside>
           )}
 
@@ -86,12 +81,7 @@ const AppContent: React.FC<AppContentProps> = ({
 
           {sidePanelPosition === 'right' && (
             <aside className="app-sidebar">
-              <SidePanel
-                apiKeys={apiKeys}
-                presenceMap={presenceMap}
-                onRefreshAgentPresence={refresh}
-                onOpenGlobalSettings={() => setSettingsOpen(true)}
-              />
+              <SidePanel onOpenGlobalSettings={() => setSettingsOpen(true)} />
             </aside>
           )}
         </div>

--- a/src/components/chat/SidePanel.css
+++ b/src/components/chat/SidePanel.css
@@ -2,8 +2,8 @@
   display: flex;
   flex-direction: column;
   height: 100%;
-  padding: 16px;
-  gap: 16px;
+  padding: 20px;
+  gap: 20px;
   background: rgba(10, 10, 10, 0.92);
   border-left: 1px solid rgba(255, 255, 255, 0.08);
   overflow-y: auto;
@@ -23,285 +23,188 @@
 .sidebar-section {
   display: flex;
   flex-direction: column;
-  gap: 10px;
-  padding: 14px;
-  border-radius: 12px;
+  gap: 16px;
+  padding: 20px;
+  border-radius: 18px;
   background: rgba(18, 18, 18, 0.85);
   border: 1px solid rgba(255, 255, 255, 0.06);
-  box-shadow: 0 8px 20px rgba(0, 0, 0, 0.45);
-}
-
-.project-manager {
-  display: grid;
-  grid-template-columns: 1fr;
-  gap: 8px;
-}
-
-.project-manager label {
-  font-size: 12px;
-  text-transform: uppercase;
-  letter-spacing: 0.6px;
-  color: rgba(255, 255, 255, 0.6);
-}
-
-.project-manager input,
-.project-manager select,
-.project-manager textarea {
-  width: 100%;
-  border: 1px solid rgba(255, 255, 255, 0.12);
-  border-radius: 8px;
-  background: rgba(0, 0, 0, 0.3);
-  color: #fff;
-  padding: 8px 10px;
-  font-size: 13px;
-}
-
-.project-manager select {
-  background: rgba(0, 0, 0, 0.4);
-}
-
-.project-manager textarea {
-  resize: vertical;
-  min-height: 72px;
-}
-
-.project-manager .project-error {
-  margin-top: 4px;
-  font-size: 12px;
-  color: #ff8a80;
-}
-
-.project-actions {
-  display: flex;
-  gap: 8px;
-  justify-content: flex-end;
-}
-
-.project-actions button {
-  border: none;
-  border-radius: 8px;
-  padding: 6px 12px;
-  font-size: 12px;
-  cursor: pointer;
-  background: rgba(255, 255, 255, 0.12);
-  color: #fff;
-  text-transform: uppercase;
-  letter-spacing: 0.6px;
-}
-
-.project-actions button:disabled {
-  opacity: 0.5;
-  cursor: default;
-}
-
-.project-actions button.danger {
-  background: rgba(255, 82, 82, 0.35);
+  box-shadow: 0 12px 28px rgba(0, 0, 0, 0.45);
 }
 
 .sidebar-section header h2 {
-  font-size: 16px;
+  font-size: 18px;
   font-weight: 600;
   letter-spacing: 0.5px;
 }
 
 .sidebar-section header p {
-  margin-top: 2px;
-  font-size: 12px;
-  color: rgba(255, 255, 255, 0.6);
+  margin-top: 4px;
+  font-size: 13px;
+  color: rgba(255, 255, 255, 0.65);
 }
 
-.provider-grid {
-  display: grid;
-  grid-template-columns: repeat(auto-fill, minmax(160px, 1fr));
-  gap: 8px;
+.model-panel {
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
 }
 
-.provider-card {
-  padding: 10px;
-  border-radius: 10px;
-  border: 1px solid rgba(255, 255, 255, 0.08);
-  background: rgba(255, 255, 255, 0.04);
+.model-panel__summary {
   display: flex;
   flex-direction: column;
   gap: 6px;
-  transition: border 0.2s ease, background 0.2s ease;
+  padding: 16px;
+  border-radius: 16px;
+  background: linear-gradient(135deg, rgba(142, 141, 255, 0.22), rgba(77, 208, 225, 0.18));
+  border: 1px solid rgba(142, 141, 255, 0.35);
 }
 
-.provider-card header {
-  display: flex;
-  justify-content: space-between;
-  align-items: center;
-  font-size: 13px;
-}
-
-.provider-name {
-  font-weight: 600;
-}
-
-.provider-status {
+.model-panel__summary-label {
   font-size: 12px;
   text-transform: uppercase;
   letter-spacing: 0.6px;
-  color: rgba(255, 255, 255, 0.6);
-}
-
-.provider-card.status-online {
-  border-color: rgba(102, 255, 102, 0.4);
-  background: rgba(102, 255, 102, 0.12);
-}
-
-.provider-card.status-loading {
-  border-color: rgba(255, 217, 102, 0.3);
-}
-
-.provider-card.status-error {
-  border-color: rgba(255, 102, 102, 0.45);
-  background: rgba(255, 102, 102, 0.16);
-}
-
-.provider-body {
-  display: flex;
-  flex-direction: column;
-  gap: 2px;
-  font-size: 12px;
   color: rgba(255, 255, 255, 0.7);
 }
 
-.local-model-card {
-  margin-top: 6px;
-  padding: 12px;
-  border-radius: 10px;
-  background: linear-gradient(135deg, rgba(77, 208, 225, 0.15), rgba(142, 141, 255, 0.12));
-  border: 1px solid rgba(142, 141, 255, 0.35);
-  display: flex;
-  justify-content: space-between;
-  align-items: center;
-  gap: 8px;
-}
-
-.local-model-card h3 {
-  font-size: 14px;
-  font-weight: 600;
-  margin-bottom: 2px;
-}
-
-.local-model-card p {
-  font-size: 12px;
+.model-panel__summary-sub {
+  font-size: 13px;
   color: rgba(255, 255, 255, 0.75);
 }
 
-.local-model-card button {
-  border: none;
-  border-radius: 999px;
-  padding: 6px 12px;
-  background: rgba(142, 141, 255, 0.45);
-  color: #fff;
-  cursor: pointer;
-  font-size: 12px;
-  letter-spacing: 0.6px;
-  text-transform: uppercase;
+.model-panel__counts {
+  display: flex;
+  gap: 12px;
 }
 
-.sidebar-stats {
-  list-style: none;
-  margin: 0;
-  padding: 0;
-  display: grid;
-  grid-template-columns: repeat(auto-fit, minmax(120px, 1fr));
-  gap: 8px;
-}
-
-.sidebar-stats li {
-  padding: 8px 10px;
-  border-radius: 8px;
-  background: rgba(255, 255, 255, 0.04);
-  border: 1px solid rgba(255, 255, 255, 0.05);
+.model-panel__counts > div {
+  flex: 1;
+  padding: 12px 14px;
+  border-radius: 14px;
+  background: rgba(255, 255, 255, 0.05);
+  border: 1px solid rgba(255, 255, 255, 0.08);
   display: flex;
   flex-direction: column;
   gap: 4px;
 }
 
-.stat-label {
+.model-panel__count-label {
   font-size: 11px;
-  letter-spacing: 0.5px;
   text-transform: uppercase;
+  letter-spacing: 0.5px;
   color: rgba(255, 255, 255, 0.55);
 }
 
-.stat-value {
-  font-size: 18px;
+.model-panel__count-value {
+  font-size: 20px;
   font-weight: 600;
 }
 
-.suggestion-list {
+.model-panel__list {
   list-style: none;
   margin: 0;
   padding: 0;
   display: flex;
   flex-direction: column;
-  gap: 8px;
+  gap: 10px;
 }
 
-.suggestion-list li button {
-  width: 100%;
-  text-align: left;
+.model-panel__item {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  gap: 12px;
+  padding: 12px 14px;
+  border-radius: 12px;
   background: rgba(255, 255, 255, 0.04);
   border: 1px solid rgba(255, 255, 255, 0.06);
-  border-radius: 8px;
-  padding: 10px 12px;
-  color: #fff;
-  cursor: pointer;
+}
+
+.model-panel__item.is-active {
+  border-color: rgba(142, 141, 255, 0.6);
+  background: linear-gradient(135deg, rgba(142, 141, 255, 0.25), rgba(255, 183, 77, 0.18));
+}
+
+.model-panel__item-info {
   display: flex;
   flex-direction: column;
-  gap: 4px;
-  transition: border 0.2s ease, transform 0.2s ease;
+  gap: 2px;
 }
 
-.suggestion-list li button:hover:not(:disabled) {
-  border-color: rgba(255, 183, 77, 0.6);
-  transform: translateY(-1px);
-}
-
-.suggestion-list li button:disabled {
-  opacity: 0.6;
-  cursor: default;
-}
-
-.suggestion-list strong {
-  font-size: 13px;
+.model-panel__name {
   font-weight: 600;
+  font-size: 14px;
 }
 
-.suggestion-list span {
+.model-panel__provider {
   font-size: 12px;
   color: rgba(255, 255, 255, 0.65);
 }
 
-.command-list {
+.model-panel__status {
+  font-size: 12px;
+  letter-spacing: 0.5px;
+  text-transform: uppercase;
+  color: rgba(255, 255, 255, 0.7);
+}
+
+.model-panel__status.status-ready {
+  color: rgba(129, 212, 250, 0.95);
+}
+
+.model-panel__status.status-downloading {
+  color: rgba(255, 183, 77, 0.9);
+}
+
+.model-panel__status.status-not_installed {
+  color: rgba(255, 255, 255, 0.45);
+}
+
+.model-panel__loading,
+.model-panel__error,
+.model-panel__empty {
+  font-size: 12px;
+  color: rgba(255, 255, 255, 0.7);
+}
+
+.model-panel__error {
+  color: #ff8a80;
+}
+
+.model-panel__actions {
   display: flex;
-  flex-direction: column;
-  gap: 6px;
+  gap: 12px;
+  justify-content: flex-end;
 }
 
-.command-list button {
-  text-align: left;
-  border: 1px solid rgba(255, 255, 255, 0.06);
+.model-panel__actions button {
+  border: none;
   border-radius: 999px;
-  padding: 6px 12px;
-  background: rgba(255, 255, 255, 0.05);
+  padding: 8px 16px;
+  font-size: 12px;
+  letter-spacing: 0.6px;
+  text-transform: uppercase;
+  background: rgba(255, 255, 255, 0.12);
   color: #fff;
-  font-size: 12px;
-  letter-spacing: 0.4px;
   cursor: pointer;
-  transition: border 0.2s ease, transform 0.2s ease;
 }
 
-.command-list button:hover {
-  border-color: rgba(255, 183, 77, 0.55);
-  transform: translateY(-1px);
+.model-panel__actions button:disabled {
+  opacity: 0.5;
+  cursor: default;
 }
 
-.command-empty {
-  font-size: 12px;
-  color: rgba(255, 255, 255, 0.6);
+.model-panel__actions .primary {
+  background: linear-gradient(135deg, rgba(142, 141, 255, 0.65), rgba(255, 183, 77, 0.65));
+  color: #0a0a0a;
+  font-weight: 600;
+}
+
+@media (max-width: 1200px) {
+  .sidebar {
+    padding: 16px;
+  }
+
+  .sidebar-section {
+    padding: 16px;
+  }
 }

--- a/src/components/chat/SidePanel.tsx
+++ b/src/components/chat/SidePanel.tsx
@@ -1,500 +1,96 @@
-import React, { useMemo, useState, useEffect, useCallback } from 'react';
+import React, { useMemo } from 'react';
 import './SidePanel.css';
-import { useAgents } from '../../core/agents/AgentContext';
-import { AgentPresenceEntry, AgentPresenceStatus } from '../../core/agents/presence';
-import { useMessages } from '../../core/messages/MessageContext';
-import { ApiKeySettings, ProjectProfile } from '../../types/globalSettings';
 import { useLocalModels } from '../../hooks/useLocalModels';
-import { getAgentDisplayName, getAgentVersionLabel } from '../../utils/agentDisplay';
-import { useProjects, ProjectDraft } from '../../core/projects/ProjectContext';
-
-interface ProviderSummary {
-  id: string;
-  label: string;
-  status: AgentPresenceStatus;
-  active: number;
-  total: number;
-  hasKey: boolean;
-}
-
-interface SuggestionItem {
-  id: string;
-  title: string;
-  description: string;
-  action?: () => void;
-}
-
-const PROVIDER_LABELS: Record<string, string> = {
-  openai: 'OpenAI',
-  anthropic: 'Anthropic',
-  groq: 'Groq',
-};
-
-const createDraftFromProject = (project?: ProjectProfile | null): ProjectDraft => ({
-  id: project?.id,
-  name: project?.name ?? '',
-  repositoryPath: project?.repositoryPath ?? '',
-  defaultBranch: project?.defaultBranch ?? '',
-  instructions: project?.instructions ?? '',
-  preferredProvider: project?.preferredProvider ?? '',
-  preferredModel: project?.preferredModel ?? '',
-});
 
 interface SidePanelProps {
-  apiKeys: ApiKeySettings;
-  presenceMap: Map<string, AgentPresenceEntry>;
-  onRefreshAgentPresence: (agentId?: string) => void | Promise<void>;
   onOpenGlobalSettings: () => void;
 }
 
-export const SidePanel: React.FC<SidePanelProps> = ({
-  apiKeys,
-  presenceMap,
-  onRefreshAgentPresence,
-  onOpenGlobalSettings,
-}) => {
-  const { agents } = useAgents();
-  const {
-    messages,
-    quickCommands,
-    appendToDraft,
-    pendingResponses,
-    agentResponses,
-    formatTimestamp,
-  } = useMessages();
-  const { models } = useLocalModels();
-  const { projects, activeProject, selectProject, upsertProject, removeProject } = useProjects();
-  const [selectedProjectId, setSelectedProjectId] = useState<string>(activeProject?.id ?? 'new');
-  const [projectForm, setProjectForm] = useState<ProjectDraft>(() => createDraftFromProject(activeProject));
-  const [formError, setFormError] = useState<string | null>(null);
+const formatStatus = (status: string, active: boolean, progress?: number) => {
+  if (status === 'ready') {
+    return active ? 'Activo' : 'Listo';
+  }
+  if (status === 'downloading') {
+    const percent = Math.round((progress ?? 0) * 100);
+    return percent > 0 ? `${percent}%` : 'Descargando';
+  }
+  return 'No instalado';
+};
 
-  const configuredProviders = useMemo(() => {
-    const map = new Map<string, string>();
-    Object.entries(apiKeys).forEach(([key, value]) => {
-      if (typeof value !== 'string') {
-        if (value) {
-          map.set(key.trim().toLowerCase(), String(value));
-        }
-        return;
-      }
-      const trimmed = value.trim();
-      if (trimmed) {
-        map.set(key.trim().toLowerCase(), trimmed);
-      }
-    });
-    return map;
-  }, [apiKeys]);
+export const SidePanel: React.FC<SidePanelProps> = ({ onOpenGlobalSettings }) => {
+  const { models, isLoading, error, refresh } = useLocalModels();
 
-  useEffect(() => {
-    if (!projects.length) {
-      setSelectedProjectId('new');
-      setProjectForm(createDraftFromProject());
-      return;
-    }
+  const summary = useMemo(() => {
+    const activeModel = models.find(model => model.active) ?? null;
+    const readyCount = models.filter(model => model.status === 'ready').length;
+    const downloadingCount = models.filter(model => model.status === 'downloading').length;
 
-    if (!activeProject) {
-      if (!projects.some(project => project.id === selectedProjectId)) {
-        const [first] = projects;
-        if (first) {
-          setSelectedProjectId(first.id);
-          setProjectForm(createDraftFromProject(first));
-          setFormError(null);
-        }
-      }
-      return;
-    }
-
-    if (selectedProjectId === 'new' || selectedProjectId === activeProject.id) {
-      setSelectedProjectId(activeProject.id);
-      setProjectForm(createDraftFromProject(activeProject));
-      setFormError(null);
-      return;
-    }
-
-    if (!projects.some(project => project.id === selectedProjectId)) {
-      setSelectedProjectId(activeProject.id);
-      setProjectForm(createDraftFromProject(activeProject));
-      setFormError(null);
-    }
-  }, [activeProject, projects, selectedProjectId]);
-
-  const handleProjectSelectChange = useCallback(
-    (event: React.ChangeEvent<HTMLSelectElement>) => {
-      const value = event.target.value;
-      setFormError(null);
-      if (value === 'new') {
-        setSelectedProjectId('new');
-        setProjectForm(createDraftFromProject());
-        return;
-      }
-
-      setSelectedProjectId(value);
-      const match = projects.find(project => project.id === value) ?? null;
-      setProjectForm(createDraftFromProject(match));
-    },
-    [projects],
-  );
-
-  const updateFormField = useCallback(
-    (field: keyof ProjectDraft) =>
-      (event: React.ChangeEvent<HTMLInputElement | HTMLTextAreaElement>) => {
-        const { value } = event.target;
-        setProjectForm(prev => ({ ...prev, [field]: value }));
-        setFormError(null);
-      },
-    [],
-  );
-
-  const handleSaveProject = useCallback(() => {
-    if (!projectForm.name?.trim() || !projectForm.repositoryPath?.trim()) {
-      setFormError('Indica al menos nombre y ruta del repositorio.');
-      return;
-    }
-
-    try {
-      const saved = upsertProject(projectForm, { activate: selectedProjectId === 'new' });
-      setSelectedProjectId(saved.id);
-      setProjectForm(createDraftFromProject(saved));
-      setFormError(null);
-    } catch (error) {
-      const message = error instanceof Error ? error.message : 'No se pudo guardar el proyecto.';
-      setFormError(message);
-    }
-  }, [projectForm, selectedProjectId, upsertProject]);
-
-  const handleActivateProject = useCallback(() => {
-    if (selectedProjectId === 'new') {
-      return;
-    }
-    selectProject(selectedProjectId);
-    setFormError(null);
-  }, [selectProject, selectedProjectId]);
-
-  const handleDeleteProject = useCallback(() => {
-    if (selectedProjectId === 'new') {
-      setProjectForm(createDraftFromProject());
-      setFormError(null);
-      return;
-    }
-
-    removeProject(selectedProjectId);
-    setSelectedProjectId('new');
-    setProjectForm(createDraftFromProject());
-    setFormError(null);
-  }, [removeProject, selectedProjectId]);
-
-  const providerSummaries = useMemo<ProviderSummary[]>(() => {
-    const grouped = new Map<
-      string,
-      ProviderSummary & { statusCounts: Record<AgentPresenceStatus, number> }
-    >();
-
-    agents
-      .filter(agent => agent.kind === 'cloud')
-      .forEach(agent => {
-        const providerKey = (agent.provider || agent.channel || agent.id).toLowerCase();
-        const providerValue = configuredProviders.get(providerKey);
-        if (!providerValue) {
-          return;
-        }
-        const providerId = providerKey;
-        const summary = grouped.get(providerId) ?? {
-          id: providerId,
-          label: PROVIDER_LABELS[providerId] ?? providerId.toUpperCase(),
-          status: 'offline' as AgentPresenceStatus,
-          active: 0,
-          total: 0,
-          hasKey: Boolean(providerValue),
-          statusCounts: {
-            online: 0,
-            offline: 0,
-            loading: 0,
-            error: 0,
-          } as Record<AgentPresenceStatus, number>,
-        };
-
-        const presence = presenceMap.get(agent.id);
-        const status = presence?.status ?? (agent.active ? 'loading' : 'offline');
-        summary.total += 1;
-        summary.active += agent.active ? 1 : 0;
-        summary.statusCounts[status] += 1;
-        summary.hasKey = summary.hasKey || Boolean(providerValue);
-        grouped.set(providerId, summary);
-      });
-
-    return Array.from(grouped.values())
-      .map(entry => {
-        const status: AgentPresenceStatus =
-          entry.statusCounts.error > 0
-            ? 'error'
-            : entry.statusCounts.online > 0
-            ? 'online'
-            : entry.statusCounts.loading > 0
-            ? 'loading'
-            : 'offline';
-
-        return {
-          id: entry.id,
-          label: entry.label,
-          status,
-          active: entry.active,
-          total: entry.total,
-          hasKey: entry.hasKey,
-        };
-      })
-      .sort((a, b) => a.label.localeCompare(b.label));
-  }, [agents, apiKeys, configuredProviders, presenceMap]);
-
-  const activeModel = useMemo(() => models.find(model => model.active), [models]);
-
-  const messageStats = useMemo(
-    () => {
-      const userCount = messages.filter(message => message.author === 'user').length;
-      const agentCount = messages.filter(message => message.author === 'agent').length;
-      const systemCount = messages.filter(message => message.author === 'system').length;
-
-      return [
-        { label: 'Mensajes usuario', value: userCount },
-        { label: 'Mensajes agentes', value: agentCount },
-        { label: 'Mensajes sistema', value: systemCount },
-        { label: 'Pendientes', value: pendingResponses },
-      ];
-    },
-    [messages, pendingResponses],
-  );
-
-  const latestAgentResponse = agentResponses.length ? agentResponses[agentResponses.length - 1] : null;
-  const latestAgentSummary = latestAgentResponse
-    ? (() => {
-        const agent = latestAgentResponse.agentId
-          ? agents.find(candidate => candidate.id === latestAgentResponse.agentId)
-          : undefined;
-        if (!agent) {
-          return null;
-        }
-        return {
-          name: getAgentDisplayName(agent),
-          variant: agent.kind === 'local' ? getAgentVersionLabel(agent) : agent.provider,
-          timestamp: formatTimestamp(latestAgentResponse.timestamp),
-        };
-      })()
-    : null;
-
-  const suggestions = useMemo<SuggestionItem[]>(() => {
-    const items: SuggestionItem[] = [];
-
-    if (pendingResponses > 0) {
-      items.push({
-        id: 'pending',
-        title: 'Revisar respuestas pendientes',
-        description: 'Hay agentes pensando todavía, actualiza su estado.',
-        action: () => void onRefreshAgentPresence(),
-      });
-    }
-
-    if (!activeModel) {
-      items.push({
-        id: 'local-model',
-        title: 'Activa un modelo local',
-        description: 'Jarvis está inactivo, gestiona los modelos en los ajustes globales.',
-        action: onOpenGlobalSettings,
-      });
-    }
-
-    if (latestAgentSummary) {
-      items.push({
-        id: 'latest-agent',
-        title: `Última respuesta de ${latestAgentSummary.name}`,
-        description: `${latestAgentSummary.variant ?? ''} · ${latestAgentSummary.timestamp}`.trim(),
-      });
-    }
-
-    if (!items.length) {
-      items.push({
-        id: 'start',
-        title: 'Lanza una nueva instrucción',
-        description: 'Combina @menciones para coordinar varios agentes en la misma orden.',
-      });
-    }
-
-    return items.slice(0, 3);
-  }, [activeModel, latestAgentSummary, onOpenGlobalSettings, onRefreshAgentPresence, pendingResponses]);
+    return { activeModel, readyCount, downloadingCount };
+  }, [models]);
 
   return (
     <div className="sidebar">
       <section className="sidebar-section">
         <header>
-          <h2>Proyectos</h2>
-          <p>Configura repositorios y preferencias activas.</p>
+          <h2>Modelos locales</h2>
+          <p>Revisa rápidamente los modelos descargados en este equipo.</p>
         </header>
-        <div className="project-manager">
-          <label htmlFor="project-selector">Proyecto</label>
-          <select
-            id="project-selector"
-            value={selectedProjectId}
-            onChange={handleProjectSelectChange}
-          >
-            <option value="new">Nuevo proyecto…</option>
-            {projects.map(project => (
-              <option key={project.id} value={project.id}>
-                {project.name}
-              </option>
+
+        <div className="model-panel">
+          <div className="model-panel__summary">
+            <span className="model-panel__summary-label">Modelo activo</span>
+            <strong>{summary.activeModel ? summary.activeModel.name : 'Ninguno'}</strong>
+            <span className="model-panel__summary-sub">
+              {summary.activeModel
+                ? summary.activeModel.provider
+                : 'Gestiona los modelos para activarlos en el orquestador local.'}
+            </span>
+          </div>
+
+          <div className="model-panel__counts">
+            <div>
+              <span className="model-panel__count-label">Listos</span>
+              <span className="model-panel__count-value">{summary.readyCount}</span>
+            </div>
+            <div>
+              <span className="model-panel__count-label">Descargando</span>
+              <span className="model-panel__count-value">{summary.downloadingCount}</span>
+            </div>
+          </div>
+
+          {isLoading && <p className="model-panel__loading">Sincronizando inventario…</p>}
+          {error && <p className="model-panel__error">{error}</p>}
+
+          <ul className="model-panel__list">
+            {models.map(model => (
+              <li
+                key={model.id}
+                className={`model-panel__item ${model.active ? 'is-active' : ''}`}
+                aria-label={`${model.name} · ${formatStatus(model.status, model.active, model.progress)}`}
+              >
+                <div className="model-panel__item-info">
+                  <span className="model-panel__name">{model.name}</span>
+                  <span className="model-panel__provider">{model.provider}</span>
+                </div>
+                <span className={`model-panel__status status-${model.status}`}>
+                  {formatStatus(model.status, model.active, model.progress)}
+                </span>
+              </li>
             ))}
-          </select>
+          </ul>
 
-          <label htmlFor="project-name">Nombre</label>
-          <input
-            id="project-name"
-            type="text"
-            value={projectForm.name ?? ''}
-            onChange={updateFormField('name')}
-            placeholder="Nombre descriptivo"
-          />
-
-          <label htmlFor="project-path">Repositorio</label>
-          <input
-            id="project-path"
-            type="text"
-            value={projectForm.repositoryPath ?? ''}
-            onChange={updateFormField('repositoryPath')}
-            placeholder="/ruta/al/repositorio"
-          />
-
-          <label htmlFor="project-branch">Rama por defecto</label>
-          <input
-            id="project-branch"
-            type="text"
-            value={projectForm.defaultBranch ?? ''}
-            onChange={updateFormField('defaultBranch')}
-            placeholder="main"
-          />
-
-          <label htmlFor="project-provider">Proveedor preferido</label>
-          <input
-            id="project-provider"
-            type="text"
-            value={projectForm.preferredProvider ?? ''}
-            onChange={updateFormField('preferredProvider')}
-            placeholder="openai"
-          />
-
-          <label htmlFor="project-model">Modelo preferido</label>
-          <input
-            id="project-model"
-            type="text"
-            value={projectForm.preferredModel ?? ''}
-            onChange={updateFormField('preferredModel')}
-            placeholder="gpt-4"
-          />
-
-          <label htmlFor="project-instructions">Instrucciones fijas</label>
-          <textarea
-            id="project-instructions"
-            value={projectForm.instructions ?? ''}
-            onChange={updateFormField('instructions')}
-            placeholder="Notas clave para este repositorio"
-            rows={3}
-          />
-
-          {formError && <p className="project-error">{formError}</p>}
-
-          <div className="project-actions">
-            <button type="button" onClick={handleSaveProject}>
-              Guardar
-            </button>
-            <button
-              type="button"
-              onClick={handleActivateProject}
-              disabled={selectedProjectId === 'new' || activeProject?.id === selectedProjectId}
-            >
-              Activar
-            </button>
-            <button
-              type="button"
-              className="danger"
-              onClick={handleDeleteProject}
-              disabled={selectedProjectId === 'new'}
-            >
-              Eliminar
-            </button>
-          </div>
+          {!models.length && !isLoading && (
+            <p className="model-panel__empty">No hay modelos locales instalados.</p>
+          )}
         </div>
-      </section>
 
-      <section className="sidebar-section">
-        <header>
-          <h2>Proveedores</h2>
-          <p>Resumen rápido del estado de conexión.</p>
-        </header>
-        <div className="provider-grid">
-          {providerSummaries.map(provider => (
-            <article key={provider.id} className={`provider-card status-${provider.status}`}>
-              <header>
-                <span className="provider-name">{provider.label}</span>
-                <span className="provider-status">{provider.status}</span>
-              </header>
-              <div className="provider-body">
-                <span>{provider.active} activos de {provider.total}</span>
-                <span>{provider.hasKey ? 'API key configurada' : 'Configura la API key'}</span>
-              </div>
-            </article>
-          ))}
-        </div>
-        <div className="local-model-card">
-          <div>
-            <h3>Modelo local</h3>
-            <p>{activeModel ? `${activeModel.name} listo para usar` : 'Ningún modelo activo'}</p>
-          </div>
-          <button type="button" onClick={onOpenGlobalSettings}>
-            Gestionar
+        <div className="model-panel__actions">
+          <button type="button" onClick={() => void refresh()} disabled={isLoading}>
+            Actualizar
           </button>
-        </div>
-      </section>
-
-      <section className="sidebar-section">
-        <header>
-          <h2>Estadísticas</h2>
-          <p>Actividad en la sesión actual.</p>
-        </header>
-        <ul className="sidebar-stats">
-          {messageStats.map(stat => (
-            <li key={stat.label}>
-              <span className="stat-label">{stat.label}</span>
-              <span className="stat-value">{stat.value}</span>
-            </li>
-          ))}
-        </ul>
-      </section>
-
-      <section className="sidebar-section">
-        <header>
-          <h2>Sugerencias</h2>
-          <p>Acciones rápidas según la actividad.</p>
-        </header>
-        <ul className="suggestion-list">
-          {suggestions.map(item => (
-            <li key={item.id}>
-              <button type="button" onClick={item.action} disabled={!item.action}>
-                <strong>{item.title}</strong>
-                <span>{item.description}</span>
-              </button>
-            </li>
-          ))}
-        </ul>
-      </section>
-
-      <section className="sidebar-section">
-        <header>
-          <h2>Comandos rápidos</h2>
-          <p>Inserta instrucciones guardadas en el chat.</p>
-        </header>
-        <div className="command-list">
-          {quickCommands.length === 0 && <p className="command-empty">No tienes comandos guardados.</p>}
-          {quickCommands.map(command => (
-            <button key={command} type="button" onClick={() => appendToDraft(command)}>
-              {command}
-            </button>
-          ))}
+          <button type="button" className="primary" onClick={onOpenGlobalSettings}>
+            Gestionar descargas
+          </button>
         </div>
       </section>
     </div>

--- a/src/components/settings/GlobalSettingsDialog.css
+++ b/src/components/settings/GlobalSettingsDialog.css
@@ -116,6 +116,77 @@
   font-size: 12px;
 }
 
+.project-manager {
+  display: grid;
+  grid-template-columns: 1fr;
+  gap: 12px;
+  padding: 20px;
+  border-radius: 16px;
+  background: rgba(255, 255, 255, 0.04);
+  border: 1px solid rgba(255, 255, 255, 0.08);
+}
+
+.project-manager label {
+  font-size: 12px;
+  text-transform: uppercase;
+  letter-spacing: 0.6px;
+  color: rgba(255, 255, 255, 0.6);
+}
+
+.project-manager input,
+.project-manager select,
+.project-manager textarea {
+  width: 100%;
+  border: 1px solid rgba(255, 255, 255, 0.16);
+  border-radius: 10px;
+  background: rgba(0, 0, 0, 0.35);
+  color: #fff;
+  padding: 10px 12px;
+  font-size: 13px;
+}
+
+.project-manager select {
+  background: rgba(0, 0, 0, 0.45);
+}
+
+.project-manager textarea {
+  resize: vertical;
+  min-height: 90px;
+}
+
+.project-error {
+  margin-top: 4px;
+  font-size: 12px;
+  color: #ff8a80;
+}
+
+.project-actions {
+  display: flex;
+  gap: 8px;
+  justify-content: flex-end;
+}
+
+.project-actions button {
+  border: none;
+  border-radius: 10px;
+  padding: 8px 16px;
+  font-size: 12px;
+  cursor: pointer;
+  background: rgba(255, 255, 255, 0.14);
+  color: #fff;
+  text-transform: uppercase;
+  letter-spacing: 0.6px;
+}
+
+.project-actions button:disabled {
+  opacity: 0.5;
+  cursor: default;
+}
+
+.project-actions .danger {
+  background: rgba(255, 82, 82, 0.32);
+}
+
 .preference-card {
   padding: 16px;
   border-radius: 16px;


### PR DESCRIPTION
## Summary
- add a dedicated “Proyectos” tab to the global settings dialog that manages project profiles via `useProjects`
- restyle the dialog to host the project form and migrate related styles from the chat sidebar
- replace the chat side panel with a lightweight local model summary and update tests/usages accordingly

## Testing
- npm test -- --run

------
https://chatgpt.com/codex/tasks/task_e_68cefce806b88333a1a6bfaf235b1074