### PR TITLE
feat: add plugin and MCP management modals

### DIFF
--- a/plugins/ableton-mixer/manifest.json
+++ b/plugins/ableton-mixer/manifest.json
@@ -1,0 +1,54 @@
+{
+  "id": "ableton-mixer",
+  "name": "Ableton Live Mixer",
+  "version": "0.1.0",
+  "description": "Controla volúmenes y muteos de pistas en Ableton Live mediante comandos MCP y un panel lateral interactivo.",
+  "capabilities": [
+    {
+      "type": "mcp-session",
+      "id": "ableton-mixer-session",
+      "label": "Sesión de mezcla Ableton",
+      "description": "Expone controles de mezcla vía OSC y WebSocket para pistas seleccionadas.",
+      "endpoints": [
+        { "transport": "osc", "url": "udp://127.0.0.1:9010" },
+        { "transport": "ws", "url": "ws://127.0.0.1:17660" },
+        { "transport": "rest", "url": "http://127.0.0.1:5454/api/mixer" }
+      ],
+      "permissions": [
+        {
+          "id": "set-volume",
+          "label": "Ajustar volumen de pista",
+          "description": "Actualiza el volumen de una pista utilizando mensajes MCP.",
+          "command": "set_volume",
+          "scopes": ["ableton:mixer:write"]
+        },
+        {
+          "id": "toggle-mute",
+          "label": "Alternar mute de pista",
+          "description": "Activa o desactiva el mute de una pista determinada.",
+          "command": "toggle_mute",
+          "scopes": ["ableton:mixer:write"]
+        }
+      ]
+    },
+    {
+      "type": "workspace-panel",
+      "id": "ableton-mixer-panel",
+      "label": "Ableton Mixer",
+      "slot": "side-panel",
+      "module": "./Panel"
+    }
+  ],
+  "commands": [
+    {
+      "name": "set_volume",
+      "description": "Establece el volumen de una pista de Ableton utilizando MCP.",
+      "signature": "ableton-set-volume-v1"
+    },
+    {
+      "name": "toggle_mute",
+      "description": "Alterna el estado de mute de una pista.",
+      "signature": "ableton-toggle-mute-v1"
+    }
+  ]
+}

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -22,8 +22,8 @@ import { ChatActorFilter } from './types/chat';
 import { PluginHostProvider } from './core/plugins/PluginHostProvider';
 import { GlobalSettingsDialog } from './components/settings/GlobalSettingsDialog';
 import { OverlayModal } from './components/common/OverlayModal';
-import { PluginSummary } from './components/settings/PluginSummary';
-import { McpSummary } from './components/settings/McpSummary';
+import { PluginManagerModal } from './components/settings/PluginManagerModal';
+import { McpManagerModal } from './components/settings/McpManagerModal';
 import { ProjectProvider } from './core/projects/ProjectContext';
 import { ModelManagerModal } from './components/models/ModelManagerModal';
 
