### PR TITLE
feat: show conversation stats in modal

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -5,6 +5,7 @@ import './components/chat/ChatInterface.css';
 import { ChatTopBar } from './components/chat/ChatTopBar';
 import { ChatWorkspace } from './components/chat/ChatWorkspace';
 import { SidePanel } from './components/chat/SidePanel';
+import { ConversationStatsModal } from './components/chat/ConversationStatsModal';
 import { RepoStudio } from './components/repo/RepoStudio';
 import { AgentProvider, useAgents } from './core/agents/AgentContext';
 import { useAgentPresence } from './core/agents/presence';
@@ -46,6 +47,7 @@ const AppContent: React.FC<AppContentProps> = ({
   const [isSettingsOpen, setSettingsOpen] = useState(false);
   const [isPluginsOpen, setPluginsOpen] = useState(false);
   const [isMcpOpen, setMcpOpen] = useState(false);
+  const [isStatsOpen, setStatsOpen] = useState(false);
 
   const sidePanelPosition = settings.workspacePreferences.sidePanel.position;
 
@@ -60,6 +62,7 @@ const AppContent: React.FC<AppContentProps> = ({
         activeFilter={actorFilter}
         onFilterChange={setActorFilter}
         onRefreshPresence={() => void refresh()}
+        onOpenStats={() => setStatsOpen(true)}
         onOpenGlobalSettings={() => setSettingsOpen(true)}
         onOpenPlugins={() => setPluginsOpen(true)}
         onOpenMcp={() => setMcpOpen(true)}
@@ -113,6 +116,8 @@ const AppContent: React.FC<AppContentProps> = ({
       <OverlayModal title="Perfiles MCP" isOpen={isMcpOpen} onClose={() => setMcpOpen(false)}>
         <McpSummary settings={settings} />
       </OverlayModal>
+
+      <ConversationStatsModal isOpen={isStatsOpen} onClose={() => setStatsOpen(false)} />
     </div>
   );
 };

--- a/src/components/chat/ChatTopBar.tsx
+++ b/src/components/chat/ChatTopBar.tsx
@@ -14,6 +14,7 @@ interface ChatTopBarProps {
   activeFilter: ChatActorFilter;
   onFilterChange: (filter: ChatActorFilter) => void;
   onRefreshPresence: () => void;
+  onOpenStats: () => void;
   onOpenGlobalSettings: () => void;
   onOpenPlugins: () => void;
   onOpenMcp: () => void;
@@ -55,6 +56,7 @@ export const ChatTopBar: React.FC<ChatTopBarProps> = ({
   activeFilter,
   onFilterChange,
   onRefreshPresence,
+  onOpenStats,
   onOpenGlobalSettings,
   onOpenPlugins,
   onOpenMcp,
@@ -169,6 +171,14 @@ export const ChatTopBar: React.FC<ChatTopBarProps> = ({
             aria-label="Actualizar estado de agentes"
           >
             ↻
+          </button>
+          <button
+            type="button"
+            className="icon-button"
+            onClick={onOpenStats}
+            aria-label="Ver estadísticas de la conversación"
+          >
+            📊
           </button>
         </div>
 

--- a/src/components/chat/ConversationStatsModal.css
+++ b/src/components/chat/ConversationStatsModal.css
@@ -1,0 +1,121 @@
+.conversation-stats {
+  display: flex;
+  flex-direction: column;
+  gap: 18px;
+}
+
+.conversation-stats__summary {
+  display: flex;
+  gap: 16px;
+  flex-wrap: wrap;
+}
+
+.conversation-stats__total,
+.conversation-stats__pending {
+  flex: 1 1 180px;
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+  padding: 16px;
+  border-radius: 16px;
+  background: rgba(255, 255, 255, 0.04);
+  border: 1px solid rgba(255, 255, 255, 0.08);
+}
+
+.conversation-stats__total {
+  background: linear-gradient(135deg, rgba(142, 141, 255, 0.28), rgba(77, 208, 225, 0.18));
+  border-color: rgba(142, 141, 255, 0.4);
+}
+
+.conversation-stats__label {
+  font-size: 11px;
+  text-transform: uppercase;
+  letter-spacing: 0.6px;
+  color: rgba(255, 255, 255, 0.65);
+}
+
+.conversation-stats__value {
+  font-size: 28px;
+  font-weight: 600;
+  letter-spacing: 0.5px;
+}
+
+.conversation-stats__value.is-warning {
+  color: rgba(255, 183, 77, 0.95);
+}
+
+.conversation-stats__hint {
+  font-size: 13px;
+  color: rgba(255, 255, 255, 0.7);
+}
+
+.conversation-stats__grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(160px, 1fr));
+  gap: 12px;
+}
+
+.conversation-stats__card {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+  padding: 14px 16px;
+  border-radius: 14px;
+  background: rgba(255, 255, 255, 0.05);
+  border: 1px solid rgba(255, 255, 255, 0.08);
+}
+
+.conversation-stats__card-label {
+  font-size: 12px;
+  letter-spacing: 0.4px;
+  color: rgba(255, 255, 255, 0.65);
+}
+
+.conversation-stats__card-value {
+  font-size: 20px;
+  font-weight: 600;
+}
+
+.conversation-stats__meta {
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+  padding: 14px 16px;
+  border-radius: 14px;
+  background: rgba(255, 255, 255, 0.04);
+  border: 1px solid rgba(255, 255, 255, 0.08);
+}
+
+.conversation-stats__meta-row {
+  display: flex;
+  justify-content: space-between;
+  gap: 12px;
+  flex-wrap: wrap;
+}
+
+.conversation-stats__meta-label {
+  font-size: 12px;
+  text-transform: uppercase;
+  letter-spacing: 0.5px;
+  color: rgba(255, 255, 255, 0.6);
+}
+
+.conversation-stats__meta-value {
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+  font-size: 13px;
+  color: rgba(255, 255, 255, 0.85);
+}
+
+.conversation-stats__meta-author {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  padding: 4px 10px;
+  border-radius: 999px;
+  background: rgba(255, 255, 255, 0.08);
+  font-size: 11px;
+  text-transform: uppercase;
+  letter-spacing: 0.6px;
+}

--- a/src/components/chat/ConversationStatsModal.tsx
+++ b/src/components/chat/ConversationStatsModal.tsx
@@ -1,0 +1,108 @@
+import React, { useMemo } from 'react';
+import './ConversationStatsModal.css';
+import { OverlayModal } from '../common/OverlayModal';
+import { useMessages } from '../../core/messages/MessageContext';
+import { ChatAuthor } from '../../core/messages/messageTypes';
+
+interface ConversationStatsModalProps {
+  isOpen: boolean;
+  onClose: () => void;
+}
+
+interface AuthorBreakdown {
+  author: ChatAuthor;
+  count: number;
+  label: string;
+}
+
+export const ConversationStatsModal: React.FC<ConversationStatsModalProps> = ({ isOpen, onClose }) => {
+  const { messages, pendingResponses, formatTimestamp } = useMessages();
+
+  const stats = useMemo(() => {
+    const publicMessages = messages.filter(message => message.visibility !== 'internal');
+
+    const breakdown: AuthorBreakdown[] = (
+      [
+        { author: 'user' as const, label: 'Mensajes de usuario' },
+        { author: 'agent' as const, label: 'Respuestas de agentes' },
+        { author: 'system' as const, label: 'Mensajes del sistema' },
+      ] satisfies { author: ChatAuthor; label: string }[]
+    ).map(({ author, label }) => ({
+      author,
+      label,
+      count: publicMessages.filter(message => message.author === author).length,
+    }));
+
+    const lastMessage = messages[messages.length - 1] ?? null;
+
+    return {
+      totalMessages: messages.length,
+      publicCount: publicMessages.length,
+      internalCount: messages.length - publicMessages.length,
+      breakdown,
+      pendingResponses,
+      lastMessage,
+    };
+  }, [messages, pendingResponses]);
+
+  const lastTimestamp = stats.lastMessage ? formatTimestamp(stats.lastMessage.timestamp) : null;
+  const lastDate = stats.lastMessage ? new Date(stats.lastMessage.timestamp) : null;
+  const lastAbsoluteTimestamp =
+    lastDate && !Number.isNaN(lastDate.getTime()) ? lastDate.toLocaleString() : null;
+
+  return (
+    <OverlayModal
+      title="Estadísticas de la conversación"
+      isOpen={isOpen}
+      onClose={onClose}
+      width={420}
+    >
+      <div className="conversation-stats" aria-live="polite">
+        <div className="conversation-stats__summary">
+          <div className="conversation-stats__total">
+            <span className="conversation-stats__label">Mensajes totales</span>
+            <span className="conversation-stats__value">{stats.totalMessages}</span>
+            <span className="conversation-stats__hint">
+              {stats.publicCount} públicos · {stats.internalCount} internos
+            </span>
+          </div>
+          <div className="conversation-stats__pending">
+            <span className="conversation-stats__label">Pendientes</span>
+            <span
+              className={`conversation-stats__value${stats.pendingResponses ? ' is-warning' : ''}`}
+            >
+              {stats.pendingResponses}
+            </span>
+          </div>
+        </div>
+
+        <div className="conversation-stats__grid">
+          {stats.breakdown.map(bucket => (
+            <div key={bucket.author} className="conversation-stats__card">
+              <span className="conversation-stats__card-label">{bucket.label}</span>
+              <span className="conversation-stats__card-value">{bucket.count}</span>
+            </div>
+          ))}
+        </div>
+
+        <div className="conversation-stats__meta">
+          <div className="conversation-stats__meta-row">
+            <span className="conversation-stats__meta-label">Último mensaje</span>
+            <span className="conversation-stats__meta-value" title={lastAbsoluteTimestamp ?? undefined}>
+              {stats.lastMessage ? (
+                <>
+                  <span className="conversation-stats__meta-author">{stats.lastMessage.author}</span>
+                  <span>{lastTimestamp}</span>
+                </>
+              ) : (
+                'Sin actividad registrada'
+              )}
+            </span>
+          </div>
+        </div>
+      </div>
+    </OverlayModal>
+  );
+};
+
+export default ConversationStatsModal;


### PR DESCRIPTION
## Summary
- add a dedicated ConversationStatsModal that reads the chat log via useMessages and renders a compact summary
- wire an "open stats" control into ChatTopBar and App so the modal can be triggered from the chat header
- style the new modal to match the existing interface and keep the sidebar focused on local models

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68cf00e0effc8333b481e2367acc7575