### PR TITLE
Refine chat workspace header presentation

### DIFF
--- a/src/components/chat/ChatInterface.css
+++ b/src/components/chat/ChatInterface.css
@@ -1940,6 +1940,18 @@
   gap: 12px;
 }
 
+.metric-caption {
+  display: inline-flex;
+  align-items: center;
+  padding: 6px 10px;
+  border-radius: 999px;
+  font-size: 11px;
+  letter-spacing: 0.4px;
+  color: rgba(255, 255, 255, 0.65);
+  background: rgba(255, 255, 255, 0.04);
+  white-space: nowrap;
+}
+
 .metric-chip {
   display: flex;
   flex-direction: column;
@@ -2057,18 +2069,9 @@
   display: flex;
   flex-direction: column;
   height: 100%;
-  padding: 24px 32px;
-  gap: 24px;
+  padding: 20px 32px;
+  gap: 20px;
   overflow: hidden;
-}
-
-.chat-feed-header {
-  padding: 6px 10px;
-  margin-bottom: 6px;
-  font-size: 13px;
-  color: rgba(255, 255, 255, 0.7);
-  border-radius: 8px;
-  background: rgba(10, 10, 10, 0.45);
 }
 
 .chat-feed {

--- a/src/components/chat/ChatTopBar.tsx
+++ b/src/components/chat/ChatTopBar.tsx
@@ -66,6 +66,10 @@ export const ChatTopBar: React.FC<ChatTopBarProps> = ({
   const hasPending = pendingResponses > 0;
   const overallStatus = resolveStatus(presenceSummary);
   const { projects, activeProjectId, activeProject, selectProject } = useProjects();
+  const activeAgentsMessage = useMemo(() => {
+    const base = `${activeAgents} agente${activeAgents === 1 ? '' : 's'}`;
+    return `${base} coordinando la conversación`;
+  }, [activeAgents]);
 
   const handleProjectChange = (event: React.ChangeEvent<HTMLSelectElement>) => {
     const nextId = event.target.value || null;
@@ -164,6 +168,9 @@ export const ChatTopBar: React.FC<ChatTopBarProps> = ({
             <span className="metric-label">Pendientes</span>
             <span className="metric-value">{pendingResponses}</span>
           </div>
+          <span className="metric-caption" role="status" aria-live="polite">
+            {activeAgentsMessage}
+          </span>
           <button
             type="button"
             className="icon-button"

--- a/src/components/chat/ChatWorkspace.tsx
+++ b/src/components/chat/ChatWorkspace.tsx
@@ -14,7 +14,7 @@ interface ChatWorkspaceProps {
 }
 
 export const ChatWorkspace: React.FC<ChatWorkspaceProps> = ({ actorFilter }) => {
-  const { activeAgents, agentMap } = useAgents();
+  const { agentMap } = useAgents();
   const {
     messages,
     draft,
@@ -181,17 +181,8 @@ export const ChatWorkspace: React.FC<ChatWorkspaceProps> = ({ actorFilter }) => 
     return publicMessages;
   }, [actorFilter, agentMap, publicMessages]);
 
-  const activeAgentsStatus = useMemo(() => {
-    const base = `${activeAgents.length} agente${activeAgents.length === 1 ? '' : 's'}`;
-    return `${base} coordinando la conversación.`;
-  }, [activeAgents.length]);
-
   return (
     <div className="chat-workspace">
-      <div className="chat-feed-header" role="status" aria-live="polite">
-        {activeAgentsStatus}
-      </div>
-
       <section className="chat-feed" aria-label="Historial de mensajes">
         <div className="message-feed">
           {filteredMessages.length === 0 ? (


### PR DESCRIPTION
## Summary
- remove the chat feed header banner from the workspace and adjust layout spacing
- surface the active agent coordination message within the top bar metrics and style a subtle caption
- clean up unused agent state in the workspace component

## Testing
- npm run test

------
https://chatgpt.com/codex/tasks/task_e_68cf0690844c833397a14fceb617c7f2