@@ -134,11 +134,15 @@ const AppContent: React.FC<AppContentProps> = ({
         isOpen={isPluginsOpen}
         onClose={() => setPluginsOpen(false)}
       >
-        <PluginSummary settings={settings} onSettingsChange={onSettingsChange} />
+        <PluginManagerModal settings={settings} onSettingsChange={onSettingsChange} />
       </OverlayModal>
 
-      <OverlayModal title="Perfiles MCP" isOpen={isMcpOpen} onClose={() => setMcpOpen(false)}>
-        <McpSummary settings={settings} />
+      <OverlayModal
+        title="Perfiles MCP"
+        isOpen={isMcpOpen}
+        onClose={() => setMcpOpen(false)}
+      >
+        <McpManagerModal settings={settings} onSettingsChange={onSettingsChange} />
       </OverlayModal>
 
       <ConversationStatsModal isOpen={isStatsOpen} onClose={() => setStatsOpen(false)} />

--- a/src/components/settings/McpManagerModal.css
+++ b/src/components/settings/McpManagerModal.css
@@ -1,0 +1,169 @@
+.mcp-manager {
+  display: flex;
+  gap: 1.5rem;
+  min-height: 320px;
+}
+
+.mcp-manager__list {
+  flex: 0 0 38%;
+  max-height: 420px;
+  overflow-y: auto;
+  padding-right: 0.5rem;
+  border-right: 1px solid rgba(255, 255, 255, 0.08);
+}
+
+.mcp-manager__list h3 {
+  margin: 0 0 0.75rem;
+  font-size: 1rem;
+}
+
+.mcp-manager__item {
+  border-radius: 8px;
+  padding: 0.75rem;
+  cursor: pointer;
+  transition: background 0.2s ease;
+}
+
+.mcp-manager__item:hover {
+  background: rgba(255, 255, 255, 0.05);
+}
+
+.mcp-manager__item:focus-visible {
+  outline: 2px solid rgba(255, 255, 255, 0.4);
+  outline-offset: 2px;
+}
+
+.mcp-manager__item--active {
+  background: rgba(255, 255, 255, 0.08);
+}
+
+.mcp-manager__item-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: flex-start;
+  gap: 0.5rem;
+}
+
+.mcp-manager__item strong {
+  display: block;
+  font-size: 0.95rem;
+}
+
+.mcp-manager__item-description {
+  margin: 0.25rem 0 0;
+  font-size: 0.82rem;
+  color: rgba(255, 255, 255, 0.65);
+}
+
+.mcp-manager__toggle {
+  background: rgba(255, 255, 255, 0.08);
+  border: none;
+  border-radius: 999px;
+  padding: 0.3rem 0.7rem;
+  color: inherit;
+  cursor: pointer;
+  font-size: 0.75rem;
+}
+
+.mcp-manager__toggle--on {
+  background: rgba(76, 217, 100, 0.25);
+  color: #9ff4b9;
+}
+
+.mcp-manager__details {
+  flex: 1 1 auto;
+  overflow-y: auto;
+  padding-right: 0.25rem;
+}
+
+.mcp-manager__details header {
+  display: flex;
+  align-items: baseline;
+  gap: 0.5rem;
+}
+
+.mcp-manager__details h3 {
+  margin: 0;
+}
+
+.mcp-manager__badge {
+  font-size: 0.75rem;
+  color: rgba(255, 255, 255, 0.6);
+  background: rgba(255, 255, 255, 0.08);
+  border-radius: 999px;
+  padding: 0.2rem 0.6rem;
+}
+
+.mcp-manager__details-description {
+  margin: 0.5rem 0 0;
+  color: rgba(255, 255, 255, 0.75);
+}
+
+.mcp-manager__details-block {
+  margin-top: 1.25rem;
+}
+
+.mcp-manager__details-block h4 {
+  margin: 0 0 0.5rem;
+  font-size: 0.9rem;
+}
+
+.mcp-manager__details-block ul {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+}
+
+.mcp-manager__endpoint-transport {
+  display: inline-block;
+  min-width: 3.2rem;
+  font-size: 0.75rem;
+  font-weight: 600;
+  color: rgba(255, 255, 255, 0.7);
+}
+
+.mcp-manager__endpoint-url {
+  margin-left: 0.5rem;
+  font-size: 0.85rem;
+}
+
+.mcp-manager__scopes {
+  display: flex;
+  flex-direction: column;
+  gap: 0.35rem;
+  font-size: 0.82rem;
+}
+
+.mcp-manager__credentials {
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+  list-style: none;
+  margin: 0;
+  padding: 0;
+}
+
+.mcp-manager__credentials label {
+  display: flex;
+  flex-direction: column;
+  gap: 0.35rem;
+}
+
+.mcp-manager__credentials input {
+  background: rgba(255, 255, 255, 0.08);
+  border: 1px solid rgba(255, 255, 255, 0.15);
+  border-radius: 6px;
+  padding: 0.45rem 0.6rem;
+  color: inherit;
+}
+
+.mcp-manager__helper {
+  margin: 0.25rem 0 0;
+  font-size: 0.75rem;
+  color: rgba(255, 255, 255, 0.6);
+}
+
+.mcp-manager__credentials-empty,
+.mcp-manager__details-empty {
+  color: rgba(255, 255, 255, 0.75);
+}

--- a/src/components/settings/McpManagerModal.tsx
+++ b/src/components/settings/McpManagerModal.tsx
@@ -1,0 +1,257 @@
+import React, { useEffect, useMemo, useState } from 'react';
+import { GlobalSettings, McpCredentialEntry } from '../../types/globalSettings';
+import {
+  PREDEFINED_MCP_PROFILES,
+  PredefinedMcpProfile,
+  buildDefaultCredentialState,
+  buildMcpProfileFromCatalog,
+} from '../../core/mcp/predefinedProfiles';
+import './McpManagerModal.css';
+
+interface McpManagerModalProps {
+  settings: GlobalSettings;
+  onSettingsChange: (updater: (prev: GlobalSettings) => GlobalSettings) => void;
+}
+
+const ensureCredentialRecord = (
+  entry: PredefinedMcpProfile,
+  current: Record<string, McpCredentialEntry> | undefined,
+): Record<string, McpCredentialEntry> => {
+  const defaults = buildDefaultCredentialState(entry);
+  if (!current) {
+    return defaults;
+  }
+  const merged: Record<string, McpCredentialEntry> = { ...defaults, ...current };
+  Object.keys(merged).forEach(key => {
+    const value = merged[key];
+    if (!value.id) {
+      merged[key] = { ...value, id: key };
+    }
+  });
+  return merged;
+};
+
+export const McpManagerModal: React.FC<McpManagerModalProps> = ({ settings, onSettingsChange }) => {
+  const [selectedProfileId, setSelectedProfileId] = useState<string | null>(null);
+
+  const catalog = useMemo(
+    () => [...PREDEFINED_MCP_PROFILES].sort((a, b) => a.label.localeCompare(b.label, 'es')),
+    [],
+  );
+
+  useEffect(() => {
+    if (!catalog.length) {
+      setSelectedProfileId(null);
+      return;
+    }
+    if (!selectedProfileId || !catalog.some(entry => entry.id === selectedProfileId)) {
+      setSelectedProfileId(catalog[0]?.id ?? null);
+    }
+  }, [catalog, selectedProfileId]);
+
+  const isProfileActive = (profileId: string) =>
+    settings.mcpProfiles.some(profile => profile.id === profileId);
+
+  const handleToggle = (entry: PredefinedMcpProfile, enabled: boolean) => {
+    onSettingsChange(prev => {
+      const active = prev.mcpProfiles.some(profile => profile.id === entry.id);
+      if (enabled && active) {
+        return prev;
+      }
+      if (!enabled && !active) {
+        return prev;
+      }
+
+      const nextProfiles = enabled
+        ? [...prev.mcpProfiles.filter(profile => profile.id !== entry.id), buildMcpProfileFromCatalog(entry)]
+        : prev.mcpProfiles.filter(profile => profile.id !== entry.id);
+
+      const currentCredentials = prev.mcpCredentials[entry.id];
+      const mergedCredentials = ensureCredentialRecord(entry, currentCredentials);
+
+      return {
+        ...prev,
+        mcpProfiles: nextProfiles,
+        mcpCredentials: {
+          ...prev.mcpCredentials,
+          [entry.id]: mergedCredentials,
+        },
+      };
+    });
+  };
+
+  const handleCredentialChange = (
+    profile: PredefinedMcpProfile,
+    fieldId: string,
+    patch: Partial<Pick<McpCredentialEntry, 'value' | 'secretId'>>,
+  ) => {
+    onSettingsChange(prev => {
+      const entry = ensureCredentialRecord(profile, prev.mcpCredentials[profile.id]);
+      const current = entry[fieldId] ?? { id: fieldId, type: 'api-key' };
+      const updated: McpCredentialEntry = {
+        ...current,
+        id: fieldId,
+        type: current.type,
+        ...patch,
+      };
+      return {
+        ...prev,
+        mcpCredentials: {
+          ...prev.mcpCredentials,
+          [profile.id]: {
+            ...entry,
+            [fieldId]: updated,
+          },
+        },
+      };
+    });
+  };
+
+  const selectedProfile = catalog.find(entry => entry.id === selectedProfileId) ?? null;
+  const selectedCredentialStore = selectedProfile
+    ? ensureCredentialRecord(selectedProfile, settings.mcpCredentials[selectedProfile.id])
+    : null;
+
+  return (
+    <div className="mcp-manager">
+      <aside className="mcp-manager__list" aria-label="Catálogo de perfiles MCP">
+        <h3>Perfiles disponibles</h3>
+        <ul>
+          {catalog.map(entry => {
+            const active = isProfileActive(entry.id);
+            const isActiveItem = entry.id === selectedProfileId;
+            return (
+              <li key={entry.id}>
+                <div
+                  role="button"
+                  tabIndex={0}
+                  className={`mcp-manager__item${isActiveItem ? ' mcp-manager__item--active' : ''}`}
+                  onClick={() => setSelectedProfileId(entry.id)}
+                  onKeyDown={event => {
+                    if (event.key === 'Enter' || event.key === ' ') {
+                      event.preventDefault();
+                      setSelectedProfileId(entry.id);
+                    }
+                  }}
+                >
+                  <div className="mcp-manager__item-header">
+                    <div>
+                      <strong>{entry.label}</strong>
+                      {entry.description && (
+                        <p className="mcp-manager__item-description">{entry.description}</p>
+                      )}
+                    </div>
+                    <button
+                      type="button"
+                      data-testid={`mcp-toggle-${entry.id}`}
+                      className={`mcp-manager__toggle${active ? ' mcp-manager__toggle--on' : ''}`}
+                      onClick={event => {
+                        event.stopPropagation();
+                        handleToggle(entry, !active);
+                      }}
+                      aria-pressed={active}
+                      aria-label={`${active ? 'Desactivar' : 'Activar'} perfil ${entry.label}`}
+                    >
+                      {active ? 'Activo' : 'Inactivo'}
+                    </button>
+                  </div>
+                </div>
+              </li>
+            );
+          })}
+        </ul>
+      </aside>
+
+      <section className="mcp-manager__details" aria-live="polite">
+        {selectedProfile ? (
+          <>
+            <header>
+              <h3>{selectedProfile.label}</h3>
+              <span className="mcp-manager__badge">{isProfileActive(selectedProfile.id) ? 'Activo' : 'Disponible'}</span>
+            </header>
+            {selectedProfile.description && (
+              <p className="mcp-manager__details-description">{selectedProfile.description}</p>
+            )}
+
+            <section className="mcp-manager__details-block">
+              <h4>Endpoints</h4>
+              <ul>
+                {selectedProfile.endpoints.map(endpoint => (
+                  <li key={endpoint.id}>
+                    <span className="mcp-manager__endpoint-transport">{endpoint.transport.toUpperCase()}</span>
+                    <span className="mcp-manager__endpoint-url">{endpoint.url}</span>
+                  </li>
+                ))}
+              </ul>
+            </section>
+
+            {selectedProfile.scopes.length ? (
+              <section className="mcp-manager__details-block">
+                <h4>Scopes sugeridos</h4>
+                <ul className="mcp-manager__scopes">
+                  {selectedProfile.scopes.map(scope => (
+                    <li key={scope}>{scope}</li>
+                  ))}
+                </ul>
+              </section>
+            ) : null}
+
+            {selectedProfile.credentialRequirements?.length ? (
+              <section className="mcp-manager__details-block">
+                <h4>Credenciales</h4>
+                <ul className="mcp-manager__credentials">
+                  {selectedProfile.credentialRequirements.map(requirement => {
+                    const credential = selectedCredentialStore?.[requirement.id];
+                    const value = credential?.value ?? '';
+                    const secretId = credential?.secretId ?? '';
+                    return (
+                      <li key={requirement.id}>
+                        <label>
+                          <span>{requirement.label}</span>
+                          {requirement.type === 'api-key' ? (
+                            <input
+                              type="text"
+                              value={value}
+                              placeholder={requirement.placeholder ?? 'Introduce la API key'}
+                              onChange={event =>
+                                handleCredentialChange(selectedProfile, requirement.id, {
+                                  value: event.target.value,
+                                })
+                              }
+                            />
+                          ) : (
+                            <input
+                              type="text"
+                              value={secretId}
+                              placeholder={requirement.placeholder ?? 'Identificador en SecretManager'}
+                              onChange={event =>
+                                handleCredentialChange(selectedProfile, requirement.id, {
+                                  secretId: event.target.value,
+                                })
+                              }
+                            />
+                          )}
+                        </label>
+                        {requirement.helperText && (
+                          <p className="mcp-manager__helper">{requirement.helperText}</p>
+                        )}
+                      </li>
+                    );
+                  })}
+                </ul>
+              </section>
+            ) : (
+              <p className="mcp-manager__credentials-empty">
+                Este perfil no requiere credenciales adicionales para activarse.
+              </p>
+            )}
+          </>
+        ) : (
+          <p className="mcp-manager__details-empty">Selecciona un conector para ver los detalles.</p>
+        )}
+      </section>
+    </div>
+  );
+};
+
+export default McpManagerModal;

--- a/src/components/settings/PluginManagerModal.css
+++ b/src/components/settings/PluginManagerModal.css
@@ -1,0 +1,207 @@
+.plugin-manager {
+  display: flex;
+  gap: 1.5rem;
+  min-height: 360px;
+}
+
+.plugin-manager__list {
+  flex: 0 0 40%;
+  max-height: 420px;
+  overflow-y: auto;
+  padding-right: 0.5rem;
+  border-right: 1px solid rgba(255, 255, 255, 0.08);
+}
+
+.plugin-manager__list h3 {
+  margin: 0;
+  font-size: 1rem;
+}
+
+.plugin-manager__list-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  margin-bottom: 0.75rem;
+}
+
+.plugin-manager__refresh {
+  background: transparent;
+  border: 1px solid rgba(255, 255, 255, 0.25);
+  border-radius: 6px;
+  color: inherit;
+  cursor: pointer;
+  font-size: 0.85rem;
+  padding: 0.25rem 0.5rem;
+}
+
+.plugin-manager__refresh:hover,
+.plugin-manager__refresh:focus-visible {
+  border-color: rgba(255, 255, 255, 0.5);
+}
+
+.plugin-manager__item {
+  background: transparent;
+  border-radius: 8px;
+  padding: 0.75rem;
+  cursor: pointer;
+  outline: none;
+  transition: background 0.2s ease;
+}
+
+.plugin-manager__item:focus-visible {
+  box-shadow: 0 0 0 2px rgba(255, 255, 255, 0.35);
+}
+
+.plugin-manager__item:hover {
+  background: rgba(255, 255, 255, 0.05);
+}
+
+.plugin-manager__item--active {
+  background: rgba(255, 255, 255, 0.08);
+}
+
+.plugin-manager__item-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 0.5rem;
+}
+
+.plugin-manager__item-header strong {
+  display: block;
+  font-size: 0.95rem;
+}
+
+.plugin-manager__item-version {
+  display: block;
+  font-size: 0.75rem;
+  color: rgba(255, 255, 255, 0.6);
+}
+
+.plugin-manager__item-description {
+  margin: 0.5rem 0 0;
+  font-size: 0.85rem;
+  color: rgba(255, 255, 255, 0.7);
+}
+
+.plugin-manager__toggle {
+  background: rgba(255, 255, 255, 0.08);
+  border: none;
+  border-radius: 999px;
+  padding: 0.3rem 0.75rem;
+  color: inherit;
+  cursor: pointer;
+  font-size: 0.75rem;
+  transition: background 0.2s ease, color 0.2s ease;
+}
+
+.plugin-manager__toggle--on {
+  background: rgba(76, 217, 100, 0.25);
+  color: #9ff4b9;
+}
+
+.plugin-manager__details {
+  flex: 1 1 auto;
+  overflow-y: auto;
+  padding-right: 0.25rem;
+}
+
+.plugin-manager__details header {
+  display: flex;
+  align-items: baseline;
+  gap: 0.5rem;
+}
+
+.plugin-manager__details h3 {
+  margin: 0;
+}
+
+.plugin-manager__details-version {
+  font-size: 0.85rem;
+  color: rgba(255, 255, 255, 0.6);
+}
+
+.plugin-manager__details-description {
+  margin-top: 0.5rem;
+  color: rgba(255, 255, 255, 0.75);
+}
+
+.plugin-manager__details-block {
+  margin-top: 1.25rem;
+}
+
+.plugin-manager__details-block h4 {
+  margin: 0 0 0.5rem;
+  font-size: 0.9rem;
+}
+
+.plugin-manager__details-block ul {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+}
+
+.plugin-manager__credentials {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+}
+
+.plugin-manager__credential {
+  display: flex;
+  align-items: flex-end;
+  gap: 0.5rem;
+}
+
+.plugin-manager__credential label {
+  flex: 1 1 auto;
+  display: flex;
+  flex-direction: column;
+  gap: 0.35rem;
+}
+
+.plugin-manager__credential input {
+  background: rgba(255, 255, 255, 0.08);
+  border: 1px solid rgba(255, 255, 255, 0.15);
+  border-radius: 6px;
+  padding: 0.4rem 0.5rem;
+  color: inherit;
+}
+
+.plugin-manager__credential-remove {
+  background: transparent;
+  border: none;
+  color: rgba(255, 255, 255, 0.6);
+  cursor: pointer;
+  font-size: 1rem;
+  padding: 0.2rem;
+}
+
+.plugin-manager__credential-remove:hover,
+.plugin-manager__credential-remove:focus-visible {
+  color: rgba(255, 255, 255, 0.9);
+}
+
+.plugin-manager__add-credential {
+  margin-top: 0.75rem;
+  background: rgba(255, 255, 255, 0.08);
+  border: 1px solid rgba(255, 255, 255, 0.15);
+  border-radius: 6px;
+  color: inherit;
+  cursor: pointer;
+  padding: 0.45rem 0.75rem;
+  font-size: 0.85rem;
+}
+
+.plugin-manager__credentials-empty {
+  color: rgba(255, 255, 255, 0.7);
+}
+
+.plugin-manager__details-empty,
+.plugin-manager__empty {
+  color: rgba(255, 255, 255, 0.75);
+  text-align: center;
+}

