### PR TITLE
Add model manager shortcut for visual layouts

### DIFF
--- a/src/components/ResourceExplorer.tsx
+++ b/src/components/ResourceExplorer.tsx
@@ -287,7 +287,7 @@ const ResourceExplorer: React.FC<ResourceExplorerProps> = ({
           )}
         </div>
         <div className="resource-explorer__hint">
-          Arrastra cualquier recurso al grid para asignarlo a un slot.
+          Arrastra cualquier recurso al grid para asignarlo a un slot. También puedes abrir el gestor de modelos con el botón 🤗 de la barra superior.
         </div>
       </div>
     </aside>

--- a/src/components/TopBar.tsx
+++ b/src/components/TopBar.tsx
@@ -2,7 +2,7 @@ import React, { useEffect, useState } from 'react';
 import { LAUNCHPAD_PRESETS } from '../utils/launchpad';
 import './TopBar.css';
 
-interface TopBarProps {
+export interface TopBarProps {
   midiActive: boolean;
   midiDeviceName: string | null;
   midiDeviceCount: number;
@@ -18,6 +18,7 @@ interface TopBarProps {
   onClearAll: () => void;
   onOpenSettings: () => void;
   onOpenResources: () => void;
+  onOpenModelGallery?: () => void;
   launchpadAvailable: boolean;
   launchpadOutput: any | null;
   launchpadRunning: boolean;
@@ -44,6 +45,7 @@ export const TopBar: React.FC<TopBarProps> = ({
   onClearAll,
   onOpenSettings,
   onOpenResources,
+  onOpenModelGallery,
   launchpadAvailable,
   launchpadOutput,
   launchpadRunning,
@@ -108,6 +110,17 @@ export const TopBar: React.FC<TopBarProps> = ({
 
         {/* Center section - Actions and resources */}
         <div className="actions-section">
+          {onOpenModelGallery && (
+            <button
+              type="button"
+              onClick={onOpenModelGallery}
+              className="action-button"
+              title="Abrir gestor de modelos locales (🤗 Hugging Face)"
+              aria-label="Abrir gestor de modelos locales"
+            >
+              🤗
+            </button>
+          )}
           <button
             onClick={onOpenResources}
             className="action-button"

--- a/src/components/visualizer/VisualizerTopBar.tsx
+++ b/src/components/visualizer/VisualizerTopBar.tsx
@@ -1,0 +1,46 @@
+import React, { useCallback, useState } from 'react';
+import { TopBar, TopBarProps } from '../TopBar';
+import { ModelManagerModal } from '../models/ModelManagerModal';
+import { useLocalModels } from '../../hooks/useLocalModels';
+import type { HuggingFacePreferences } from '../../types/globalSettings';
+
+interface VisualizerTopBarProps extends TopBarProps {
+  storageDir: string | null;
+  huggingFacePreferences: HuggingFacePreferences;
+  onStorageDirChange: (nextPath: string | null) => void;
+}
+
+export const VisualizerTopBar: React.FC<VisualizerTopBarProps> = ({
+  storageDir,
+  huggingFacePreferences,
+  onStorageDirChange,
+  ...topBarProps
+}) => {
+  const [isModelManagerOpen, setModelManagerOpen] = useState(false);
+  const { refresh } = useLocalModels({ storageDir });
+
+  const handleOpenModelGallery = useCallback(() => {
+    void refresh();
+    setModelManagerOpen(true);
+  }, [refresh]);
+
+  const handleCloseModelGallery = useCallback(() => {
+    setModelManagerOpen(false);
+    void refresh();
+  }, [refresh]);
+
+  return (
+    <>
+      <TopBar {...topBarProps} onOpenModelGallery={handleOpenModelGallery} />
+      <ModelManagerModal
+        isOpen={isModelManagerOpen}
+        onClose={handleCloseModelGallery}
+        storageDir={storageDir}
+        huggingFacePreferences={huggingFacePreferences}
+        onStorageDirChange={onStorageDirChange}
+      />
+    </>
+  );
+};
+
+export default VisualizerTopBar;


### PR DESCRIPTION
## Summary
- expose a new `onOpenModelGallery` callback in `TopBar` and render a 🤗 launcher button
- add a `VisualizerTopBar` wrapper that manages the Model Manager modal and refreshes local models
- update the resource explorer hint to mention the new top bar shortcut for the model gallery

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68cfb58a68248333b9b709e0f1b8af96