### PR TITLE
Add model preferences UI and Hugging Face catalog manager

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useRef, useState } from 'react';
+import React, { useCallback, useEffect, useRef, useState } from 'react';
 import './App.css';
 import './AppLayout.css';
 import './components/chat/ChatInterface.css';
@@ -25,6 +25,7 @@ import { OverlayModal } from './components/common/OverlayModal';
 import { PluginSummary } from './components/settings/PluginSummary';
 import { McpSummary } from './components/settings/McpSummary';
 import { ProjectProvider } from './core/projects/ProjectContext';
+import { ModelManagerModal } from './components/models/ModelManagerModal';
 
 interface AppContentProps {
   apiKeys: ApiKeySettings;
@@ -48,6 +49,20 @@ const AppContent: React.FC<AppContentProps> = ({
   const [isPluginsOpen, setPluginsOpen] = useState(false);
   const [isMcpOpen, setMcpOpen] = useState(false);
   const [isStatsOpen, setStatsOpen] = useState(false);
+  const [isModelManagerOpen, setModelManagerOpen] = useState(false);
+
+  const handleModelStorageDirChange = useCallback(
+    (nextPath: string | null) => {
+      onSettingsChange(prev => ({
+        ...prev,
+        modelPreferences: {
+          ...prev.modelPreferences,
+          storageDir: nextPath,
+        },
+      }));
+    },
+    [onSettingsChange],
+  );
 
   const sidePanelPosition = settings.workspacePreferences.sidePanel.position;
 
@@ -66,6 +81,7 @@ const AppContent: React.FC<AppContentProps> = ({
         onOpenGlobalSettings={() => setSettingsOpen(true)}
         onOpenPlugins={() => setPluginsOpen(true)}
         onOpenMcp={() => setMcpOpen(true)}
+        onOpenModelManager={() => setModelManagerOpen(true)}
         activeView={activeView}
         onChangeView={setActiveView}
       />
@@ -103,6 +119,14 @@ const AppContent: React.FC<AppContentProps> = ({
         apiKeys={apiKeys}
         onApiKeyChange={onApiKeyChange}
         onSettingsChange={onSettingsChange}
+      />
+
+      <ModelManagerModal
+        isOpen={isModelManagerOpen}
+        onClose={() => setModelManagerOpen(false)}
+        storageDir={settings.modelPreferences.storageDir}
+        huggingFacePreferences={settings.modelPreferences.huggingFace}
+        onStorageDirChange={handleModelStorageDirChange}
       />
 
       <OverlayModal

--- a/src/components/chat/ChatTopBar.tsx
+++ b/src/components/chat/ChatTopBar.tsx
@@ -18,6 +18,7 @@ interface ChatTopBarProps {
   onOpenGlobalSettings: () => void;
   onOpenPlugins: () => void;
   onOpenMcp: () => void;
+  onOpenModelManager: () => void;
   activeView: 'chat' | 'repo';
   onChangeView: (view: 'chat' | 'repo') => void;
 }
@@ -60,6 +61,7 @@ export const ChatTopBar: React.FC<ChatTopBarProps> = ({
   onOpenGlobalSettings,
   onOpenPlugins,
   onOpenMcp,
+  onOpenModelManager,
   activeView,
   onChangeView,
 }) => {
@@ -186,6 +188,14 @@ export const ChatTopBar: React.FC<ChatTopBarProps> = ({
             aria-label="Ver estadísticas de la conversación"
           >
             📊
+          </button>
+          <button
+            type="button"
+            className="icon-button"
+            onClick={onOpenModelManager}
+            aria-label="Abrir gestor de modelos"
+          >
+            💾
           </button>
         </div>
 

--- a/src/components/chat/__tests__/SidePanel.test.tsx
+++ b/src/components/chat/__tests__/SidePanel.test.tsx
@@ -189,6 +189,7 @@ describe('Gestión de proyectos y modelos', () => {
           onOpenGlobalSettings={vi.fn()}
           onOpenPlugins={vi.fn()}
           onOpenMcp={vi.fn()}
+          onOpenModelManager={vi.fn()}
           activeView="chat"
           onChangeView={vi.fn()}
         />

--- a/src/components/models/ModelManagerModal.css
+++ b/src/components/models/ModelManagerModal.css
@@ -1,0 +1,271 @@
+.model-manager {
+  display: flex;
+  flex-direction: column;
+  gap: 1.5rem;
+  color: var(--text-color, #fff);
+}
+
+.model-manager__preferences {
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+  background: rgba(255, 255, 255, 0.04);
+  padding: 1rem 1.5rem;
+  border-radius: 12px;
+}
+
+.model-manager__storage label {
+  font-weight: 600;
+  display: block;
+  margin-bottom: 0.25rem;
+}
+
+.model-manager__storage-input {
+  display: flex;
+  gap: 0.75rem;
+}
+
+.model-manager__storage-input input {
+  flex: 1;
+}
+
+.model-manager__storage-input button {
+  white-space: nowrap;
+}
+
+.model-manager__storage-hint {
+  margin-top: 0.5rem;
+  font-size: 0.85rem;
+  color: rgba(255, 255, 255, 0.65);
+}
+
+.model-manager__filters {
+  display: grid;
+  gap: 1rem;
+}
+
+.model-manager__search label {
+  display: block;
+  font-weight: 600;
+  margin-bottom: 0.25rem;
+}
+
+.model-manager__search > div {
+  display: flex;
+  gap: 0.75rem;
+}
+
+.model-manager__filter-grid {
+  display: grid;
+  gap: 1rem;
+  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+}
+
+.model-manager__filter-grid label {
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+  font-weight: 600;
+}
+
+.model-manager__filter-grid select {
+  padding: 0.35rem 0.5rem;
+  border-radius: 8px;
+}
+
+.model-manager__filters-footer {
+  display: flex;
+  flex-wrap: wrap;
+  justify-content: space-between;
+  gap: 0.75rem;
+  align-items: center;
+}
+
+.model-manager__pagination {
+  display: flex;
+  align-items: center;
+  gap: 0.75rem;
+}
+
+.model-manager__filters-actions {
+  display: flex;
+  gap: 0.75rem;
+}
+
+.model-manager__content {
+  display: grid;
+  grid-template-columns: 3fr 1.3fr;
+  gap: 1.5rem;
+}
+
+.model-manager__catalog header,
+.model-manager__local header {
+  display: flex;
+  align-items: baseline;
+  gap: 0.75rem;
+  margin-bottom: 0.75rem;
+}
+
+.model-manager__query {
+  font-size: 0.85rem;
+  color: rgba(255, 255, 255, 0.65);
+}
+
+.model-manager__catalog-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(220px, 1fr));
+  gap: 1rem;
+}
+
+.model-card {
+  background: rgba(255, 255, 255, 0.05);
+  border-radius: 12px;
+  padding: 1rem;
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+  border: 1px solid transparent;
+}
+
+.model-card__header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 0.5rem;
+}
+
+.model-card__header h4 {
+  font-size: 1rem;
+  margin: 0;
+}
+
+.model-card__tag {
+  font-size: 0.75rem;
+  padding: 0.15rem 0.4rem;
+  border-radius: 999px;
+  background: rgba(92, 187, 255, 0.18);
+  color: #5cbbff;
+}
+
+.model-card__stats {
+  display: grid;
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+  gap: 0.5rem;
+  font-size: 0.8rem;
+}
+
+.model-card__stats dt {
+  opacity: 0.65;
+}
+
+.model-card__stats dd {
+  margin: 0;
+  font-weight: 600;
+}
+
+.model-card__footer {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  flex-wrap: wrap;
+}
+
+.model-card__progress {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  width: 100%;
+}
+
+.model-card__progress-bar {
+  flex: 1;
+  height: 6px;
+  border-radius: 999px;
+  background: linear-gradient(90deg, #58d0ff, #2c8ee8);
+}
+
+.model-card__active {
+  font-size: 0.8rem;
+  color: #8affb8;
+  font-weight: 600;
+}
+
+.model-card__status {
+  font-size: 0.75rem;
+  opacity: 0.6;
+}
+
+.model-manager__error {
+  padding: 0.75rem 1rem;
+  border-radius: 10px;
+  background: rgba(255, 99, 132, 0.14);
+  color: #ff6b86;
+  font-size: 0.9rem;
+}
+
+.model-manager__empty,
+.model-manager__loading {
+  padding: 1rem;
+  border-radius: 10px;
+  background: rgba(255, 255, 255, 0.04);
+  text-align: center;
+  font-size: 0.9rem;
+}
+
+.model-manager__local {
+  background: rgba(255, 255, 255, 0.04);
+  border-radius: 12px;
+  padding: 1rem;
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+}
+
+.model-manager__local-list {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+}
+
+.model-manager__local-list li {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  padding: 0.65rem 0.75rem;
+  border-radius: 10px;
+  background: rgba(0, 0, 0, 0.25);
+  gap: 0.75rem;
+}
+
+.model-manager__local-list li.is-active {
+  border: 1px solid rgba(90, 205, 150, 0.4);
+}
+
+.model-manager__local-name {
+  font-weight: 600;
+}
+
+.model-manager__local-status {
+  font-size: 0.75rem;
+  opacity: 0.6;
+  margin-left: 0.5rem;
+}
+
+.model-manager__local-progress {
+  font-size: 0.8rem;
+}
+
+.model-manager__local-active {
+  font-size: 0.8rem;
+  color: #8affb8;
+  font-weight: 600;
+}
+
+@media (max-width: 1100px) {
+  .model-manager__content {
+    grid-template-columns: 1fr;
+  }
+}

--- a/src/components/models/ModelManagerModal.tsx
+++ b/src/components/models/ModelManagerModal.tsx
@@ -1,0 +1,401 @@
+import React, { useCallback, useMemo, useState } from 'react';
+import { OverlayModal } from '../common/OverlayModal';
+import { useHuggingFaceCatalog } from '../../hooks/useHuggingFaceCatalog';
+import { useLocalModels } from '../../hooks/useLocalModels';
+import type { HuggingFacePreferences } from '../../types/globalSettings';
+import './ModelManagerModal.css';
+
+interface ModelManagerModalProps {
+  isOpen: boolean;
+  onClose: () => void;
+  storageDir: string | null;
+  huggingFacePreferences: HuggingFacePreferences;
+  onStorageDirChange: (nextPath: string | null) => void;
+}
+
+const TASK_FILTERS: Array<{ value: string; label: string }> = [
+  { value: '', label: 'Todas las tareas' },
+  { value: 'text-generation', label: 'Generación de texto' },
+  { value: 'text2text-generation', label: 'Instrucciones' },
+  { value: 'conversational', label: 'Conversacional' },
+  { value: 'translation', label: 'Traducción' },
+  { value: 'summarization', label: 'Resumen' },
+];
+
+const LIBRARY_FILTERS: Array<{ value: string; label: string }> = [
+  { value: '', label: 'Todas las librerías' },
+  { value: 'transformers', label: 'Transformers' },
+  { value: 'ggml', label: 'GGML / GGUF' },
+  { value: 'safetensors', label: 'SafeTensors' },
+];
+
+const formatCount = (value: number | undefined): string => {
+  if (!value) {
+    return '—';
+  }
+  if (value >= 1_000_000) {
+    return `${(value / 1_000_000).toFixed(1)}M`;
+  }
+  if (value >= 1_000) {
+    return `${(value / 1_000).toFixed(1)}K`;
+  }
+  return String(value);
+};
+
+const formatDate = (value: string | undefined): string => {
+  if (!value) {
+    return '—';
+  }
+  try {
+    const date = new Date(value);
+    if (Number.isNaN(date.getTime())) {
+      return value;
+    }
+    return date.toLocaleDateString();
+  } catch {
+    return value;
+  }
+};
+
+export const ModelManagerModal: React.FC<ModelManagerModalProps> = ({
+  isOpen,
+  onClose,
+  storageDir,
+  huggingFacePreferences,
+  onStorageDirChange,
+}) => {
+  const [syncToken, setSyncToken] = useState(0);
+  const [searchDraft, setSearchDraft] = useState('');
+
+  const {
+    models: catalogModels,
+    isLoading: isCatalogLoading,
+    error: catalogError,
+    page,
+    hasNextPage,
+    hasPreviousPage,
+    search,
+    filters,
+    setSearch,
+    setFilters,
+    setPage,
+    refresh: refreshCatalog,
+  } = useHuggingFaceCatalog({
+    apiBaseUrl: huggingFacePreferences.apiBaseUrl,
+    pageSize: 12,
+    maxResults: huggingFacePreferences.maxResults,
+    initialSearch: '',
+    initialFilters: {},
+  });
+
+  const {
+    models: localModels,
+    isLoading: isLocalLoading,
+    error: localError,
+    download,
+    activate,
+    refresh: refreshLocal,
+  } = useLocalModels({ storageDir, syncToken });
+
+  const localMap = useMemo(() => {
+    const map = new Map<string, typeof localModels[number]>();
+    localModels.forEach(model => {
+      map.set(model.id, model);
+    });
+    return map;
+  }, [localModels]);
+
+  const handleApplySearch = useCallback(
+    (event: React.FormEvent<HTMLFormElement>) => {
+      event.preventDefault();
+      setSearch(searchDraft);
+      setPage(0);
+    },
+    [searchDraft, setPage, setSearch],
+  );
+
+  const handleResetFilters = useCallback(() => {
+    setSearch('');
+    setSearchDraft('');
+    setFilters({ task: undefined, library: undefined });
+    setPage(0);
+  }, [setFilters, setPage, setSearch]);
+
+  const handleDownload = useCallback(
+    async (modelId: string) => {
+      await download(modelId);
+      setSyncToken(value => value + 1);
+      await refreshLocal();
+    },
+    [download, refreshLocal],
+  );
+
+  const handleActivate = useCallback(
+    async (modelId: string) => {
+      await activate(modelId);
+      setSyncToken(value => value + 1);
+      await refreshLocal();
+    },
+    [activate, refreshLocal],
+  );
+
+  const handleBrowseStorage = useCallback(async () => {
+    if (typeof window === 'undefined') {
+      return;
+    }
+
+    try {
+      const module = await import('@tauri-apps/api/dialog');
+      const selection = await module.open({ directory: true, multiple: false });
+      if (typeof selection === 'string' && selection.trim()) {
+        onStorageDirChange(selection);
+        setSyncToken(value => value + 1);
+        await refreshLocal();
+        return;
+      }
+    } catch (error) {
+      console.warn('No se pudo abrir el selector de carpetas', error);
+    }
+
+    const next = window.prompt('Ruta donde se guardarán los modelos locales', storageDir ?? '');
+    if (typeof next === 'string') {
+      onStorageDirChange(next.trim() ? next.trim() : null);
+      setSyncToken(value => value + 1);
+      await refreshLocal();
+    }
+  }, [onStorageDirChange, refreshLocal, storageDir]);
+
+  const handleStorageInputChange = useCallback(
+    (event: React.ChangeEvent<HTMLInputElement>) => {
+      const value = event.target.value;
+      const trimmed = value.trim();
+      onStorageDirChange(trimmed ? trimmed : null);
+      setSyncToken(prev => prev + 1);
+    },
+    [onStorageDirChange],
+  );
+
+  return (
+    <OverlayModal title="Gestor de modelos" isOpen={isOpen} onClose={onClose} width={960}>
+      <div className="model-manager">
+        <section className="model-manager__preferences">
+          <div className="model-manager__storage">
+            <label htmlFor="model-storage">Carpeta de almacenamiento</label>
+            <div className="model-manager__storage-input">
+              <input
+                id="model-storage"
+                type="text"
+                value={storageDir ?? ''}
+                placeholder="Usar ubicación predeterminada"
+                onChange={handleStorageInputChange}
+              />
+              <button type="button" onClick={() => void handleBrowseStorage()}>
+                Seleccionar…
+              </button>
+            </div>
+            <p className="model-manager__storage-hint">
+              Los modelos descargados se guardarán en esta carpeta. Cambia la ruta si necesitas un disco externo.
+            </p>
+          </div>
+
+          <form className="model-manager__filters" onSubmit={handleApplySearch}>
+            <div className="model-manager__search">
+              <label htmlFor="catalog-search">Buscar modelos</label>
+              <div>
+                <input
+                  id="catalog-search"
+                  type="search"
+                  placeholder="Nombre, autor o etiqueta"
+                  value={searchDraft}
+                  onChange={event => setSearchDraft(event.target.value)}
+                />
+                <button type="submit" disabled={isCatalogLoading}>
+                  Buscar
+                </button>
+              </div>
+            </div>
+
+            <div className="model-manager__filter-grid">
+              <label>
+                <span>Tarea</span>
+                <select
+                  value={filters.task ?? ''}
+                  onChange={event => setFilters({
+                    task: event.target.value || undefined,
+                    library: filters.library,
+                  })}
+                >
+                  {TASK_FILTERS.map(option => (
+                    <option key={option.value} value={option.value}>
+                      {option.label}
+                    </option>
+                  ))}
+                </select>
+              </label>
+
+              <label>
+                <span>Librería</span>
+                <select
+                  value={filters.library ?? ''}
+                  onChange={event => setFilters({
+                    task: filters.task,
+                    library: event.target.value || undefined,
+                  })}
+                >
+                  {LIBRARY_FILTERS.map(option => (
+                    <option key={option.value} value={option.value}>
+                      {option.label}
+                    </option>
+                  ))}
+                </select>
+              </label>
+            </div>
+
+            <div className="model-manager__filters-footer">
+              <div className="model-manager__pagination">
+                <button
+                  type="button"
+                  onClick={() => setPage(Math.max(0, page - 1))}
+                  disabled={!hasPreviousPage || isCatalogLoading}
+                >
+                  ← Anterior
+                </button>
+                <span>
+                  Página {page + 1}
+                </span>
+                <button
+                  type="button"
+                  onClick={() => setPage(page + 1)}
+                  disabled={!hasNextPage || isCatalogLoading}
+                >
+                  Siguiente →
+                </button>
+              </div>
+              <div className="model-manager__filters-actions">
+                <button type="button" onClick={handleResetFilters}>
+                  Limpiar filtros
+                </button>
+                <button type="button" onClick={() => refreshCatalog()} disabled={isCatalogLoading}>
+                  Actualizar catálogo
+                </button>
+              </div>
+            </div>
+          </form>
+        </section>
+
+        <section className="model-manager__content">
+          <div className="model-manager__catalog">
+            <header>
+              <h3>Catálogo de Hugging Face</h3>
+              {search && <span className="model-manager__query">Filtro activo: “{search}”</span>}
+            </header>
+            {catalogError && <div className="model-manager__error">{catalogError}</div>}
+            <div className="model-manager__catalog-grid">
+              {catalogModels.map(model => {
+                const local = localMap.get(model.id);
+                const status = local?.status ?? 'not_installed';
+                const isActive = Boolean(local?.active);
+                const isReady = status === 'ready';
+                const isDownloading = status === 'downloading';
+                const progress = local?.progress ?? 0;
+
+                return (
+                  <article key={model.id} className={`model-card model-card--${status}`}>
+                    <header className="model-card__header">
+                      <h4>{model.name}</h4>
+                      {model.pipelineTag && <span className="model-card__tag">{model.pipelineTag}</span>}
+                    </header>
+                    <dl className="model-card__stats">
+                      <div>
+                        <dt>Descargas</dt>
+                        <dd>{formatCount(model.downloads)}</dd>
+                      </div>
+                      <div>
+                        <dt>Favoritos</dt>
+                        <dd>{formatCount(model.likes)}</dd>
+                      </div>
+                      <div>
+                        <dt>Actualizado</dt>
+                        <dd>{formatDate(model.lastModified)}</dd>
+                      </div>
+                    </dl>
+                    <footer className="model-card__footer">
+                      {isDownloading && (
+                        <div className="model-card__progress">
+                          <div className="model-card__progress-bar" style={{ width: `${Math.round(progress * 100)}%` }} />
+                          <span>{Math.round(progress * 100)}%</span>
+                        </div>
+                      )}
+                      {!isDownloading && !isReady && (
+                        <button
+                          type="button"
+                          onClick={() => void handleDownload(model.id)}
+                          disabled={isCatalogLoading || isLocalLoading}
+                        >
+                          Descargar
+                        </button>
+                      )}
+                      {isReady && !isActive && (
+                        <button
+                          type="button"
+                          onClick={() => void handleActivate(model.id)}
+                          disabled={isLocalLoading}
+                        >
+                          Activar
+                        </button>
+                      )}
+                      {isReady && isActive && <span className="model-card__active">Activo</span>}
+                      {!local && <span className="model-card__status">No instalado</span>}
+                    </footer>
+                  </article>
+                );
+              })}
+
+              {!catalogModels.length && !isCatalogLoading && (
+                <div className="model-manager__empty">No se encontraron modelos para los filtros seleccionados.</div>
+              )}
+
+              {isCatalogLoading && <div className="model-manager__loading">Cargando catálogo…</div>}
+            </div>
+          </div>
+
+          <aside className="model-manager__local">
+            <header>
+              <h3>Modelos instalados</h3>
+            </header>
+            {localError && <div className="model-manager__error">{localError}</div>}
+            <ul className="model-manager__local-list">
+              {localModels.map(model => (
+                <li key={model.id} className={model.active ? 'is-active' : ''}>
+                  <div>
+                    <span className="model-manager__local-name">{model.name}</span>
+                    <span className="model-manager__local-status">{model.status}</span>
+                  </div>
+                  {model.progress !== undefined && model.status === 'downloading' && (
+                    <div className="model-manager__local-progress" aria-live="polite">
+                      {Math.round(model.progress * 100)}%
+                    </div>
+                  )}
+                  {model.status === 'ready' && !model.active && (
+                    <button type="button" onClick={() => void handleActivate(model.id)} disabled={isLocalLoading}>
+                      Activar
+                    </button>
+                  )}
+                  {model.status === 'ready' && model.active && <span className="model-manager__local-active">Activo</span>}
+                </li>
+              ))}
+
+              {!localModels.length && !isLocalLoading && (
+                <li className="model-manager__empty">Aún no se han descargado modelos locales.</li>
+              )}
+
+              {isLocalLoading && <li className="model-manager__loading">Sincronizando con el registro local…</li>}
+            </ul>
+          </aside>
+        </section>
+      </div>
+    </OverlayModal>
+  );
+};
+
+export default ModelManagerModal;

--- a/src/components/models/__tests__/ModelManagerModal.test.tsx
+++ b/src/components/models/__tests__/ModelManagerModal.test.tsx
@@ -1,0 +1,110 @@
+import React from 'react';
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import '@testing-library/jest-dom/vitest';
+import { ModelManagerModal } from '../ModelManagerModal';
+
+const activateMock = vi.fn().mockResolvedValue(undefined);
+const downloadMock = vi.fn().mockResolvedValue(undefined);
+const refreshMock = vi.fn().mockResolvedValue(undefined);
+
+vi.mock('../../../hooks/useHuggingFaceCatalog', () => ({
+  useHuggingFaceCatalog: vi.fn(() => ({
+    models: [
+      {
+        id: 'remote-1',
+        name: 'Remote Model',
+        pipelineTag: 'text-generation',
+        downloads: 1250,
+        likes: 230,
+        lastModified: '2024-04-01T00:00:00Z',
+        tags: [],
+      },
+    ],
+    isLoading: false,
+    error: null,
+    page: 0,
+    hasNextPage: false,
+    hasPreviousPage: false,
+    search: '',
+    filters: {},
+    setSearch: vi.fn(),
+    setFilters: vi.fn(),
+    setPage: vi.fn(),
+    refresh: vi.fn(),
+  })),
+}));
+
+vi.mock('../../../hooks/useLocalModels', () => ({
+  useLocalModels: vi.fn(() => ({
+    models: [
+      {
+        id: 'remote-1',
+        name: 'Remote Model',
+        description: 'ready model',
+        provider: 'Local',
+        tags: [],
+        size: 0,
+        checksum: 'abc',
+        status: 'ready',
+        localPath: '/models/remote-1',
+        active: false,
+        progress: 1,
+      },
+      {
+        id: 'local-2',
+        name: 'Local Secondary',
+        description: 'downloading',
+        provider: 'Local',
+        tags: [],
+        size: 0,
+        checksum: 'def',
+        status: 'downloading',
+        localPath: '/models/local-2',
+        active: false,
+        progress: 0.4,
+      },
+    ],
+    isLoading: false,
+    error: null,
+    refresh: refreshMock,
+    download: downloadMock,
+    activate: activateMock,
+  })),
+}));
+
+describe('ModelManagerModal', () => {
+  beforeEach(() => {
+    activateMock.mockClear();
+    downloadMock.mockClear();
+    refreshMock.mockClear();
+  });
+
+  it('renders catalog and local model information', async () => {
+    const handleStorageChange = vi.fn();
+
+    render(
+      <ModelManagerModal
+        isOpen
+        onClose={() => undefined}
+        storageDir={null}
+        huggingFacePreferences={{ apiBaseUrl: 'https://huggingface.co', maxResults: 30, useStoredToken: false }}
+        onStorageDirChange={handleStorageChange}
+      />,
+    );
+
+    expect(screen.getByRole('heading', { name: 'Remote Model' })).toBeInTheDocument();
+    expect(screen.getByText('Local Secondary')).toBeInTheDocument();
+
+    fireEvent.change(screen.getByLabelText('Carpeta de almacenamiento'), {
+      target: { value: '  /data/models  ' },
+    });
+    expect(handleStorageChange).toHaveBeenCalledWith('/data/models');
+
+    fireEvent.click(screen.getAllByText('Activar')[0]);
+
+    await waitFor(() => {
+      expect(activateMock).toHaveBeenCalledWith('remote-1');
+    });
+  });
+});

--- a/src/components/settings/GlobalSettingsDialog.css
+++ b/src/components/settings/GlobalSettingsDialog.css
@@ -207,6 +207,90 @@
   color: rgba(255, 255, 255, 0.65);
 }
 
+.model-preferences {
+  display: flex;
+  flex-direction: column;
+  gap: 18px;
+  padding: 18px;
+  border-radius: 18px;
+  background: rgba(255, 255, 255, 0.04);
+  border: 1px solid rgba(255, 255, 255, 0.08);
+}
+
+.model-preferences__field {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+
+.model-preferences__field label {
+  font-size: 13px;
+  font-weight: 600;
+}
+
+.model-preferences__input-row {
+  display: flex;
+  gap: 8px;
+}
+
+.model-preferences__input-row input {
+  flex: 1 1 auto;
+}
+
+.model-preferences__input-row button {
+  white-space: nowrap;
+}
+
+.model-preferences__field input[type='text'],
+.model-preferences__field input[type='url'],
+.model-preferences__field input[type='number'] {
+  border: 1px solid rgba(255, 255, 255, 0.14);
+  border-radius: 12px;
+  padding: 10px 14px;
+  background: rgba(0, 0, 0, 0.35);
+  color: #fff;
+}
+
+.model-preferences__field--compact input[type='number'] {
+  max-width: 140px;
+}
+
+.model-preferences__hint {
+  font-size: 12px;
+  color: rgba(255, 255, 255, 0.6);
+}
+
+.model-preferences__token {
+  display: grid;
+  gap: 6px;
+}
+
+.model-preferences__token label {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  font-weight: 600;
+}
+
+.model-preferences__token-status {
+  font-size: 12px;
+  letter-spacing: 0.4px;
+  text-transform: uppercase;
+  padding: 4px 10px;
+  border-radius: 999px;
+  width: fit-content;
+}
+
+.model-preferences__token-status.is-available {
+  background: rgba(90, 205, 150, 0.2);
+  color: #a6f4c5;
+}
+
+.model-preferences__token-status.is-missing {
+  background: rgba(255, 138, 101, 0.2);
+  color: #ffab91;
+}
+
 .preference-options {
   display: flex;
   gap: 16px;

--- a/src/hooks/useHuggingFaceCatalog.ts
+++ b/src/hooks/useHuggingFaceCatalog.ts
@@ -1,0 +1,252 @@
+import { useCallback, useEffect, useMemo, useState } from 'react';
+
+export interface HuggingFaceModel {
+  id: string;
+  name: string;
+  pipelineTag?: string;
+  libraryName?: string;
+  likes?: number;
+  downloads?: number;
+  lastModified?: string;
+  private?: boolean;
+  tags: string[];
+  cardData?: Record<string, unknown> | null;
+}
+
+export interface CatalogFilters {
+  task?: string;
+  library?: string;
+}
+
+export interface UseHuggingFaceCatalogOptions {
+  apiBaseUrl: string;
+  pageSize?: number;
+  maxResults?: number;
+  fetcher?: typeof fetch;
+  initialSearch?: string;
+  initialFilters?: CatalogFilters;
+}
+
+export interface HuggingFaceCatalogResult {
+  models: HuggingFaceModel[];
+  isLoading: boolean;
+  error: string | null;
+  page: number;
+  hasNextPage: boolean;
+  hasPreviousPage: boolean;
+  search: string;
+  filters: CatalogFilters;
+  setSearch: (value: string) => void;
+  setFilters: (filters: CatalogFilters) => void;
+  setPage: (page: number) => void;
+  refresh: () => void;
+}
+
+const DEFAULT_PAGE_SIZE = 15;
+const DEFAULT_MAX_RESULTS = 60;
+
+const buildRequestUrl = (
+  baseUrl: string,
+  search: string,
+  filters: CatalogFilters,
+  page: number,
+  pageSize: number,
+  maxResults: number,
+): URL => {
+  const normalizedBase = baseUrl.endsWith('/api')
+    ? `${baseUrl}/models`
+    : baseUrl.endsWith('/api/models')
+    ? baseUrl
+    : `${baseUrl.replace(/\/$/, '')}/api/models`;
+
+  const params = new URLSearchParams();
+  const effectivePageSize = Math.max(1, Math.min(pageSize, maxResults));
+  const skip = Math.max(0, page * effectivePageSize);
+  params.set('limit', String(effectivePageSize));
+  params.set('skip', String(skip));
+  params.set('full', 'true');
+  params.set('sort', 'downloads');
+
+  if (search.trim()) {
+    params.set('search', search.trim());
+  }
+
+  if (filters.task) {
+    params.set('pipeline_tag', filters.task);
+  }
+
+  if (filters.library) {
+    params.set('library', filters.library);
+  }
+
+  return new URL(`${normalizedBase}?${params.toString()}`);
+};
+
+const mapModel = (entry: Record<string, unknown>): HuggingFaceModel | null => {
+  const id = typeof entry.id === 'string' ? entry.id : null;
+  if (!id) {
+    return null;
+  }
+
+  const name = typeof entry.modelId === 'string' ? entry.modelId : id;
+  const pipelineTag = typeof entry.pipeline_tag === 'string' ? entry.pipeline_tag : undefined;
+  const libraryName = typeof entry.library_name === 'string' ? entry.library_name : undefined;
+  const likes = typeof entry.likes === 'number' ? entry.likes : undefined;
+  const downloads = typeof entry.downloads === 'number' ? entry.downloads : undefined;
+  const lastModified = typeof entry.lastModified === 'string' ? entry.lastModified : undefined;
+  const isPrivate = typeof entry.private === 'boolean' ? entry.private : undefined;
+  const tags = Array.isArray(entry.tags)
+    ? entry.tags.filter((value): value is string => typeof value === 'string')
+    : [];
+
+  const cardData = entry.cardData && typeof entry.cardData === 'object' ? (entry.cardData as Record<string, unknown>) : null;
+
+  return {
+    id,
+    name,
+    pipelineTag,
+    libraryName,
+    likes,
+    downloads,
+    lastModified,
+    private: isPrivate,
+    tags,
+    cardData,
+  };
+};
+
+export const useHuggingFaceCatalog = (
+  options: UseHuggingFaceCatalogOptions,
+): HuggingFaceCatalogResult => {
+  const {
+    apiBaseUrl,
+    pageSize = DEFAULT_PAGE_SIZE,
+    maxResults = DEFAULT_MAX_RESULTS,
+    fetcher = fetch,
+    initialSearch = '',
+    initialFilters = {},
+  } = options;
+
+  const [page, setPage] = useState(0);
+  const [search, setSearchInternal] = useState(initialSearch);
+  const [filters, setFiltersInternal] = useState<CatalogFilters>(initialFilters);
+  const [models, setModels] = useState<HuggingFaceModel[]>([]);
+  const [isLoading, setIsLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [refreshKey, setRefreshKey] = useState(0);
+
+  const effectiveMaxResults = Math.max(1, maxResults);
+  const effectivePageSize = Math.max(1, Math.min(pageSize, effectiveMaxResults));
+  const totalPages = Math.max(1, Math.ceil(effectiveMaxResults / effectivePageSize));
+  const boundedPage = Math.min(page, totalPages - 1);
+
+  useEffect(() => {
+    if (boundedPage !== page) {
+      setPage(boundedPage);
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [boundedPage]);
+
+  const refresh = useCallback(() => {
+    setRefreshKey(value => value + 1);
+  }, []);
+
+  useEffect(() => {
+    const abortController = new AbortController();
+    const signal = abortController.signal;
+
+    const run = async () => {
+      setIsLoading(true);
+      setError(null);
+
+      try {
+        const url = buildRequestUrl(
+          apiBaseUrl,
+          search,
+          filters,
+          boundedPage,
+          effectivePageSize,
+          effectiveMaxResults,
+        );
+        const response = await fetcher(url.toString(), { signal });
+        if (!response.ok) {
+          throw new Error(`Catálogo Hugging Face: ${response.status} ${response.statusText}`);
+        }
+
+        const payload = (await response.json()) as unknown;
+        if (!Array.isArray(payload)) {
+          throw new Error('Formato de catálogo no válido');
+        }
+
+        const mapped = payload
+          .map(entry => (entry && typeof entry === 'object' ? mapModel(entry as Record<string, unknown>) : null))
+          .filter((entry): entry is HuggingFaceModel => Boolean(entry));
+
+        setModels(mapped);
+      } catch (err) {
+        if (signal.aborted) {
+          return;
+        }
+        console.error('No se pudo cargar el catálogo de modelos', err);
+        setError(err instanceof Error ? err.message : String(err));
+        setModels([]);
+      } finally {
+        if (!signal.aborted) {
+          setIsLoading(false);
+        }
+      }
+    };
+
+    void run();
+
+    return () => {
+      abortController.abort();
+    };
+  }, [apiBaseUrl, search, filters, boundedPage, effectivePageSize, effectiveMaxResults, fetcher, refreshKey]);
+
+  const hasNextPage = useMemo(() => {
+    if (models.length < Math.min(effectivePageSize, effectiveMaxResults)) {
+      return false;
+    }
+    return boundedPage < totalPages - 1;
+  }, [boundedPage, effectiveMaxResults, models.length, effectivePageSize, totalPages]);
+
+  const hasPreviousPage = boundedPage > 0;
+
+  const handleSetSearch = useCallback((value: string) => {
+    setSearchInternal(value);
+    setPage(0);
+  }, []);
+
+  const handleSetFilters = useCallback((nextFilters: CatalogFilters) => {
+    setFiltersInternal(prev => {
+      if (
+        prev.task === nextFilters.task &&
+        prev.library === nextFilters.library
+      ) {
+        return prev;
+      }
+      return { ...nextFilters };
+    });
+    setPage(0);
+  }, []);
+
+  const handleSetPage = useCallback((nextPage: number) => {
+    setPage(Math.max(0, Math.min(nextPage, totalPages - 1)));
+  }, [totalPages]);
+
+  return {
+    models,
+    isLoading,
+    error,
+    page: boundedPage,
+    hasNextPage,
+    hasPreviousPage,
+    search,
+    filters,
+    setSearch: handleSetSearch,
+    setFilters: handleSetFilters,
+    setPage: handleSetPage,
+    refresh,
+  };
+};

--- a/src/types/globalSettings.ts
+++ b/src/types/globalSettings.ts
@@ -86,6 +86,17 @@ export interface DataLocationSettings {
   lastMigrationAt?: string;
 }
 
+export interface HuggingFacePreferences {
+  apiBaseUrl: string;
+  maxResults: number;
+  useStoredToken: boolean;
+}
+
+export interface ModelPreferences {
+  storageDir: string | null;
+  huggingFace: HuggingFacePreferences;
+}
+
 export interface GlobalSettings {
   version: number;
   apiKeys: ApiKeySettings;
@@ -97,6 +108,7 @@ export interface GlobalSettings {
   mcpProfiles: McpProfile[];
   workspacePreferences: WorkspacePreferences;
   dataLocation: DataLocationSettings;
+  modelPreferences: ModelPreferences;
   projectProfiles: ProjectProfile[];
   activeProjectId: string | null;
   githubDefaultOwner?: string;

--- a/tests/globalSettings.test.ts
+++ b/tests/globalSettings.test.ts
@@ -1,0 +1,34 @@
+import { describe, expect, beforeEach, it } from 'vitest';
+import {
+  CURRENT_SCHEMA_VERSION,
+  DEFAULT_GLOBAL_SETTINGS,
+  loadGlobalSettings,
+  migratePersistedGlobalSettings,
+} from '../src/utils/globalSettings';
+
+beforeEach(() => {
+  localStorage.clear();
+});
+
+describe('globalSettings model preferences', () => {
+  it('includes model preferences in default payload', () => {
+    const settings = loadGlobalSettings();
+
+    expect(settings.modelPreferences).toBeDefined();
+    expect(settings.modelPreferences.storageDir).toBeNull();
+    expect(settings.modelPreferences.huggingFace.apiBaseUrl).toBeTruthy();
+    expect(typeof settings.modelPreferences.huggingFace.maxResults).toBe('number');
+  });
+
+  it('migrates legacy payloads without model preferences', () => {
+    const legacy = JSON.parse(JSON.stringify(DEFAULT_GLOBAL_SETTINGS)) as typeof DEFAULT_GLOBAL_SETTINGS;
+    delete (legacy as any).modelPreferences;
+    legacy.version = CURRENT_SCHEMA_VERSION - 1;
+
+    const migrated = migratePersistedGlobalSettings(legacy);
+
+    expect(migrated.version).toBe(CURRENT_SCHEMA_VERSION);
+    expect(migrated.modelPreferences).toBeDefined();
+    expect(migrated.modelPreferences.huggingFace.apiBaseUrl).toBeTruthy();
+  });
+});


### PR DESCRIPTION
## Summary
- add modelPreferences block to global settings with migration utilities
- replace model tab in GlobalSettingsDialog with model preference form and surface a new ModelManagerModal
- integrate new Hugging Face catalog hook, refresh useLocalModels, and expose manager entrypoint in ChatTopBar
- add vitest coverage for settings migration and modal rendering

## Testing
- npm test -- --run

------
https://chatgpt.com/codex/tasks/task_e_68cf1f70ba388333b8696f597e1f1983