--- a/src/components/settings/PluginManagerModal.tsx
+++ b/src/components/settings/PluginManagerModal.tsx
@@ -1,0 +1,296 @@
+import React, { useEffect, useMemo, useState } from 'react';
+import { GlobalSettings, PluginSettingsEntry } from '../../types/globalSettings';
+import { usePluginHost } from '../../core/plugins/PluginHostProvider';
+import './PluginManagerModal.css';
+
+interface PluginManagerModalProps {
+  settings: GlobalSettings;
+  onSettingsChange: (updater: (prev: GlobalSettings) => GlobalSettings) => void;
+}
+
+const ensurePluginSettingsEntry = (
+  settings: GlobalSettings,
+  pluginId: string,
+): PluginSettingsEntry => {
+  const existing = settings.pluginSettings[pluginId];
+  if (existing) {
+    return existing;
+  }
+  return { enabled: false, credentials: {} };
+};
+
+export const PluginManagerModal: React.FC<PluginManagerModalProps> = ({
+  settings,
+  onSettingsChange,
+}) => {
+  const { plugins, refresh } = usePluginHost();
+  const [selectedPluginId, setSelectedPluginId] = useState<string | null>(null);
+
+  const sortedPlugins = useMemo(
+    () =>
+      [...plugins].sort((a, b) => a.manifest.name.localeCompare(b.manifest.name, 'es')), // stable alphabetical
+    [plugins],
+  );
+
+  useEffect(() => {
+    if (!sortedPlugins.length) {
+      setSelectedPluginId(null);
+      return;
+    }
+    if (!selectedPluginId || !sortedPlugins.some(entry => entry.pluginId === selectedPluginId)) {
+      setSelectedPluginId(sortedPlugins[0]?.pluginId ?? null);
+    }
+  }, [sortedPlugins, selectedPluginId]);
+
+  const handleToggle = (pluginId: string, enabled: boolean) => {
+    onSettingsChange(prev => {
+      const entry = ensurePluginSettingsEntry(prev, pluginId);
+      const enabledSet = new Set(prev.enabledPlugins);
+      if (enabled) {
+        enabledSet.add(pluginId);
+      } else {
+        enabledSet.delete(pluginId);
+      }
+
+      return {
+        ...prev,
+        enabledPlugins: Array.from(enabledSet),
+        pluginSettings: {
+          ...prev.pluginSettings,
+          [pluginId]: {
+            ...entry,
+            enabled,
+          },
+        },
+      };
+    });
+    refresh();
+  };
+
+  const handleCredentialChange = (pluginId: string, key: string, value: string) => {
+    onSettingsChange(prev => {
+      const entry = ensurePluginSettingsEntry(prev, pluginId);
+      return {
+        ...prev,
+        pluginSettings: {
+          ...prev.pluginSettings,
+          [pluginId]: {
+            ...entry,
+            credentials: {
+              ...entry.credentials,
+              [key]: value,
+            },
+          },
+        },
+      };
+    });
+  };
+
+  const handleRemoveCredential = (pluginId: string, key: string) => {
+    onSettingsChange(prev => {
+      const entry = ensurePluginSettingsEntry(prev, pluginId);
+      const credentials = { ...entry.credentials };
+      delete credentials[key];
+      return {
+        ...prev,
+        pluginSettings: {
+          ...prev.pluginSettings,
+          [pluginId]: {
+            ...entry,
+            credentials,
+          },
+        },
+      };
+    });
+  };
+
+  const handleAddCredential = (pluginId: string) => {
+    const key = window.prompt('Introduce un identificador para la credencial del plugin');
+    if (!key) {
+      return;
+    }
+    const trimmed = key.trim();
+    if (!trimmed) {
+      return;
+    }
+    onSettingsChange(prev => {
+      const entry = ensurePluginSettingsEntry(prev, pluginId);
+      if (entry.credentials[trimmed] !== undefined) {
+        return prev;
+      }
+      return {
+        ...prev,
+        pluginSettings: {
+          ...prev.pluginSettings,
+          [pluginId]: {
+            ...entry,
+            credentials: {
+              ...entry.credentials,
+              [trimmed]: '',
+            },
+          },
+        },
+      };
+    });
+  };
+
+  if (!sortedPlugins.length) {
+    return (
+      <div className="plugin-manager__empty">
+        <p>No se han detectado plugins instalados.</p>
+        <button type="button" onClick={() => void refresh()}>
+          Volver a buscar
+        </button>
+      </div>
+    );
+  }
+
+  const selectedPlugin = sortedPlugins.find(entry => entry.pluginId === selectedPluginId) ?? null;
+  const selectedSettings = selectedPlugin
+    ? ensurePluginSettingsEntry(settings, selectedPlugin.pluginId)
+    : null;
+
+  return (
+    <div className="plugin-manager">
+      <aside className="plugin-manager__list" aria-label="Listado de plugins">
+        <div className="plugin-manager__list-header">
+          <h3>Plugins detectados</h3>
+          <button type="button" onClick={() => void refresh()} className="plugin-manager__refresh">
+            ↻ Actualizar
+          </button>
+        </div>
+        <ul>
+          {sortedPlugins.map(entry => {
+            const enabled = settings.enabledPlugins.includes(entry.pluginId);
+            const isActive = entry.pluginId === selectedPluginId;
+            return (
+              <li key={entry.pluginId}>
+                <div
+                  role="button"
+                  tabIndex={0}
+                  className={`plugin-manager__item${isActive ? ' plugin-manager__item--active' : ''}`}
+                  onClick={() => setSelectedPluginId(entry.pluginId)}
+                  onKeyDown={event => {
+                    if (event.key === 'Enter' || event.key === ' ') {
+                      event.preventDefault();
+                      setSelectedPluginId(entry.pluginId);
+                    }
+                  }}
+                >
+                  <div className="plugin-manager__item-header">
+                    <div>
+                      <strong>{entry.manifest.name}</strong>
+                      <span className="plugin-manager__item-version">v{entry.manifest.version}</span>
+                    </div>
+                    <button
+                      type="button"
+                      data-testid={`plugin-toggle-${entry.pluginId}`}
+                      className={`plugin-manager__toggle${enabled ? ' plugin-manager__toggle--on' : ''}`}
+                      onClick={event => {
+                        event.stopPropagation();
+                        handleToggle(entry.pluginId, !enabled);
+                      }}
+                      aria-pressed={enabled}
+                      aria-label={`${enabled ? 'Desactivar' : 'Activar'} plugin ${entry.manifest.name}`}
+                    >
+                      {enabled ? 'Activo' : 'Inactivo'}
+                    </button>
+                  </div>
+                  {entry.manifest.description && (
+                    <p className="plugin-manager__item-description">{entry.manifest.description}</p>
+                  )}
+                </div>
+              </li>
+            );
+          })}
+        </ul>
+      </aside>
+
+      <section className="plugin-manager__details" aria-live="polite">
+        {selectedPlugin && selectedSettings ? (
+          <>
+            <header>
+              <h3>{selectedPlugin.manifest.name}</h3>
+              <span className="plugin-manager__details-version">v{selectedPlugin.manifest.version}</span>
+            </header>
+            {selectedPlugin.manifest.description && (
+              <p className="plugin-manager__details-description">{selectedPlugin.manifest.description}</p>
+            )}
+
+            {selectedPlugin.manifest.capabilities?.length ? (
+              <section className="plugin-manager__details-block">
+                <h4>Capacidades</h4>
+                <ul>
+                  {selectedPlugin.manifest.capabilities.map(capability => (
+                    <li key={capability.id}>
+                      <strong>{capability.type}</strong>
+                      {capability.label && <span> · {capability.label}</span>}
+                    </li>
+                  ))}
+                </ul>
+              </section>
+            ) : null}
+
+            {selectedPlugin.manifest.commands?.length ? (
+              <section className="plugin-manager__details-block">
+                <h4>Comandos</h4>
+                <ul>
+                  {selectedPlugin.manifest.commands.map(command => (
+                    <li key={command.name}>
+                      <strong>{command.name}</strong>
+                      {command.description && <span> — {command.description}</span>}
+                    </li>
+                  ))}
+                </ul>
+              </section>
+            ) : null}
+
+            <section className="plugin-manager__details-block">
+              <h4>Credenciales</h4>
+              {Object.keys(selectedSettings.credentials).length ? (
+                <ul className="plugin-manager__credentials">
+                  {Object.entries(selectedSettings.credentials).map(([key, value]) => (
+                    <li key={key} className="plugin-manager__credential">
+                      <label>
+                        <span>{key}</span>
+                        <input
+                          type="text"
+                          value={value}
+                          onChange={event => handleCredentialChange(selectedPlugin.pluginId, key, event.target.value)}
+                          placeholder="Introduce el valor"
+                        />
+                      </label>
+                      <button
+                        type="button"
+                        className="plugin-manager__credential-remove"
+                        onClick={() => handleRemoveCredential(selectedPlugin.pluginId, key)}
+                        aria-label={`Eliminar la credencial ${key}`}
+                      >
+                        ✕
+                      </button>
+                    </li>
+                  ))}
+                </ul>
+              ) : (
+                <p className="plugin-manager__credentials-empty">
+                  No hay credenciales configuradas todavía para este plugin.
+                </p>
+              )}
+              <button
+                type="button"
+                className="plugin-manager__add-credential"
+                onClick={() => handleAddCredential(selectedPlugin.pluginId)}
+              >
+                Añadir credencial
+              </button>
+            </section>
+          </>
+        ) : (
+          <p className="plugin-manager__details-empty">Selecciona un plugin para revisar sus opciones.</p>
+        )}
+      </section>
+    </div>
+  );
+};
+
+export default PluginManagerModal;

