### PR TITLE
feat: sync linked repository before repo workflows

### DIFF
--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -12,13 +12,13 @@ mod vscode;
 
 use config::{Config, ConfigState, LayerConfig};
 use git::{
-    apply_patch as git_apply_patch, commit_changes as git_commit_changes,
-    create_pull_request as git_create_pull_request, get_file_diff as git_get_file_diff,
-    get_repository_context as git_get_repository_context,
-    has_secret as git_has_secret, list_repository_files as git_list_repository_files,
+    apply_patch as git_apply_patch, clone_repository as git_clone_repository,
+    commit_changes as git_commit_changes, create_pull_request as git_create_pull_request,
+    get_file_diff as git_get_file_diff, get_repository_context as git_get_repository_context,
+    git_pull_repository, has_secret as git_has_secret, list_repository_files as git_list_repository_files,
     list_user_repos as git_list_user_repos, pull_changes as git_pull_changes,
     push_changes as git_push_changes, repository_status as git_repository_status,
-    clone_repository as git_clone_repository, store_secret as git_store_secret, SecretManager,
+    store_secret as git_store_secret, SecretManager,
 };
 use log::error;
 use models::{activate_model, download_model, list_models, ModelRegistry};
@@ -128,6 +128,7 @@ fn main() {
             git_apply_patch,
             git_commit_changes,
             git_push_changes,
+            git_pull_repository,
             git_pull_changes,
             git_create_pull_request,
             git_get_file_diff,

--- a/src/components/repo/__tests__/RepoWorkflow.integration.test.tsx
+++ b/src/components/repo/__tests__/RepoWorkflow.integration.test.tsx
@@ -76,6 +76,8 @@ describe('Repo workflow integration', () => {
               branch: 'main',
             },
           });
+        case 'git_pull_repository':
+          return Promise.resolve('Fast-forward completado desde origin/main hasta def456.');
         case 'git_create_pull_request':
           return Promise.resolve({ url: 'https://example.com/pr/1' });
         case 'git_commit_changes':
@@ -160,6 +162,16 @@ describe('Repo workflow integration', () => {
       'Describe qué cambios necesitas (usa `rutas/relativas` para guiar al motor).',
     );
     await waitFor(() => expect((analysisField as HTMLTextAreaElement).value).toBe(canonicalSnippet));
+
+    await waitFor(() =>
+      expect(invokeMock).toHaveBeenCalledWith('git_pull_repository', {
+        repoPath: '/tmp/demo',
+        remote: 'origin',
+        branch: 'main',
+      }),
+    );
+
+    await screen.findByText(/Sincronización completada:/);
 
     fireEvent.change(screen.getByPlaceholderText('org'), { target: { value: 'acme' } });
     fireEvent.change(screen.getByPlaceholderText('repo'), { target: { value: 'wonder-project' } });

--- a/src/core/codex/__tests__/RepoWorkflowContext.test.tsx
+++ b/src/core/codex/__tests__/RepoWorkflowContext.test.tsx
@@ -61,5 +61,6 @@ describe('RepoWorkflowContext', () => {
     expect(pending?.request.context.repositoryPath).toBe('/workbench/app');
     expect(pending?.request.context.branch).toBe('develop');
     expect(pending?.request.context.actor).toBe('openai:gpt-4');
+    expect(pending?.remoteName).toBe('origin');
   });
 });

--- a/src/core/messages/__tests__/MessageContext.test.tsx
+++ b/src/core/messages/__tests__/MessageContext.test.tsx
@@ -1,24 +1,79 @@
 import React from 'react';
-import { renderHook, act } from '@testing-library/react';
-import { describe, expect, it } from 'vitest';
+import { renderHook, act, waitFor } from '@testing-library/react';
+import { describe, expect, it, beforeEach, vi } from 'vitest';
+
+const hoistedMocks = vi.hoisted(() => ({
+  invoke: vi.fn(),
+  enqueue: vi.fn(),
+  sync: vi.fn(),
+}));
+
+vi.mock('@tauri-apps/api/tauri', () => ({
+  invoke: hoistedMocks.invoke,
+}));
+
+vi.mock('../../storage/userDataPathsClient', () => ({
+  isTauriEnvironment: () => true,
+}));
+
+vi.mock('../../codex', () => ({
+  enqueueRepoWorkflowRequest: hoistedMocks.enqueue,
+  syncRepositoryViaWorkflow: hoistedMocks.sync,
+}));
+
+const invokeMock = hoistedMocks.invoke;
+const enqueueRepoWorkflowRequestMock = hoistedMocks.enqueue;
+const syncRepositoryViaWorkflowMock = hoistedMocks.sync;
 import { AgentProvider } from '../../agents/AgentContext';
 import { MessageProvider, useMessages } from '../MessageContext';
 import { ProjectProvider } from '../../projects/ProjectContext';
 import { DEFAULT_GLOBAL_SETTINGS } from '../../../utils/globalSettings';
 
