### PR TITLE
feat: centralize conversation suggestions in composer

### DIFF
--- a/src/components/chat/ChatInterface.css
+++ b/src/components/chat/ChatInterface.css
@@ -735,9 +735,17 @@
 
 .chat-suggestions {
   display: flex;
-  align-items: center;
-  gap: 12px;
+  align-items: flex-start;
+  gap: 10px;
   flex-wrap: wrap;
+}
+
+.suggestion-chip-row {
+  display: flex;
+  align-items: center;
+  flex-wrap: wrap;
+  gap: 8px;
+  row-gap: 6px;
 }
 
 .chat-composer-panel {
@@ -774,23 +782,62 @@
   font-size: 12px;
   letter-spacing: 0.7px;
   text-transform: uppercase;
-  color: rgba(255, 255, 255, 0.6);
+  color: rgba(255, 255, 255, 0.55);
+  padding-top: 4px;
 }
 
 .suggestion-chip {
-  border: 1px solid rgba(255, 255, 255, 0.12);
-  background: rgba(255, 255, 255, 0.04);
-  color: #fff;
-  padding: 6px 12px;
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
   border-radius: 999px;
+  padding: 6px 12px;
   font-size: 12px;
   cursor: pointer;
-  transition: background 0.2s ease, border-color 0.2s ease;
+  border: 1px solid transparent;
+  transition: background 0.2s ease, border-color 0.2s ease, transform 0.2s ease;
+}
+
+.suggestion-chip--dynamic {
+  background: rgba(142, 141, 255, 0.16);
+  border-color: rgba(142, 141, 255, 0.35);
+  color: rgba(255, 255, 255, 0.95);
+}
+
+.suggestion-chip--command {
+  background: rgba(255, 255, 255, 0.08);
+  border-color: rgba(255, 255, 255, 0.15);
+  color: rgba(255, 255, 255, 0.92);
 }
 
 .suggestion-chip:hover {
-  background: rgba(255, 183, 77, 0.16);
+  transform: translateY(-1px);
   border-color: rgba(255, 183, 77, 0.5);
+  background: rgba(255, 183, 77, 0.16);
+}
+
+.suggestion-chip-icon {
+  font-size: 14px;
+  line-height: 1;
+}
+
+.suggestion-chip-text {
+  max-width: 200px;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.suggestion-chip-badge {
+  display: inline-flex;
+  align-items: center;
+  padding: 2px 6px;
+  border-radius: 999px;
+  background: rgba(0, 0, 0, 0.35);
+  color: rgba(255, 255, 255, 0.75);
+  font-size: 10px;
+  letter-spacing: 0.4px;
+  text-transform: uppercase;
 }
 
 .chat-composer {
@@ -2074,7 +2121,14 @@
 
 .chat-suggestions {
   display: flex;
-  align-items: center;
+  align-items: flex-start;
+  flex-wrap: wrap;
+  gap: 8px;
+  row-gap: 6px;
+}
+
+.suggestion-chip-row {
+  display: flex;
   flex-wrap: wrap;
   gap: 6px;
   row-gap: 4px;
@@ -2085,21 +2139,57 @@
   text-transform: uppercase;
   letter-spacing: 0.5px;
   color: rgba(255, 255, 255, 0.55);
+  padding-top: 2px;
 }
 
 .suggestion-chip {
-  border: 1px solid rgba(255, 255, 255, 0.08);
+  display: inline-flex;
+  align-items: center;
+  gap: 4px;
   border-radius: 999px;
   padding: 4px 10px;
   background: rgba(255, 255, 255, 0.05);
   color: #fff;
   cursor: pointer;
   font-size: 11px;
+  border: 1px solid rgba(255, 255, 255, 0.08);
+  transition: background 0.2s ease, border-color 0.2s ease;
+}
+
+.suggestion-chip--dynamic {
+  background: rgba(142, 141, 255, 0.18);
+  border-color: rgba(142, 141, 255, 0.35);
+}
+
+.suggestion-chip--command {
+  background: rgba(255, 255, 255, 0.08);
 }
 
 .suggestion-chip:hover {
   background: rgba(255, 183, 77, 0.16);
   border-color: rgba(255, 183, 77, 0.35);
+}
+
+.suggestion-chip-icon {
+  font-size: 13px;
+  line-height: 1;
+}
+
+.suggestion-chip-text {
+  max-width: 160px;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.suggestion-chip-badge {
+  padding: 1px 4px;
+  border-radius: 999px;
+  background: rgba(0, 0, 0, 0.35);
+  color: rgba(255, 255, 255, 0.7);
+  font-size: 9px;
+  letter-spacing: 0.4px;
+  text-transform: uppercase;
 }
 
 .composer-transcriptions {

--- a/src/core/messages/__tests__/useConversationSuggestions.test.ts
+++ b/src/core/messages/__tests__/useConversationSuggestions.test.ts
@@ -1,0 +1,91 @@
+import { describe, expect, it } from 'vitest';
+import { buildDynamicSuggestions, buildRecentCommands } from '../useConversationSuggestions';
+import type { ChatMessage } from '../messageTypes';
+
+const baseTimestamp = new Date().toISOString();
+
+const createAgentMessage = (overrides: Partial<ChatMessage>): ChatMessage => ({
+  id: `agent-${Math.random().toString(16).slice(2, 8)}`,
+  author: 'agent',
+  content: 'Respuesta generada.',
+  timestamp: baseTimestamp,
+  status: 'sent',
+  ...overrides,
+});
+
+const createUserMessage = (overrides: Partial<ChatMessage>): ChatMessage => ({
+  id: `user-${Math.random().toString(16).slice(2, 8)}`,
+  author: 'user',
+  content: 'gpt, ayúdame con esto.',
+  timestamp: baseTimestamp,
+  status: 'sent',
+  ...overrides,
+});
+
+describe('useConversationSuggestions helpers', () => {
+  it('genera sugerencias dinámicas para respuestas pendientes y seguimiento', () => {
+    const agentMessage = createAgentMessage({
+      id: 'a-1',
+      agentId: 'claude',
+      content: 'Resumen listo.',
+    });
+
+    const suggestions = buildDynamicSuggestions({
+      pendingResponses: 2,
+      agentResponses: [agentMessage],
+      lastUserMessage: undefined,
+      resolveAgentName: agentId => (agentId === 'claude' ? 'Claude' : undefined),
+      toPlainText: content => (typeof content === 'string' ? content : ''),
+    });
+
+    expect(suggestions.some(entry => entry.id === 'pending-responses')).toBe(true);
+    const followUp = suggestions.find(entry => entry.id === `followup-${agentMessage.id}`);
+    expect(followUp?.label).toContain('Claude');
+  });
+
+  it('omite la sugerencia de pendientes cuando el contador es cero', () => {
+    const suggestions = buildDynamicSuggestions({
+      pendingResponses: 0,
+      agentResponses: [],
+      lastUserMessage: undefined,
+      resolveAgentName: () => undefined,
+      toPlainText: content => (typeof content === 'string' ? content : ''),
+    });
+
+    expect(suggestions.find(entry => entry.id === 'pending-responses')).toBeUndefined();
+  });
+
+  it('incluye la reutilización del último mensaje del usuario', () => {
+    const lastMessage = createUserMessage({
+      id: 'u-1',
+      content: 'equipo, revisad el pull request más reciente.',
+    });
+
+    const suggestions = buildDynamicSuggestions({
+      pendingResponses: 0,
+      agentResponses: [],
+      lastUserMessage: lastMessage,
+      resolveAgentName: () => undefined,
+      toPlainText: content => (typeof content === 'string' ? content : ''),
+    });
+
+    const reuse = suggestions.find(entry => entry.id === `reuse-${lastMessage.id}`);
+    expect(reuse?.text).toBe('equipo, revisad el pull request más reciente.');
+  });
+
+  it('detecta comandos recientes desde los mensajes del usuario', () => {
+    const messages: ChatMessage[] = [
+      createUserMessage({ id: 'u-1', content: 'hola equipo' }),
+      createUserMessage({ id: 'u-2', content: 'gpt, genera un resumen del proyecto.' }),
+      createUserMessage({ id: 'u-3', content: '/auditar tareas abiertas' }),
+      { ...createUserMessage({ id: 'u-4', content: 'gpt, genera un resumen del proyecto.' }), timestamp: baseTimestamp },
+    ];
+
+    const commands = buildRecentCommands(messages, content => (typeof content === 'string' ? content : ''));
+
+    expect(commands).toContain('gpt, genera un resumen del proyecto.');
+    expect(commands).toContain('/auditar tareas abiertas');
+    expect(commands).not.toContain('hola equipo');
+    expect(commands.length).toBeLessThanOrEqual(4);
+  });
+});

--- a/src/core/messages/useConversationSuggestions.ts
+++ b/src/core/messages/useConversationSuggestions.ts
@@ -1,0 +1,169 @@
+import { useCallback, useMemo } from 'react';
+import { useAgents } from '../agents/AgentContext';
+import { getAgentDisplayName } from '../../utils/agentDisplay';
+import { useMessages } from './MessageContext';
+import type { ChatMessage } from './messageTypes';
+
+export interface ConversationSuggestionDescriptor {
+  id: string;
+  label: string;
+  text: string;
+  icon?: string;
+  badge?: string;
+  title?: string;
+}
+
+interface DynamicSuggestionInput {
+  pendingResponses: number;
+  agentResponses: ChatMessage[];
+  lastUserMessage?: ChatMessage;
+  resolveAgentName: (agentId?: string) => string | undefined;
+  toPlainText: (content: ChatMessage['content']) => string;
+}
+
+const truncate = (value: string, length: number): string => {
+  if (value.length <= length) {
+    return value;
+  }
+  return `${value.slice(0, Math.max(0, length - 1))}…`;
+};
+
+const isCommandLike = (text: string): boolean => {
+  const trimmed = text.trim();
+  if (!trimmed) {
+    return false;
+  }
+  if (trimmed.startsWith('/')) {
+    return true;
+  }
+  return /^[\p{L}\p{N}_-]+[:,]/u.test(trimmed);
+};
+
+export const buildDynamicSuggestions = ({
+  pendingResponses,
+  agentResponses,
+  lastUserMessage,
+  resolveAgentName,
+  toPlainText,
+}: DynamicSuggestionInput): ConversationSuggestionDescriptor[] => {
+  const suggestions: ConversationSuggestionDescriptor[] = [];
+
+  if (pendingResponses > 0) {
+    const label =
+      pendingResponses === 1 ? '1 respuesta pendiente' : `${pendingResponses} respuestas pendientes`;
+    const text =
+      pendingResponses === 1
+        ? '¿Puedes finalizar la respuesta pendiente?'
+        : 'Equipo, ¿podéis completar las respuestas pendientes?';
+
+    suggestions.push({
+      id: 'pending-responses',
+      label,
+      text,
+      icon: '⏳',
+      badge: 'Estado',
+      title: 'Hay agentes que todavía están preparando su respuesta.',
+    });
+  }
+
+  const latestAgentMessage = [...agentResponses]
+    .reverse()
+    .find(message => (message.status ?? 'sent') !== 'pending');
+
+  if (latestAgentMessage) {
+    const agentName = resolveAgentName(latestAgentMessage.agentId) ?? 'el último agente';
+    const snippet = toPlainText(latestAgentMessage.content).trim();
+
+    suggestions.push({
+      id: `followup-${latestAgentMessage.id}`,
+      label: `Seguimiento con ${agentName}`,
+      text: `${agentName}, ¿podrías profundizar en tu último mensaje?`,
+      icon: '🤖',
+      badge: 'Seguimiento',
+      title: snippet ? `Último mensaje: ${truncate(snippet, 120)}` : undefined,
+    });
+  }
+
+  if (lastUserMessage) {
+    const lastUserText = toPlainText(lastUserMessage.content).trim();
+    if (lastUserText) {
+      suggestions.push({
+        id: `reuse-${lastUserMessage.id}`,
+        label: 'Reutilizar mi último mensaje',
+        text: lastUserText,
+        icon: '📝',
+        badge: 'Historial',
+        title: truncate(lastUserText, 120),
+      });
+    }
+  }
+
+  return suggestions;
+};
+
+export const buildRecentCommands = (
+  messages: ChatMessage[],
+  toPlainText: (content: ChatMessage['content']) => string,
+  limit = 4,
+): string[] => {
+  const commands: string[] = [];
+  const seen = new Set<string>();
+
+  for (const message of [...messages].reverse()) {
+    if (message.author !== 'user') {
+      continue;
+    }
+    const text = toPlainText(message.content).trim();
+    if (!text || !isCommandLike(text)) {
+      continue;
+    }
+    const normalized = text.toLowerCase();
+    if (seen.has(normalized)) {
+      continue;
+    }
+    seen.add(normalized);
+    commands.push(text);
+    if (commands.length >= limit) {
+      break;
+    }
+  }
+
+  return commands;
+};
+
+export const useConversationSuggestions = () => {
+  const { messages, pendingResponses, agentResponses, lastUserMessage, toPlainText } = useMessages();
+  const { agentMap } = useAgents();
+
+  const resolveAgentName = useCallback(
+    (agentId?: string) => {
+      if (!agentId) {
+        return undefined;
+      }
+      const agent = agentMap.get(agentId);
+      return agent ? getAgentDisplayName(agent) : undefined;
+    },
+    [agentMap],
+  );
+
+  const dynamicSuggestions = useMemo(
+    () =>
+      buildDynamicSuggestions({
+        pendingResponses,
+        agentResponses,
+        lastUserMessage,
+        resolveAgentName,
+        toPlainText,
+      }),
+    [agentResponses, lastUserMessage, pendingResponses, resolveAgentName, toPlainText],
+  );
+
+  const recentCommands = useMemo(
+    () => buildRecentCommands(messages, toPlainText),
+    [messages, toPlainText],
+  );
+
+  return { dynamicSuggestions, recentCommands } as const;
+};
+
+export default useConversationSuggestions;


### PR DESCRIPTION
## Summary
- extract conversation awareness from the sidebar into a dedicated `useConversationSuggestions` helper that emits dynamic tips and recent commands for the composer
- mix dynamic tips with quick commands inside `ChatWorkspace`, adding visual badges/icons and click-to-insert behavior while tightening composer chip layout styles
- refresh chat composer styles to accommodate the new chip row spacing and add coverage for suggestion helpers

## Testing
- npm test
- npx vitest run src/core/messages/__tests__/useConversationSuggestions.test.ts


------
https://chatgpt.com/codex/tasks/task_e_68cf0257fdc883338f7aef6e69a1c48e