--- a/src/components/settings/__tests__/McpManagerModal.test.tsx
+++ b/src/components/settings/__tests__/McpManagerModal.test.tsx
@@ -1,0 +1,47 @@
+import React, { useState } from 'react';
+import { render, screen, fireEvent } from '@testing-library/react';
+import { describe, expect, it } from 'vitest';
+import { McpManagerModal } from '../McpManagerModal';
+import { DEFAULT_GLOBAL_SETTINGS } from '../../../utils/globalSettings';
+import type { GlobalSettings } from '../../../types/globalSettings';
+
+type SettingsUpdater = (updater: (prev: GlobalSettings) => GlobalSettings) => void;
+
+const createSettings = (): GlobalSettings => ({
+  ...DEFAULT_GLOBAL_SETTINGS,
+  pluginSettings: {},
+  enabledPlugins: [],
+  mcpProfiles: [],
+  mcpCredentials: {},
+});
+
+const renderWithState = () => {
+  const Wrapper: React.FC = () => {
+    const [settings, setSettings] = useState<GlobalSettings>(createSettings());
+    const handleUpdate: SettingsUpdater = updater => setSettings(prev => updater(prev));
+    const activeProfiles = settings.mcpProfiles.map(profile => profile.id).join(',');
+    const credentialKeys = Object.keys(settings.mcpCredentials.gmail ?? {}).join(',');
+
+    return (
+      <div>
+        <McpManagerModal settings={settings} onSettingsChange={handleUpdate} />
+        <output data-testid="active-profiles">{activeProfiles}</output>
+        <output data-testid="gmail-credentials">{credentialKeys}</output>
+      </div>
+    );
+  };
+
+  return render(<Wrapper />);
+};
+
+describe('McpManagerModal', () => {
+  it('activa perfiles predefinidos y prepara credenciales', () => {
+    renderWithState();
+
+    const toggle = screen.getByTestId('mcp-toggle-gmail');
+    fireEvent.click(toggle);
+
+    expect(screen.getByTestId('active-profiles').textContent).toContain('gmail');
+    expect(screen.getByTestId('gmail-credentials').textContent).toContain('oauthToken');
+  });
+});

