### PR TITLE
feat: extend project git metadata

### DIFF
--- a/src/core/projects/ProjectContext.tsx
+++ b/src/core/projects/ProjectContext.tsx
@@ -1,5 +1,9 @@
 import React, { createContext, useCallback, useContext, useMemo } from 'react';
-import type { GlobalSettings, ProjectProfile } from '../../types/globalSettings';
+import type {
+  GitHostingProvider,
+  GlobalSettings,
+  ProjectProfile,
+} from '../../types/globalSettings';
 
 interface ProjectProviderProps {
   settings: GlobalSettings;
@@ -11,6 +15,10 @@ export interface ProjectDraft {
   id?: string;
   name: string;
   repositoryPath: string;
+  gitProvider?: GitHostingProvider;
+  gitOwner?: string;
+  gitRepository?: string;
+  defaultRemote?: string;
   defaultBranch?: string;
   instructions?: string;
   preferredProvider?: string;
@@ -58,10 +66,20 @@ const ensureProjectId = (draft: ProjectDraft, projects: ProjectProfile[]): strin
 };
 
 const sanitizeDraft = (draft: ProjectDraft): ProjectDraft => {
+  const normalizedProvider = draft.gitProvider?.toLowerCase().trim();
+  const gitProvider: GitHostingProvider | undefined =
+    normalizedProvider === 'github' || normalizedProvider === 'gitlab'
+      ? (normalizedProvider as GitHostingProvider)
+      : undefined;
+
   return {
     ...draft,
     name: draft.name.trim(),
     repositoryPath: draft.repositoryPath.trim(),
+    gitProvider,
+    gitOwner: draft.gitOwner?.trim() || undefined,
+    gitRepository: draft.gitRepository?.trim() || undefined,
+    defaultRemote: draft.defaultRemote?.trim() || undefined,
     defaultBranch: draft.defaultBranch?.trim() || undefined,
     instructions: draft.instructions?.trim() || undefined,
     preferredProvider: draft.preferredProvider?.trim() || undefined,
@@ -124,6 +142,10 @@ export const ProjectProvider: React.FC<ProjectProviderProps> = ({
           id,
           name: sanitized.name,
           repositoryPath: sanitized.repositoryPath,
+          gitProvider: sanitized.gitProvider,
+          gitOwner: sanitized.gitOwner,
+          gitRepository: sanitized.gitRepository,
+          defaultRemote: sanitized.defaultRemote,
           defaultBranch: sanitized.defaultBranch,
           instructions: sanitized.instructions,
           preferredProvider: sanitized.preferredProvider,

--- a/src/types/globalSettings.ts
+++ b/src/types/globalSettings.ts
@@ -61,10 +61,16 @@ export interface WorkspacePreferences {
   sidePanel: SidePanelPreferences;
 }
 
+export type GitHostingProvider = 'github' | 'gitlab' | (string & {});
+
 export interface ProjectProfile {
   id: string;
   name: string;
   repositoryPath: string;
+  gitProvider?: GitHostingProvider;
+  gitOwner?: string;
+  gitRepository?: string;
+  defaultRemote?: string;
   defaultBranch?: string;
   instructions?: string;
   preferredProvider?: string;
@@ -93,6 +99,7 @@ export interface GlobalSettings {
   dataLocation: DataLocationSettings;
   projectProfiles: ProjectProfile[];
   activeProjectId: string | null;
+  githubDefaultOwner?: string;
 }
 
 export interface PluginSettingsEntry {


### PR DESCRIPTION
## Summary
- extend project profile metadata with git provider, owner, repository and default remote fields while persisting a github default owner in global settings
- enhance the global settings dialog to manage the new git metadata, including a remembered default GitHub owner, and keep project drafts in sync
- preload Repo Studio with git coordinates from the active project so push and PR workflows honor per-project hosting configuration

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68cefeaf7d008333a613438320e71710