-const Wrapper: React.FC<{ children: React.ReactNode }> = ({ children }) => {
-  const [settings, setSettings] = React.useState(() => ({ ...DEFAULT_GLOBAL_SETTINGS }));
+const createWrapper = (
+  settingsFactory: () => typeof DEFAULT_GLOBAL_SETTINGS,
+): React.FC<{ children: React.ReactNode }> => {
+  return ({ children }) => {
+    const [settings, setSettings] = React.useState(settingsFactory);
 
-  return (
-    <ProjectProvider settings={settings} onSettingsChange={setSettings}>
-      <AgentProvider apiKeys={{}}>
-        <MessageProvider apiKeys={{}}>{children}</MessageProvider>
-      </AgentProvider>
-    </ProjectProvider>
-  );
+    return (
+      <ProjectProvider settings={settings} onSettingsChange={setSettings}>
+        <AgentProvider apiKeys={{}}>
+          <MessageProvider apiKeys={{}}>{children}</MessageProvider>
+        </AgentProvider>
+      </ProjectProvider>
+    );
+  };
 };
 
+const baseSettingsFactory = () =>
+  JSON.parse(JSON.stringify(DEFAULT_GLOBAL_SETTINGS)) as typeof DEFAULT_GLOBAL_SETTINGS;
+
+const projectSettingsFactory = () => {
+  const cloned = JSON.parse(JSON.stringify(DEFAULT_GLOBAL_SETTINGS)) as typeof DEFAULT_GLOBAL_SETTINGS;
+  cloned.projectProfiles = [
+    {
+      id: 'toolkit',
+      name: 'Toolkit',
+      repositoryPath: '/workbench/app',
+      defaultRemote: 'origin',
+      defaultBranch: 'develop',
+    },
+  ];
+  cloned.activeProjectId = 'toolkit';
+  return cloned;
+};
+
+const Wrapper = createWrapper(baseSettingsFactory);
+const ProjectWrapper = createWrapper(projectSettingsFactory);
+
 describe('MessageContext', () => {
+  beforeEach(() => {
+    invokeMock.mockReset();
+    enqueueRepoWorkflowRequestMock.mockReset();
+    syncRepositoryViaWorkflowMock.mockReset();
+    syncRepositoryViaWorkflowMock.mockResolvedValue('Fast-forward completado.');
+  });
+
   it('carga el contenido del mensaje en el borrador', () => {
     const { result } = renderHook(() => useMessages(), { wrapper: Wrapper });
     const initialMessage = result.current.messages[0];
@@ -36,5 +91,57 @@ describe('MessageContext', () => {
 
     expect(result.current.draft).toBe(expectedDraft);
     expect(result.current.composerAttachments).toHaveLength(0);
+  });
+
+  it('sincroniza el repositorio activo al solicitar analizar el proyecto', async () => {
+    invokeMock.mockResolvedValue({ branch: 'feature/research' });
+    const { result } = renderHook(() => useMessages(), { wrapper: ProjectWrapper });
+
+    act(() => {
+      result.current.setDraft('¿Puedes analizar mi proyecto?');
+    });
+
+    act(() => {
+      result.current.sendMessage();
+    });
+
+    await waitFor(() => expect(syncRepositoryViaWorkflowMock).toHaveBeenCalled());
+    expect(syncRepositoryViaWorkflowMock).toHaveBeenCalledWith({
+      repositoryPath: '/workbench/app',
+      remote: 'origin',
+      branch: 'develop',
+    });
+
+    await waitFor(() => expect(enqueueRepoWorkflowRequestMock).toHaveBeenCalled());
+    expect(enqueueRepoWorkflowRequestMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        repositoryPath: '/workbench/app',
+        branch: 'feature/research',
+      }),
+    );
+    expect(invokeMock).toHaveBeenCalledWith('git_get_repository_context', {
+      repoPath: '/workbench/app',
+    });
+
+    const lastMessages = result.current.messages.slice(-2).map(message => message.content);
+    expect(lastMessages[1]).toContain('Sincronizando el proyecto activo');
+  });
+
+  it('avisa cuando no hay proyecto activo para analizar', () => {
+    const { result } = renderHook(() => useMessages(), { wrapper: Wrapper });
+
+    act(() => {
+      result.current.setDraft('analiza mi proyecto ahora mismo');
+    });
+
+    act(() => {
+      result.current.sendMessage();
+    });
+
+    const lastMessage = result.current.messages[result.current.messages.length - 1];
+    expect(typeof lastMessage.content).toBe('string');
+    expect(lastMessage.content).toContain('No hay ningún proyecto activo enlazado para analizar');
+    expect(syncRepositoryViaWorkflowMock).not.toHaveBeenCalled();
+    expect(enqueueRepoWorkflowRequestMock).not.toHaveBeenCalled();
   });
 });


### PR DESCRIPTION
## Summary
- add a libgit2-based `git_pull_repository` command and expose it through Tauri
- synchronize repositories from Repo Studio before processing queued workflows and refresh UI state
- detect "analiza mi proyecto" prompts in the chat to pull the active repo, enqueue Repo Studio, and cover the flow with unit/E2E tests

## Testing
- npx vitest run

------
https://chatgpt.com/codex/tasks/task_e_68cf1b5eca208333a8dd303354838138