--- a/src/components/settings/__tests__/PluginManagerModal.test.tsx
+++ b/src/components/settings/__tests__/PluginManagerModal.test.tsx
@@ -1,0 +1,76 @@
+import React, { useState } from 'react';
+import { render, screen, fireEvent } from '@testing-library/react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { PluginManagerModal } from '../PluginManagerModal';
+import { DEFAULT_GLOBAL_SETTINGS } from '../../../utils/globalSettings';
+import type { GlobalSettings } from '../../../types/globalSettings';
+
+const refreshMock = vi.fn();
+
+const mockPlugins = [
+  {
+    pluginId: 'ableton-mixer',
+    manifest: {
+      id: 'ableton-mixer',
+      name: 'Ableton Mixer',
+      version: '0.1.0',
+      description: 'Panel de mezcla para Ableton.',
+      capabilities: [],
+      commands: [],
+    },
+    checksum: 'checksum',
+    commands: [],
+  },
+];
+
+vi.mock('../../../core/plugins/PluginHostProvider', () => ({
+  usePluginHost: () => ({
+    plugins: mockPlugins,
+    refresh: refreshMock,
+    messageActions: [],
+    sidePanels: [],
+    updatePluginSettings: vi.fn(),
+  }),
+}));
+
+const createSettings = (): GlobalSettings => ({
+  ...DEFAULT_GLOBAL_SETTINGS,
+  pluginSettings: {},
+  enabledPlugins: [],
+  mcpProfiles: [],
+  mcpCredentials: {},
+});
+
+const renderWithState = () => {
+  const Wrapper: React.FC = () => {
+    const [settings, setSettings] = useState<GlobalSettings>(createSettings());
+    return (
+      <div>
+        <PluginManagerModal settings={settings} onSettingsChange={updater => setSettings(prev => updater(prev))} />
+        <output data-testid="enabled-plugins">{settings.enabledPlugins.join(',')}</output>
+      </div>
+    );
+  };
+
+  return render(<Wrapper />);
+};
+
+beforeEach(() => {
+  refreshMock.mockClear();
+});
+
+describe('PluginManagerModal', () => {
+  it('activates and desactiva plugins desde el panel', () => {
+    renderWithState();
+
+    const toggle = screen.getByTestId('plugin-toggle-ableton-mixer');
+    fireEvent.click(toggle);
+
+    expect(screen.getByTestId('enabled-plugins').textContent).toContain('ableton-mixer');
+    expect(refreshMock).toHaveBeenCalled();
+
+    fireEvent.click(toggle);
+
+    expect(screen.getByTestId('enabled-plugins').textContent).toBe('');
+  });
+});

