### PR TITLE
fix: allow bundling tauri apis in production

### DIFF
--- a/vite.config.ts
+++ b/vite.config.ts
@@ -18,19 +18,7 @@ export default defineConfig({
           react: ['react', 'react-dom'],
           three: ['three']
         }
-      },
-      // Externalizar las APIs de Tauri para evitar errores de build en Electron
-      external: [
-        '@tauri-apps/api/event',
-        '@tauri-apps/api/window',
-        '@tauri-apps/api/fs',
-        '@tauri-apps/api/path',
-        '@tauri-apps/api/dialog',
-        '@tauri-apps/api/shell',
-        '@tauri-apps/api/app',
-        '@tauri-apps/api/os',
-        '@tauri-apps/api'
-      ]
+      }
     }
   },
   assetsInclude: ['**/*.wgsl'],
@@ -41,19 +29,5 @@ export default defineConfig({
     modules: {
       localsConvention: 'camelCase'
     }
-  },
-  // Configurar el manejo de dependencias opcionales
-  optimizeDeps: {
-    exclude: [
-      '@tauri-apps/api',
-      '@tauri-apps/api/event',
-      '@tauri-apps/api/window',
-      '@tauri-apps/api/fs',
-      '@tauri-apps/api/path',
-      '@tauri-apps/api/dialog',
-      '@tauri-apps/api/shell',
-      '@tauri-apps/api/app',
-      '@tauri-apps/api/os'
-    ]
   }
 });


### PR DESCRIPTION
## Summary
- allow Vite to bundle @tauri-apps/api modules instead of marking them as externals
- remove the unnecessary optimizeDeps exclusion list so browser builds resolve the Tauri imports

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68cf3279d9288333aef726eb227871ed