### PR TITLE
Tighten chat spacing and compact layout styling

### DIFF
--- a/src/AppLayout.css
+++ b/src/AppLayout.css
@@ -1,8 +1,8 @@
 :root {
-  --chat-density-spacing-standard: 20px;
-  --chat-density-spacing-compact: 12px;
-  --chat-density-panel-padding-standard: 24px;
-  --chat-density-panel-padding-compact: 16px;
+  --chat-density-spacing-standard: 12px;
+  --chat-density-spacing-compact: 8px;
+  --chat-density-panel-padding-standard: 12px;
+  --chat-density-panel-padding-compact: 8px;
 }
 
 .app-container {

--- a/src/components/chat/ChatInterface.css
+++ b/src/components/chat/ChatInterface.css
@@ -1,33 +1,34 @@
+
 .chat-top-bar {
   width: 100%;
   display: flex;
   flex-wrap: wrap;
   align-items: flex-start;
-  gap: 18px;
-  row-gap: 16px;
-  padding: 16px 24px;
+  gap: 12px;
+  row-gap: 10px;
+  padding: 12px 16px;
   background: rgba(5, 5, 5, 0.85);
   border-bottom: 1px solid rgba(255, 255, 255, 0.08);
-  box-shadow: 0 10px 30px rgba(0, 0, 0, 0.4);
+  box-shadow: 0 8px 20px rgba(0, 0, 0, 0.35);
   z-index: 30;
 }
 
 .topbar-section {
   display: flex;
   align-items: center;
-  gap: 18px;
+  gap: 10px;
   flex-wrap: wrap;
 }
 
 .topbar-branding .brand-icon {
-  width: 36px;
-  height: 36px;
+  width: 30px;
+  height: 30px;
   display: grid;
   place-items: center;
-  font-size: 18px;
-  border-radius: 12px;
+  font-size: 16px;
+  border-radius: 8px;
   background: linear-gradient(135deg, rgba(255, 183, 77, 0.6), rgba(142, 141, 255, 0.4));
-  box-shadow: 0 10px 20px rgba(255, 183, 77, 0.2);
+  box-shadow: 0 8px 18px rgba(255, 183, 77, 0.18);
 }
 
 .brand-copy {
@@ -51,7 +52,7 @@
 
 .topbar-status {
   flex-wrap: wrap;
-  gap: 16px;
+  gap: 10px;
 }
 
 .status-indicator {
@@ -61,20 +62,20 @@
   font-size: 13px;
   letter-spacing: 0.3px;
   color: rgba(255, 255, 255, 0.85);
-  padding: 8px 14px;
-  border-radius: 12px;
+  padding: 6px 10px;
+  border-radius: 8px;
   border: 1px solid rgba(255, 255, 255, 0.1);
   background: rgba(255, 255, 255, 0.04);
 }
 
 .status-indicator.status-online {
   border-color: rgba(102, 255, 102, 0.4);
-  box-shadow: 0 8px 20px rgba(102, 255, 102, 0.12);
+  box-shadow: 0 6px 16px rgba(102, 255, 102, 0.1);
 }
 
 .status-indicator.status-error {
   border-color: rgba(255, 102, 102, 0.45);
-  box-shadow: 0 8px 20px rgba(255, 102, 102, 0.15);
+  box-shadow: 0 6px 16px rgba(255, 102, 102, 0.12);
 }
 
 .status-indicator.status-loading {
@@ -114,15 +115,15 @@
 .status-metrics {
   display: flex;
   align-items: stretch;
-  gap: 12px;
+  gap: 8px;
 }
 
 .status-metric {
   display: flex;
   flex-direction: column;
   gap: 4px;
-  padding: 6px 14px;
-  border-radius: 10px;
+  padding: 6px 10px;
+  border-radius: 8px;
   background: rgba(255, 255, 255, 0.05);
   border: 1px solid rgba(255, 255, 255, 0.08);
 }
@@ -148,7 +149,7 @@
   margin-left: auto;
   display: flex;
   align-items: center;
-  gap: 10px;
+  gap: 8px;
   flex-wrap: wrap;
 }
 
@@ -156,8 +157,8 @@
   background: rgba(255, 255, 255, 0.06);
   color: #fff;
   border: 1px solid rgba(255, 255, 255, 0.08);
-  border-radius: 8px;
-  padding: 6px 14px;
+  border-radius: 6px;
+  padding: 6px 12px;
   font-size: 12px;
   letter-spacing: 0.5px;
   text-transform: uppercase;
@@ -182,7 +183,7 @@
   flex: 1 1 320px;
   display: flex;
   flex-wrap: wrap;
-  gap: 12px;
+  gap: 8px;
   align-items: stretch;
 }
 
@@ -190,9 +191,9 @@
   flex: 1 1 240px;
   display: flex;
   flex-direction: column;
-  gap: 12px;
-  padding: 14px 16px;
-  border-radius: 14px;
+  gap: 8px;
+  padding: 12px;
+  border-radius: 10px;
   background: rgba(12, 12, 12, 0.7);
   border: 1px solid rgba(255, 255, 255, 0.08);
   transition: border 0.2s ease, box-shadow 0.2s ease;
@@ -216,7 +217,7 @@
 .presence-card-body {
   display: grid;
   grid-template-columns: repeat(auto-fit, minmax(68px, 1fr));
-  gap: 10px;
+  gap: 8px;
 }
 
 .presence-card-metric {
@@ -340,7 +341,7 @@
   display: flex;
   align-items: flex-start;
   justify-content: space-between;
-  gap: 24px;
+  gap: 12px;
   color: #fff;
   transition: max-height 0.3s ease, opacity 0.3s ease;
 }
@@ -348,14 +349,14 @@
 .chat-header-main {
   display: flex;
   align-items: flex-start;
-  gap: 16px;
+  gap: 10px;
   flex: 1;
 }
 
 .chat-header-text {
   display: flex;
   flex-direction: column;
-  gap: 10px;
+  gap: 8px;
   max-width: 580px;
 }
 
@@ -363,16 +364,16 @@
   display: flex;
   flex-direction: column;
   align-items: flex-end;
-  gap: 12px;
+  gap: 8px;
   min-width: 260px;
 }
 
 .chat-header-toggle {
   display: inline-flex;
   align-items: center;
-  gap: 8px;
-  padding: 8px 16px;
-  border-radius: 999px;
+  gap: 6px;
+  padding: 6px 12px;
+  border-radius: 12px;
   border: 1px solid rgba(255, 255, 255, 0.16);
   background: rgba(255, 255, 255, 0.06);
   color: rgba(255, 255, 255, 0.82);
@@ -391,15 +392,15 @@
 .chat-density-toggle {
   display: flex;
   padding: 4px;
-  border-radius: 999px;
+  border-radius: 12px;
   background: rgba(255, 255, 255, 0.08);
   border: 1px solid rgba(255, 255, 255, 0.16);
   gap: 4px;
 }
 
 .chat-density-toggle button {
-  padding: 6px 14px;
-  border-radius: 999px;
+  padding: 6px 10px;
+  border-radius: 10px;
   border: none;
   background: transparent;
   color: rgba(255, 255, 255, 0.7);
@@ -461,8 +462,8 @@
 .chat-visual-wrapper {
   --chat-vertical-gap: var(--chat-density-spacing-standard);
   --chat-panel-padding: var(--chat-density-panel-padding-standard);
-  --chat-horizontal-gap: clamp(16px, 2.5vw, 36px);
-  padding: calc(var(--chat-panel-padding) + 12px);
+  --chat-horizontal-gap: clamp(12px, 2vw, 24px);
+  padding: calc(var(--chat-panel-padding) + 4px);
   display: flex;
   flex-direction: column;
   gap: var(--chat-vertical-gap);
@@ -471,7 +472,7 @@
 .chat-visual-wrapper.chat-density-compact {
   --chat-vertical-gap: var(--chat-density-spacing-compact);
   --chat-panel-padding: var(--chat-density-panel-padding-compact);
-  --chat-horizontal-gap: clamp(12px, 2vw, 28px);
+  --chat-horizontal-gap: clamp(10px, 1.8vw, 20px);
 }
 
 .chat-stage {
@@ -495,7 +496,7 @@
   flex: 1 1 auto;
   min-height: 0;
   padding: 0;
-  border-radius: 12px;
+  border-radius: 8px;
   border: 1px solid rgba(255, 255, 255, 0.04);
   background: rgba(10, 10, 10, 0.55);
 }
@@ -507,12 +508,12 @@
   display: flex;
   flex-direction: column;
   gap: calc(var(--chat-vertical-gap) * 0.85);
-  padding: 16px 20px 20px;
+  padding: 12px 14px 14px;
 }
 
 .message-feed-empty {
-  padding: 24px;
-  border-radius: 12px;
+  padding: 16px;
+  border-radius: 8px;
   border: 1px dashed rgba(255, 255, 255, 0.18);
   background: rgba(10, 10, 10, 0.6);
   color: rgba(255, 255, 255, 0.6);
@@ -523,12 +524,12 @@
 .message-card {
   display: flex;
   flex-direction: column;
-  gap: 8px;
-  padding: 16px 20px;
-  border-radius: 14px;
+  gap: 6px;
+  padding: 12px 14px;
+  border-radius: 10px;
   background: rgba(12, 12, 12, 0.75);
   border: 1px solid rgba(255, 255, 255, 0.08);
-  box-shadow: 0 18px 30px rgba(0, 0, 0, 0.35);
+  box-shadow: 0 12px 22px rgba(0, 0, 0, 0.3);
   backdrop-filter: blur(16px);
   max-width: 85%;
 }
@@ -550,7 +551,7 @@
   display: flex;
   align-items: center;
   justify-content: space-between;
-  gap: 20px;
+  gap: 12px;
 }
 
 .message-card-author {
@@ -558,15 +559,15 @@
   font-size: 13px;
   letter-spacing: 0.6px;
   text-transform: uppercase;
-  padding: 6px 12px;
-  border-radius: 999px;
+  padding: 4px 10px;
+  border-radius: 10px;
   border: 1px solid rgba(255, 255, 255, 0.2);
 }
 
 .message-card-meta {
   display: flex;
   align-items: center;
-  gap: 12px;
+  gap: 8px;
   font-size: 11px;
   color: rgba(255, 255, 255, 0.6);
 }
@@ -594,26 +595,26 @@
 .message-card-body {
   display: flex;
   flex-direction: column;
-  gap: 14px;
+  gap: 10px;
 }
 
 .message-card-media {
   display: flex;
   flex-direction: column;
-  gap: 8px;
-  border-radius: 12px;
+  gap: 6px;
+  border-radius: 8px;
   overflow: hidden;
 }
 
 .message-card-media img {
   width: 100%;
-  border-radius: 12px;
+  border-radius: 8px;
 }
 
 .message-code-block {
   position: relative;
-  padding: 52px 18px 18px;
-  border-radius: 14px;
+  padding: 40px 14px 14px;
+  border-radius: 10px;
   background: radial-gradient(circle at top, rgba(29, 35, 60, 0.75), rgba(14, 16, 30, 0.85));
   border: 1px solid rgba(142, 141, 255, 0.2);
   box-shadow: inset 0 0 0 1px rgba(142, 141, 255, 0.08);
@@ -640,18 +641,18 @@
 
 .message-code-toolbar {
   position: absolute;
-  top: 14px;
-  left: 18px;
-  right: 18px;
+  top: 12px;
+  left: 14px;
+  right: 14px;
   display: flex;
   align-items: center;
   justify-content: space-between;
-  gap: 12px;
-  padding: 8px 14px;
-  border-radius: 999px;
+  gap: 8px;
+  padding: 6px 10px;
+  border-radius: 10px;
   background: linear-gradient(120deg, rgba(20, 24, 44, 0.95), rgba(35, 41, 72, 0.75));
   border: 1px solid rgba(142, 141, 255, 0.18);
-  box-shadow: 0 12px 24px rgba(12, 14, 28, 0.55);
+  box-shadow: 0 10px 20px rgba(12, 14, 28, 0.5);
   pointer-events: none;
 }
 
@@ -719,8 +720,8 @@
   border: none;
   background: rgba(255, 255, 255, 0.08);
   color: rgba(255, 255, 255, 0.85);
-  padding: 4px 10px;
-  border-radius: 999px;
+  padding: 4px 8px;
+  border-radius: 10px;
   font-size: 10px;
   letter-spacing: 0.6px;
   text-transform: uppercase;
@@ -736,7 +737,7 @@
 .chat-suggestions {
   display: flex;
   align-items: flex-start;
-  gap: 10px;
+  gap: 8px;
   flex-wrap: wrap;
 }
 
@@ -744,7 +745,7 @@
   display: flex;
   align-items: center;
   flex-wrap: wrap;
-  gap: 8px;
+  gap: 6px;
   row-gap: 6px;
 }
 
@@ -753,10 +754,10 @@
   flex-direction: column;
   gap: var(--chat-vertical-gap);
   padding: var(--chat-panel-padding);
-  border-radius: 20px;
+  border-radius: 12px;
   background: rgba(8, 8, 16, 0.85);
   border: 1px solid rgba(255, 255, 255, 0.08);
-  box-shadow: 0 20px 40px rgba(0, 0, 0, 0.45);
+  box-shadow: 0 14px 26px rgba(0, 0, 0, 0.4);
   backdrop-filter: blur(18px);
   min-height: 0;
   max-height: 100%;
@@ -790,8 +791,8 @@
   display: inline-flex;
   align-items: center;
   gap: 6px;
-  border-radius: 999px;
-  padding: 6px 12px;
+  border-radius: 10px;
+  padding: 6px 10px;
   font-size: 12px;
   cursor: pointer;
   border: 1px solid transparent;
@@ -1907,15 +1908,15 @@
   align-items: center;
   gap: 6px;
   padding: 6px;
-  border-radius: 999px;
+  border-radius: 12px;
   background: rgba(255, 255, 255, 0.06);
 }
 
 .mode-switcher button {
   border: none;
-  width: 32px;
-  height: 32px;
-  border-radius: 50%;
+  width: 30px;
+  height: 30px;
+  border-radius: 10px;
   background: transparent;
   cursor: pointer;
   font-size: 16px;
@@ -1931,20 +1932,20 @@
   display: flex;
   align-items: center;
   justify-content: space-between;
-  gap: 24px;
+  gap: 12px;
 }
 
 .metric-group {
   display: flex;
   align-items: center;
-  gap: 12px;
+  gap: 8px;
 }
 
 .metric-caption {
   display: inline-flex;
   align-items: center;
   padding: 6px 10px;
-  border-radius: 999px;
+  border-radius: 10px;
   font-size: 11px;
   letter-spacing: 0.4px;
   color: rgba(255, 255, 255, 0.65);
@@ -1957,8 +1958,8 @@
   flex-direction: column;
   align-items: flex-start;
   gap: 4px;
-  padding: 8px 12px;
-  border-radius: 12px;
+  padding: 8px 10px;
+  border-radius: 10px;
   background: rgba(255, 255, 255, 0.05);
   border: 1px solid rgba(255, 255, 255, 0.08);
   font-size: 12px;
@@ -1983,9 +1984,9 @@
 
 .icon-button {
   border: none;
-  width: 36px;
-  height: 36px;
-  border-radius: 12px;
+  width: 32px;
+  height: 32px;
+  border-radius: 8px;
   display: grid;
   place-items: center;
   background: rgba(255, 255, 255, 0.08);
@@ -2062,15 +2063,15 @@
 .topbar-actions {
   display: flex;
   align-items: center;
-  gap: 10px;
+  gap: 8px;
 }
 
 .chat-workspace {
   display: flex;
   flex-direction: column;
   height: 100%;
-  padding: 20px 32px;
-  gap: 20px;
+  padding: 12px 18px;
+  gap: 12px;
   overflow: hidden;
 }
 
@@ -2078,7 +2079,7 @@
   flex: 1 1 auto;
   overflow: hidden;
   padding: 0;
-  border-radius: 12px;
+  border-radius: 8px;
   background: rgba(10, 10, 10, 0.55);
   border: 1px solid rgba(255, 255, 255, 0.04);
 }
@@ -2086,8 +2087,8 @@
 .message-feed {
   display: flex;
   flex-direction: column;
-  gap: 14px;
-  padding: 16px 20px 20px;
+  gap: 10px;
+  padding: 12px 14px 14px;
   min-height: 0;
   flex: 1 1 auto;
   overflow-y: auto;
@@ -2095,7 +2096,7 @@
 
 .message-feed-empty {
   text-align: center;
-  padding: 60px 20px;
+  padding: 24px 16px;
   color: rgba(255, 255, 255, 0.6);
   font-size: 14px;
 }
@@ -2103,9 +2104,9 @@
 .chat-composer-area {
   display: flex;
   flex-direction: column;
-  gap: 12px;
-  padding: 12px;
-  border-radius: 14px;
+  gap: 8px;
+  padding: 10px;
+  border-radius: 10px;
   background: rgba(12, 12, 12, 0.82);
   border: 1px solid rgba(255, 255, 255, 0.05);
 }
@@ -2113,7 +2114,7 @@
 .chat-composer {
   display: flex;
   flex-direction: column;
-  gap: 8px;
+  gap: 6px;
 }
 
 .composer-header {

--- a/src/components/chat/SidePanel.css
+++ b/src/components/chat/SidePanel.css
@@ -2,8 +2,8 @@
   display: flex;
   flex-direction: column;
   height: 100%;
-  padding: 20px;
-  gap: 20px;
+  padding: 12px;
+  gap: 12px;
   background: rgba(10, 10, 10, 0.92);
   border-left: 1px solid rgba(255, 255, 255, 0.08);
   overflow-y: auto;
@@ -23,12 +23,12 @@
 .sidebar-section {
   display: flex;
   flex-direction: column;
-  gap: 16px;
-  padding: 20px;
-  border-radius: 18px;
+  gap: 12px;
+  padding: 12px;
+  border-radius: 12px;
   background: rgba(18, 18, 18, 0.85);
   border: 1px solid rgba(255, 255, 255, 0.06);
-  box-shadow: 0 12px 28px rgba(0, 0, 0, 0.45);
+  box-shadow: 0 8px 18px rgba(0, 0, 0, 0.35);
 }
 
 .sidebar-section header h2 {
@@ -46,15 +46,15 @@
 .model-panel {
   display: flex;
   flex-direction: column;
-  gap: 16px;
+  gap: 12px;
 }
 
 .model-panel__summary {
   display: flex;
   flex-direction: column;
   gap: 6px;
-  padding: 16px;
-  border-radius: 16px;
+  padding: 12px;
+  border-radius: 10px;
   background: linear-gradient(135deg, rgba(142, 141, 255, 0.22), rgba(77, 208, 225, 0.18));
   border: 1px solid rgba(142, 141, 255, 0.35);
 }
@@ -73,13 +73,13 @@
 
 .model-panel__counts {
   display: flex;
-  gap: 12px;
+  gap: 8px;
 }
 
 .model-panel__counts > div {
   flex: 1;
-  padding: 12px 14px;
-  border-radius: 14px;
+  padding: 10px 12px;
+  border-radius: 10px;
   background: rgba(255, 255, 255, 0.05);
   border: 1px solid rgba(255, 255, 255, 0.08);
   display: flex;
@@ -105,16 +105,16 @@
   padding: 0;
   display: flex;
   flex-direction: column;
-  gap: 10px;
+  gap: 8px;
 }
 
 .model-panel__item {
   display: flex;
   justify-content: space-between;
   align-items: center;
-  gap: 12px;
-  padding: 12px 14px;
-  border-radius: 12px;
+  gap: 10px;
+  padding: 10px 12px;
+  border-radius: 8px;
   background: rgba(255, 255, 255, 0.04);
   border: 1px solid rgba(255, 255, 255, 0.06);
 }
@@ -172,14 +172,14 @@
 
 .model-panel__actions {
   display: flex;
-  gap: 12px;
+  gap: 8px;
   justify-content: flex-end;
 }
 
 .model-panel__actions button {
   border: none;
-  border-radius: 999px;
-  padding: 8px 16px;
+  border-radius: 10px;
+  padding: 8px 12px;
   font-size: 12px;
   letter-spacing: 0.6px;
   text-transform: uppercase;

--- a/src/components/repo/RepoStudio.css
+++ b/src/components/repo/RepoStudio.css
@@ -1,8 +1,8 @@
 .repo-studio {
   display: flex;
   flex-direction: column;
-  gap: 24px;
-  padding: 24px;
+  gap: 16px;
+  padding: 16px;
   color: #f5f7ff;
   background: linear-gradient(145deg, rgba(17, 18, 45, 0.92), rgba(8, 10, 28, 0.95));
   min-height: 100%;
@@ -12,7 +12,7 @@
   display: flex;
   justify-content: space-between;
   align-items: center;
-  gap: 16px;
+  gap: 10px;
 }
 
 .repo-studio__header h1 {
@@ -29,12 +29,12 @@
 
 .repo-studio__actions {
   display: flex;
-  gap: 12px;
+  gap: 8px;
 }
 
 .repo-studio__actions button {
-  padding: 10px 16px;
-  border-radius: 12px;
+  padding: 8px 12px;
+  border-radius: 8px;
   border: 1px solid rgba(255, 255, 255, 0.12);
   background: rgba(126, 130, 255, 0.18);
   color: #fff;
@@ -58,23 +58,23 @@
 .repo-studio__controls {
   display: grid;
   grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
-  gap: 16px;
+  gap: 10px;
 }
 
 .repo-studio__controls label {
   display: flex;
   flex-direction: column;
-  gap: 8px;
+  gap: 6px;
   font-size: 12px;
   text-transform: uppercase;
   letter-spacing: 0.6px;
 }
 
 .repo-studio__controls input {
-  border-radius: 10px;
+  border-radius: 8px;
   border: 1px solid rgba(255, 255, 255, 0.15);
   background: rgba(0, 0, 0, 0.45);
-  padding: 8px 12px;
+  padding: 8px 10px;
   color: #fff;
   outline: none;
 }
@@ -82,17 +82,17 @@
 .repo-studio__body {
   display: grid;
   grid-template-columns: repeat(3, minmax(0, 1fr));
-  gap: 20px;
+  gap: 12px;
 }
 
 .repo-studio__column {
   background: rgba(10, 12, 36, 0.75);
   border: 1px solid rgba(255, 255, 255, 0.08);
-  border-radius: 16px;
-  padding: 16px;
+  border-radius: 10px;
+  padding: 12px;
   display: flex;
   flex-direction: column;
-  gap: 12px;
+  gap: 8px;
   min-height: 300px;
 }
 
@@ -119,8 +119,8 @@
   align-items: center;
   background: rgba(255, 255, 255, 0.05);
   border: 1px solid transparent;
-  border-radius: 12px;
-  padding: 8px 12px;
+  border-radius: 8px;
+  padding: 8px 10px;
   color: inherit;
   text-align: left;
   cursor: pointer;
@@ -149,8 +149,8 @@
 
 .repo-studio__diff {
   background: rgba(0, 0, 0, 0.55);
-  border-radius: 12px;
-  padding: 16px;
+  border-radius: 8px;
+  padding: 12px;
   overflow-x: auto;
   font-family: 'Fira Code', monospace;
   font-size: 12px;
@@ -161,39 +161,39 @@
 .repo-studio__analysis {
   background: rgba(9, 12, 38, 0.72);
   border: 1px solid rgba(255, 255, 255, 0.08);
-  border-radius: 20px;
-  padding: 20px;
+  border-radius: 12px;
+  padding: 14px;
   display: flex;
   flex-direction: column;
-  gap: 16px;
+  gap: 10px;
 }
 
 .repo-studio__analysis-inputs {
   display: grid;
-  gap: 12px;
+  gap: 8px;
 }
 
 .repo-studio__analysis textarea,
 .repo-studio__card textarea {
   min-height: 120px;
-  border-radius: 12px;
+  border-radius: 8px;
   border: 1px solid rgba(255, 255, 255, 0.12);
   background: rgba(0, 0, 0, 0.45);
   color: #fff;
-  padding: 12px;
+  padding: 10px;
   resize: vertical;
 }
 
 .repo-studio__analysis-actions {
   display: flex;
   align-items: center;
-  gap: 14px;
+  gap: 8px;
 }
 
 .repo-studio__analysis-actions button,
 .repo-studio__card button {
-  padding: 10px 14px;
-  border-radius: 12px;
+  padding: 8px 12px;
+  border-radius: 8px;
   border: 1px solid rgba(255, 255, 255, 0.12);
   background: rgba(88, 185, 255, 0.18);
   color: #fff;
@@ -218,19 +218,19 @@
 
 .repo-studio__plan {
   background: rgba(0, 0, 0, 0.45);
-  border-radius: 16px;
+  border-radius: 10px;
   border: 1px solid rgba(255, 255, 255, 0.08);
-  padding: 16px;
+  padding: 12px;
   display: flex;
   flex-direction: column;
-  gap: 12px;
+  gap: 8px;
 }
 
 .repo-studio__plan header {
   display: flex;
   justify-content: space-between;
   align-items: center;
-  gap: 12px;
+  gap: 8px;
 }
 
 .repo-studio__plan ul {
@@ -239,12 +239,12 @@
   margin: 0;
   display: flex;
   flex-direction: column;
-  gap: 10px;
+  gap: 8px;
 }
 
 .repo-studio__plan ul li label {
   display: flex;
-  gap: 10px;
+  gap: 8px;
   align-items: center;
 }
 
@@ -254,7 +254,7 @@
 
 .badge {
   padding: 4px 8px;
-  border-radius: 999px;
+  border-radius: 8px;
   font-size: 11px;
   text-transform: uppercase;
   letter-spacing: 0.6px;
@@ -273,17 +273,17 @@
 .repo-studio__operations {
   display: grid;
   grid-template-columns: repeat(auto-fit, minmax(240px, 1fr));
-  gap: 20px;
+  gap: 12px;
 }
 
 .repo-studio__card {
   background: rgba(10, 12, 36, 0.75);
   border: 1px solid rgba(255, 255, 255, 0.08);
-  border-radius: 16px;
-  padding: 16px;
+  border-radius: 10px;
+  padding: 12px;
   display: flex;
   flex-direction: column;
-  gap: 12px;
+  gap: 8px;
 }
 
 .repo-studio__card label {
@@ -296,7 +296,7 @@
 
 .repo-studio__card input,
 .repo-studio__card select {
-  border-radius: 10px;
+  border-radius: 8px;
   border: 1px solid rgba(255, 255, 255, 0.12);
   background: rgba(0, 0, 0, 0.45);
   color: #fff;
@@ -311,8 +311,8 @@
 }
 
 .repo-studio__error {
-  padding: 12px 16px;
-  border-radius: 12px;
+  padding: 10px 12px;
+  border-radius: 8px;
   background: rgba(255, 110, 110, 0.14);
   border: 1px solid rgba(255, 110, 110, 0.45);
   color: rgba(255, 200, 200, 0.92);
@@ -321,9 +321,9 @@
 
 .repo-studio__log {
   background: rgba(0, 0, 0, 0.45);
-  border-radius: 16px;
+  border-radius: 10px;
   border: 1px solid rgba(255, 255, 255, 0.08);
-  padding: 16px;
+  padding: 12px;
 }
 
 .repo-studio__log ul {


### PR DESCRIPTION
## Summary
- tighten global chat spacing variables to drive a denser layout
- compact chat interface paddings, gaps, and radii for top bar, feed, message cards, and composer
- slim the side panel and RepoStudio surfaces with reduced padding, lighter shadows, and squared accents

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68cf083050948333a2eeb49a4e89cb10