--- a/src/core/mcp/predefinedProfiles.ts
+++ b/src/core/mcp/predefinedProfiles.ts
@@ -1,0 +1,127 @@
+import { McpCredentialEntry, McpCredentialType, McpProfile, McpProfileEndpoint } from '../../types/globalSettings';
+
+export interface PredefinedMcpCredentialRequirement {
+  id: string;
+  type: McpCredentialType;
+  label: string;
+  helperText?: string;
+  placeholder?: string;
+}
+
+export interface PredefinedMcpProfile {
+  id: string;
+  label: string;
+  description?: string;
+  autoConnect: boolean;
+  endpoints: McpProfileEndpoint[];
+  scopes: string[];
+  credentialRequirements?: PredefinedMcpCredentialRequirement[];
+}
+
+export const PREDEFINED_MCP_PROFILES: PredefinedMcpProfile[] = [
+  {
+    id: 'jellyfin-media',
+    label: 'Jellyfin',
+    description: 'Sincroniza bibliotecas y estado de reproducción desde un servidor Jellyfin.',
+    autoConnect: true,
+    endpoints: [
+      { id: 'jellyfin-rest', transport: 'rest', url: 'https://jellyfin.example.com' },
+      { id: 'jellyfin-events', transport: 'ws', url: 'wss://jellyfin.example.com/socket' },
+    ],
+    scopes: ['jellyfin:libraries:read', 'jellyfin:playback:control'],
+    credentialRequirements: [
+      {
+        id: 'apiKey',
+        type: 'api-key',
+        label: 'API key del servidor',
+        helperText: 'Genera una API key desde el panel de administración de Jellyfin y pégala aquí.',
+        placeholder: 'ej. c0ffee-babe-1234',
+      },
+    ],
+  },
+  {
+    id: 'gmail',
+    label: 'Gmail',
+    description: 'Accede a mensajes, etiquetas y acciones básicas en Gmail.',
+    autoConnect: false,
+    endpoints: [
+      { id: 'gmail-rest', transport: 'rest', url: 'https://gmail.googleapis.com/gmail/v1' },
+      { id: 'gmail-realtime', transport: 'ws', url: 'wss://gmail.googleapis.com/gmail/v1/stream' },
+    ],
+    scopes: [
+      'https://www.googleapis.com/auth/gmail.readonly',
+      'https://www.googleapis.com/auth/gmail.modify',
+    ],
+    credentialRequirements: [
+      {
+        id: 'oauthToken',
+        type: 'oauth',
+        label: 'ID del token OAuth',
+        helperText:
+          'Referencia al token almacenado a través de SecretManager (por ejemplo "gmail-oauth").',
+        placeholder: 'gmail-oauth',
+      },
+    ],
+  },
+  {
+    id: 'google-calendar',
+    label: 'Google Calendar',
+    description: 'Sincroniza calendarios personales y empresariales, incluyendo recordatorios.',
+    autoConnect: false,
+    endpoints: [
+      { id: 'calendar-rest', transport: 'rest', url: 'https://www.googleapis.com/calendar/v3' },
+      {
+        id: 'calendar-updates',
+        transport: 'ws',
+        url: 'wss://streaming.googleapis.com/calendar/v3/events',
+      },
+    ],
+    scopes: [
+      'https://www.googleapis.com/auth/calendar.events.readonly',
+      'https://www.googleapis.com/auth/calendar.events',
+    ],
+    credentialRequirements: [
+      {
+        id: 'oauthToken',
+        type: 'oauth',
+        label: 'ID del token OAuth',
+        helperText:
+          'Introduce el identificador del token gestionado por SecretManager para Calendar.',
+        placeholder: 'calendar-oauth',
+      },
+    ],
+  },
+];
+
+export const getPredefinedMcpProfile = (id: string): PredefinedMcpProfile | undefined =>
+  PREDEFINED_MCP_PROFILES.find(profile => profile.id === id);
+
+export const buildMcpProfileFromCatalog = (entry: PredefinedMcpProfile): McpProfile => ({
+  id: entry.id,
+  label: entry.label,
+  description: entry.description,
+  autoConnect: entry.autoConnect,
+  endpoints: entry.endpoints,
+  scopes: entry.scopes,
+});
+
+export const buildDefaultCredentialState = (
+  entry: PredefinedMcpProfile,
+): Record<string, McpCredentialEntry> => {
+  if (!entry.credentialRequirements?.length) {
+    return {};
+  }
+
+  return entry.credentialRequirements.reduce<Record<string, McpCredentialEntry>>(
+    (acc, requirement) => {
+      acc[requirement.id] = {
+        id: requirement.id,
+        type: requirement.type,
+        value: undefined,
+        secretId: undefined,
+      };
+      return acc;
+    },
+    {},
+  );
+};

--- a/src/core/plugins/PluginHostProvider.tsx
+++ b/src/core/plugins/PluginHostProvider.tsx
@@ -1,4 +1,12 @@
-import React, { createContext, useCallback, useContext, useEffect, useMemo, useState } from 'react';
+import React, {
+  createContext,
+  useCallback,
+  useContext,
+  useEffect,
+  useMemo,
+  useRef,
+  useState,
+} from 'react';
 import type { GlobalSettings, PluginSettingsEntry } from '../../types/globalSettings';
 import type {
   LoadedPluginManifest,
@@ -200,6 +208,7 @@ export const PluginHostProvider: React.FC<PluginHostProviderProps> = ({
   const [messageActions, setMessageActions] = useState<PluginMessageActionContext[]>([]);
   const [sidePanels, setSidePanels] = useState<PluginSidePanelContribution[]>([]);
   const [revision, setRevision] = useState(0);
+  const enabledSnapshotRef = useRef<string>('');
 
   const refresh = useCallback(() => {
     setRevision(prev => prev + 1);
@@ -247,6 +256,14 @@ export const PluginHostProvider: React.FC<PluginHostProviderProps> = ({
       cancelled = true;
     };
   }, [appVersion, transport, revision]);
+
+  useEffect(() => {
+    const snapshot = settings.enabledPlugins.slice().sort().join('|');
+    if (enabledSnapshotRef.current && enabledSnapshotRef.current !== snapshot) {
+      setRevision(prev => prev + 1);
+    }
+    enabledSnapshotRef.current = snapshot;
+  }, [settings.enabledPlugins]);
 
   useEffect(() => {
     onSettingsChange(prev => {

--- a/src/plugins/ableton-mixer/Panel.css
+++ b/src/plugins/ableton-mixer/Panel.css
@@ -1,0 +1,57 @@
+.ableton-mixer-panel {
+  padding: 1rem;
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+}
+
+.ableton-mixer-panel header h3 {
+  margin: 0;
+  font-size: 1rem;
+}
+
+.ableton-mixer-panel header p {
+  margin: 0.25rem 0 0;
+  font-size: 0.85rem;
+  color: rgba(255, 255, 255, 0.7);
+}
+
+.ableton-mixer-panel__channels {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));
+  gap: 1rem;
+}
+
+.ableton-mixer-panel__channel {
+  background: rgba(255, 255, 255, 0.05);
+  border-radius: 8px;
+  padding: 0.75rem;
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+}
+
+.ableton-mixer-panel__label {
+  font-weight: 600;
+}
+
+.ableton-mixer-panel__value {
+  font-size: 0.85rem;
+  color: rgba(255, 255, 255, 0.7);
+}
+
+.ableton-mixer-panel__mute {
+  margin-top: 0.25rem;
+  background: rgba(255, 255, 255, 0.08);
+  border: none;
+  border-radius: 999px;
+  padding: 0.35rem 0.75rem;
+  font-size: 0.8rem;
+  color: inherit;
+  cursor: pointer;
+}
+
+.ableton-mixer-panel__mute--on {
+  background: rgba(255, 99, 132, 0.25);
+  color: #ffcdd2;
+}

--- a/src/plugins/ableton-mixer/Panel.tsx
+++ b/src/plugins/ableton-mixer/Panel.tsx
@@ -1,0 +1,77 @@
+import React, { useMemo, useState } from 'react';
+import './Panel.css';
+
+interface MixerChannel {
+  id: string;
+  label: string;
+}
+
+const DEFAULT_CHANNELS: MixerChannel[] = [
+  { id: 'channel-1', label: 'Kick' },
+  { id: 'channel-2', label: 'Snare' },
+  { id: 'channel-3', label: 'Bass' },
+  { id: 'channel-4', label: 'Pads' },
+  { id: 'channel-5', label: 'Lead' },
+  { id: 'channel-6', label: 'FX' },
+];
+
+export const Panel: React.FC = () => {
+  const [volumes, setVolumes] = useState<Record<string, number>>(() =>
+    DEFAULT_CHANNELS.reduce((acc, channel, index) => {
+      acc[channel.id] = 0.5 + index * 0.05;
+      return acc;
+    }, {} as Record<string, number>),
+  );
+  const [muteState, setMuteState] = useState<Record<string, boolean>>({});
+
+  const activeChannels = useMemo(() => DEFAULT_CHANNELS, []);
+
+  return (
+    <div className="ableton-mixer-panel">
+      <header>
+        <h3>Ableton Mixer</h3>
+        <p>Ajusta rápidamente los niveles de tus pistas favoritas.</p>
+      </header>
+      <div className="ableton-mixer-panel__channels">
+        {activeChannels.map(channel => {
+          const volume = volumes[channel.id] ?? 0.5;
+          const muted = Boolean(muteState[channel.id]);
+          return (
+            <div key={channel.id} className="ableton-mixer-panel__channel">
+              <span className="ableton-mixer-panel__label">{channel.label}</span>
+              <input
+                type="range"
+                min="0"
+                max="1"
+                step="0.01"
+                value={volume}
+                onChange={event =>
+                  setVolumes(prev => ({
+                    ...prev,
+                    [channel.id]: Number(event.target.value),
+                  }))
+                }
+              />
+              <span className="ableton-mixer-panel__value">{Math.round(volume * 100)}%</span>
+              <button
+                type="button"
+                className={`ableton-mixer-panel__mute${muted ? ' ableton-mixer-panel__mute--on' : ''}`}
+                onClick={() =>
+                  setMuteState(prev => ({
+                    ...prev,
+                    [channel.id]: !muted,
+                  }))
+                }
+                aria-pressed={muted}
+              >
+                {muted ? 'Mute' : 'Sonando'}
+              </button>
+            </div>
+          );
+        })}
+      </div>
+    </div>
+  );
+};
+
+export default Panel;

--- a/src/types/globalSettings.ts
+++ b/src/types/globalSettings.ts
@@ -23,7 +23,19 @@ export interface McpProfile {
   autoConnect: boolean;
   token?: string;
   endpoints: McpProfileEndpoint[];
+  scopes?: string[];
 }
+
+export type McpCredentialType = 'api-key' | 'oauth';
+
+export interface McpCredentialEntry {
+  id: string;
+  type: McpCredentialType;
+  value?: string;
+  secretId?: string;
+}
+
+export type McpCredentialMap = Record<string, Record<string, McpCredentialEntry>>;
 
 export interface CommandPresetSettings {
   temperature?: number;
@@ -106,6 +118,7 @@ export interface GlobalSettings {
   approvedManifests: AgentManifestCache;
   pluginSettings: PluginSettingsMap;
   mcpProfiles: McpProfile[];
+  mcpCredentials: McpCredentialMap;
   workspacePreferences: WorkspacePreferences;
   dataLocation: DataLocationSettings;
   modelPreferences: ModelPreferences;


### PR DESCRIPTION
## Summary
- add PluginManagerModal and McpManagerModal for managing plugin toggles, credentials, and predefined MCP connectors
- extend global settings with MCP credential storage, auto-refresh plugin host when activation changes, and add the Ableton mixer plugin with a React side panel
- cover the new flows with regression tests for the plugin and MCP manager modals

## Testing
- npm test -- --run

------
https://chatgpt.com/codex/tasks/task_e_68cf2d0cdee48333a7cdd1034c0efe80