### PR TITLE
Refactor side panel to show provider presence

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -90,7 +90,10 @@ const AppContent: React.FC<AppContentProps> = ({
         <div className={`app-body sidebar-${sidePanelPosition}`}>
           {sidePanelPosition === 'left' && (
             <aside className="app-sidebar">
-              <SidePanel onOpenGlobalSettings={() => setSettingsOpen(true)} />
+              <SidePanel
+                onOpenGlobalSettings={() => setSettingsOpen(true)}
+                onOpenModelManager={() => setModelManagerOpen(true)}
+              />
             </aside>
           )}
 
@@ -100,7 +103,10 @@ const AppContent: React.FC<AppContentProps> = ({
 
           {sidePanelPosition === 'right' && (
             <aside className="app-sidebar">
-              <SidePanel onOpenGlobalSettings={() => setSettingsOpen(true)} />
+              <SidePanel
+                onOpenGlobalSettings={() => setSettingsOpen(true)}
+                onOpenModelManager={() => setModelManagerOpen(true)}
+              />
             </aside>
           )}
         </div>

--- a/src/components/chat/SidePanel.css
+++ b/src/components/chat/SidePanel.css
@@ -43,140 +43,150 @@
   color: rgba(255, 255, 255, 0.65);
 }
 
-.model-panel {
-  display: flex;
-  flex-direction: column;
+.provider-status-list {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: grid;
+  grid-template-columns: 1fr;
   gap: 12px;
 }
 
-.model-panel__summary {
+@media (min-width: 860px) {
+  .provider-status-list {
+    grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+  }
+}
+
+.provider-card {
   display: flex;
   flex-direction: column;
-  gap: 6px;
-  padding: 12px;
-  border-radius: 10px;
-  background: linear-gradient(135deg, rgba(142, 141, 255, 0.22), rgba(77, 208, 225, 0.18));
-  border: 1px solid rgba(142, 141, 255, 0.35);
+  gap: 10px;
+  padding: 14px;
+  border-radius: 12px;
+  background: rgba(255, 255, 255, 0.04);
+  border: 1px solid rgba(255, 255, 255, 0.07);
+  box-shadow: 0 8px 22px rgba(0, 0, 0, 0.35);
 }
 
-.model-panel__summary-label {
-  font-size: 12px;
-  text-transform: uppercase;
-  letter-spacing: 0.6px;
-  color: rgba(255, 255, 255, 0.7);
-}
-
-.model-panel__summary-sub {
-  font-size: 13px;
-  color: rgba(255, 255, 255, 0.75);
-}
-
-.model-panel__counts {
+.provider-card__header {
   display: flex;
-  gap: 8px;
+  align-items: center;
+  justify-content: space-between;
+  gap: 16px;
 }
 
-.model-panel__counts > div {
-  flex: 1;
-  padding: 10px 12px;
-  border-radius: 10px;
-  background: rgba(255, 255, 255, 0.05);
-  border: 1px solid rgba(255, 255, 255, 0.08);
+.provider-card__identity {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+}
+
+.provider-card__identity-text {
   display: flex;
   flex-direction: column;
   gap: 4px;
 }
 
-.model-panel__count-label {
+.provider-card__name {
+  font-size: 15px;
+  font-weight: 600;
+  letter-spacing: 0.3px;
+}
+
+.provider-card__model {
+  font-size: 12px;
+  color: rgba(255, 255, 255, 0.7);
+}
+
+.provider-led {
+  width: 14px;
+  height: 14px;
+  border-radius: 999px;
+  box-shadow: 0 0 0 0 rgba(0, 0, 0, 0.2);
+  transition: background 0.25s ease, box-shadow 0.25s ease;
+  background: rgba(255, 255, 255, 0.2);
+}
+
+.provider-led.is-online {
+  background: #66ff99;
+  box-shadow: 0 0 14px rgba(102, 255, 153, 0.6);
+}
+
+.provider-led.is-warning {
+  background: #ffd966;
+  box-shadow: 0 0 14px rgba(255, 217, 102, 0.45);
+}
+
+.provider-led.is-error {
+  background: #ff7373;
+  box-shadow: 0 0 14px rgba(255, 115, 115, 0.55);
+}
+
+.provider-card__state {
   font-size: 11px;
   text-transform: uppercase;
-  letter-spacing: 0.5px;
-  color: rgba(255, 255, 255, 0.55);
-}
-
-.model-panel__count-value {
-  font-size: 20px;
-  font-weight: 600;
-}
-
-.model-panel__list {
-  list-style: none;
-  margin: 0;
-  padding: 0;
-  display: flex;
-  flex-direction: column;
-  gap: 8px;
-}
-
-.model-panel__item {
-  display: flex;
-  justify-content: space-between;
-  align-items: center;
-  gap: 10px;
-  padding: 10px 12px;
-  border-radius: 8px;
+  letter-spacing: 0.55px;
+  padding: 4px 10px;
+  border-radius: 999px;
+  border: 1px solid rgba(255, 255, 255, 0.12);
   background: rgba(255, 255, 255, 0.04);
-  border: 1px solid rgba(255, 255, 255, 0.06);
+  color: rgba(255, 255, 255, 0.75);
 }
 
-.model-panel__item.is-active {
-  border-color: rgba(142, 141, 255, 0.6);
-  background: linear-gradient(135deg, rgba(142, 141, 255, 0.25), rgba(255, 183, 77, 0.18));
+.provider-card__state.is-online {
+  border-color: rgba(102, 255, 153, 0.45);
+  color: rgba(102, 255, 153, 0.9);
 }
 
-.model-panel__item-info {
-  display: flex;
-  flex-direction: column;
-  gap: 2px;
+.provider-card__state.is-warning {
+  border-color: rgba(255, 217, 102, 0.35);
+  color: rgba(255, 217, 102, 0.9);
 }
 
-.model-panel__name {
-  font-weight: 600;
-  font-size: 14px;
+.provider-card__state.is-error {
+  border-color: rgba(255, 115, 115, 0.45);
+  color: rgba(255, 115, 115, 0.95);
 }
 
-.model-panel__provider {
+.provider-card__description {
+  margin: 0;
   font-size: 12px;
-  color: rgba(255, 255, 255, 0.65);
+  line-height: 1.5;
+  color: rgba(255, 255, 255, 0.72);
 }
 
-.model-panel__status {
+.provider-card__actions {
+  display: flex;
+  justify-content: flex-start;
+}
+
+.provider-card__actions button {
+  border: none;
+  border-radius: 8px;
+  padding: 6px 12px;
   font-size: 12px;
   letter-spacing: 0.5px;
   text-transform: uppercase;
-  color: rgba(255, 255, 255, 0.7);
+  background: rgba(142, 141, 255, 0.18);
+  color: rgba(255, 255, 255, 0.85);
+  cursor: pointer;
+  transition: background 0.2s ease;
 }
 
-.model-panel__status.status-ready {
-  color: rgba(129, 212, 250, 0.95);
+.provider-card__actions button:hover,
+.provider-card__actions button:focus-visible {
+  background: rgba(142, 141, 255, 0.32);
 }
 
-.model-panel__status.status-downloading {
-  color: rgba(255, 183, 77, 0.9);
-}
-
-.model-panel__status.status-not_installed {
-  color: rgba(255, 255, 255, 0.45);
-}
-
-.model-panel__loading,
-.model-panel__error,
-.model-panel__empty {
-  font-size: 12px;
-  color: rgba(255, 255, 255, 0.7);
-}
-
-.model-panel__error {
-  color: #ff8a80;
-}
-
-.model-panel__actions {
+.sidebar-actions {
   display: flex;
   gap: 8px;
   justify-content: flex-end;
+  flex-wrap: wrap;
 }
 
-.model-panel__actions button {
+.sidebar-actions button {
   border: none;
   border-radius: 10px;
   padding: 8px 12px;
@@ -186,15 +196,16 @@
   background: rgba(255, 255, 255, 0.12);
   color: #fff;
   cursor: pointer;
+  transition: background 0.2s ease, opacity 0.2s ease;
 }
 
-.model-panel__actions button:disabled {
-  opacity: 0.5;
+.sidebar-actions button:disabled {
+  opacity: 0.55;
   cursor: default;
 }
 
-.model-panel__actions .primary {
-  background: linear-gradient(135deg, rgba(142, 141, 255, 0.65), rgba(255, 183, 77, 0.65));
+.sidebar-actions .primary {
+  background: linear-gradient(135deg, rgba(142, 141, 255, 0.7), rgba(255, 183, 77, 0.7));
   color: #0a0a0a;
   font-weight: 600;
 }

--- a/src/components/chat/SidePanel.tsx
+++ b/src/components/chat/SidePanel.tsx
@@ -1,95 +1,336 @@
 import React, { useMemo } from 'react';
 import './SidePanel.css';
-import { useLocalModels } from '../../hooks/useLocalModels';
+import type { AgentDefinition } from '../../core/agents/agentRegistry';
+import { useAgents } from '../../core/agents/AgentContext';
+import type { AgentPresenceEntry } from '../../core/agents/presence';
+import { useAgentPresence } from '../../core/agents/presence';
 
 interface SidePanelProps {
   onOpenGlobalSettings: () => void;
+  onOpenModelManager: () => void;
 }
 
-const formatStatus = (status: string, active: boolean, progress?: number) => {
-  if (status === 'ready') {
-    return active ? 'Activo' : 'Listo';
+type ProviderId = 'openai' | 'anthropic' | 'groq' | 'jarvis';
+
+type ProviderTone = 'online' | 'warning' | 'error';
+
+interface ProviderCardState {
+  id: ProviderId;
+  label: string;
+  modelLabel: string;
+  statusLabel: string;
+  tone: ProviderTone;
+  description?: string;
+  showManageModels?: boolean;
+}
+
+interface ProviderConfigEntry {
+  id: ProviderId;
+  label: string;
+  kind: 'cloud' | 'local';
+}
+
+const PROVIDERS: ProviderConfigEntry[] = [
+  { id: 'openai', label: 'OpenAI', kind: 'cloud' },
+  { id: 'anthropic', label: 'Anthropic', kind: 'cloud' },
+  { id: 'groq', label: 'Groq', kind: 'cloud' },
+  { id: 'jarvis', label: 'Jarvis', kind: 'local' },
+];
+
+const mapPresenceStatus = (presence?: AgentPresenceEntry): Pick<ProviderCardState, 'tone' | 'statusLabel' | 'description'> => {
+  if (!presence) {
+    return {
+      tone: 'warning',
+      statusLabel: 'Comprobando',
+      description: 'Verificando disponibilidad del proveedor.',
+    };
   }
-  if (status === 'downloading') {
-    const percent = Math.round((progress ?? 0) * 100);
-    return percent > 0 ? `${percent}%` : 'Descargando';
+
+  switch (presence.status) {
+    case 'online':
+      return {
+        tone: 'online',
+        statusLabel: 'Operativo',
+        description: presence.message ?? 'Proveedor operativo.',
+      };
+    case 'loading':
+      return {
+        tone: 'warning',
+        statusLabel: 'Inicializando',
+        description: presence.message ?? 'Inicializando proveedor.',
+      };
+    case 'offline':
+      return {
+        tone: 'warning',
+        statusLabel: 'Sin respuesta',
+        description: presence.message ?? 'El proveedor no responde en este momento.',
+      };
+    case 'error':
+      return {
+        tone: 'error',
+        statusLabel: 'Error',
+        description: presence.message ?? 'Revisa la configuración del proveedor.',
+      };
+    default:
+      return {
+        tone: 'warning',
+        statusLabel: 'Comprobando',
+        description: presence.message,
+      };
   }
-  return 'No instalado';
 };
 
-export const SidePanel: React.FC<SidePanelProps> = ({ onOpenGlobalSettings }) => {
-  const { models, isLoading, error, refresh } = useLocalModels();
+const buildCloudProviderState = (
+  config: ProviderConfigEntry,
+  agents: AgentDefinition[],
+  presenceMap: Map<string, AgentPresenceEntry>,
+): ProviderCardState => {
+  if (!agents.length) {
+    return {
+      id: config.id,
+      label: config.label,
+      modelLabel: 'Sin modelo configurado',
+      tone: 'error',
+      statusLabel: 'Sin agente',
+      description: 'Añade este proveedor desde los ajustes globales.',
+    };
+  }
 
-  const summary = useMemo(() => {
-    const activeModel = models.find(model => model.active) ?? null;
-    const readyCount = models.filter(model => model.status === 'ready').length;
-    const downloadingCount = models.filter(model => model.status === 'downloading').length;
+  const activeAgent = agents.find(agent => agent.active) ?? agents[0];
+  const modelLabel = activeAgent.name ?? activeAgent.model ?? 'Sin modelo configurado';
 
-    return { activeModel, readyCount, downloadingCount };
-  }, [models]);
+  if (!activeAgent.active) {
+    return {
+      id: config.id,
+      label: config.label,
+      modelLabel,
+      tone: 'error',
+      statusLabel: 'Desactivado',
+      description: 'Activa el agente para utilizar este proveedor en las conversaciones.',
+    };
+  }
+
+  if (activeAgent.status === 'Sin clave') {
+    return {
+      id: config.id,
+      label: config.label,
+      modelLabel,
+      tone: 'error',
+      statusLabel: 'Sin credenciales',
+      description: 'Añade tu API key en los ajustes globales para activar este proveedor.',
+    };
+  }
+
+  if (activeAgent.status === 'Cargando') {
+    return {
+      id: config.id,
+      label: config.label,
+      modelLabel,
+      tone: 'warning',
+      statusLabel: 'Inicializando',
+      description: 'El proveedor está completando su arranque.',
+    };
+  }
+
+  const presenceState = mapPresenceStatus(presenceMap.get(activeAgent.id));
+
+  return {
+    id: config.id,
+    label: config.label,
+    modelLabel,
+    tone: presenceState.tone,
+    statusLabel: presenceState.statusLabel,
+    description:
+      presenceState.tone === 'online'
+        ? presenceState.description ?? 'Proveedor operativo.'
+        : presenceState.description,
+  };
+};
+
+const buildJarvisProviderState = (
+  agents: AgentDefinition[],
+  presenceMap: Map<string, AgentPresenceEntry>,
+): ProviderCardState => {
+  if (!agents.length) {
+    return {
+      id: 'jarvis',
+      label: 'Jarvis',
+      modelLabel: 'Sin modelo configurado',
+      tone: 'error',
+      statusLabel: 'Sin modelos',
+      description: 'Instala un modelo local en el gestor para habilitar Jarvis.',
+      showManageModels: true,
+    };
+  }
+
+  const activeLocal = agents.find(agent => agent.active) ?? null;
+  const fallback = activeLocal ?? agents[0];
+  const modelLabel = fallback?.name ?? fallback?.model ?? 'Sin modelo configurado';
+
+  if (!activeLocal) {
+    return {
+      id: 'jarvis',
+      label: 'Jarvis',
+      modelLabel,
+      tone: 'warning',
+      statusLabel: 'Sin modelo activo',
+      description: 'Activa un modelo local desde el gestor para utilizar Jarvis.',
+      showManageModels: true,
+    };
+  }
+
+  if (activeLocal.status === 'Cargando') {
+    return {
+      id: 'jarvis',
+      label: 'Jarvis',
+      modelLabel,
+      tone: 'warning',
+      statusLabel: 'Inicializando',
+      description: 'Jarvis está preparando el runtime local.',
+      showManageModels: true,
+    };
+  }
+
+  if (activeLocal.status === 'Inactivo') {
+    return {
+      id: 'jarvis',
+      label: 'Jarvis',
+      modelLabel,
+      tone: 'warning',
+      statusLabel: 'Runtime detenido',
+      description: 'Inicia el runtime local para volver a usar Jarvis.',
+      showManageModels: true,
+    };
+  }
+
+  if (activeLocal.status !== 'Disponible') {
+    return {
+      id: 'jarvis',
+      label: 'Jarvis',
+      modelLabel,
+      tone: 'error',
+      statusLabel: activeLocal.status,
+      description: 'Jarvis no está disponible. Revisa la configuración local.',
+      showManageModels: true,
+    };
+  }
+
+  const presenceState = mapPresenceStatus(presenceMap.get(activeLocal.id));
+
+  return {
+    id: 'jarvis',
+    label: 'Jarvis',
+    modelLabel,
+    tone: presenceState.tone,
+    statusLabel: presenceState.statusLabel,
+    description:
+      presenceState.tone === 'online'
+        ? presenceState.description ?? 'Jarvis está listo para colaborar.'
+        : presenceState.description ?? 'Revisa el runtime local si persisten los problemas.',
+    showManageModels: presenceState.tone !== 'online',
+  };
+};
+
+export const SidePanel: React.FC<SidePanelProps> = ({ onOpenGlobalSettings, onOpenModelManager }) => {
+  const { agents } = useAgents();
+
+  const apiKeys = useMemo(() => {
+    const keys: Record<string, string> = {};
+    agents.forEach(agent => {
+      if (agent.kind === 'cloud' && agent.apiKey) {
+        keys[agent.provider.toLowerCase()] = agent.apiKey;
+      }
+    });
+    return keys;
+  }, [agents]);
+
+  const { presenceMap, refresh } = useAgentPresence(agents, apiKeys);
+
+  const groupedAgents = useMemo(() => {
+    const groups: Record<ProviderId, AgentDefinition[]> = {
+      openai: [],
+      anthropic: [],
+      groq: [],
+      jarvis: [],
+    };
+
+    agents.forEach(agent => {
+      if (agent.kind === 'local') {
+        groups.jarvis.push(agent);
+        return;
+      }
+
+      const providerKey = agent.provider.toLowerCase();
+      if (providerKey === 'openai') {
+        groups.openai.push(agent);
+      } else if (providerKey === 'anthropic') {
+        groups.anthropic.push(agent);
+      } else if (providerKey === 'groq') {
+        groups.groq.push(agent);
+      }
+    });
+
+    return groups;
+  }, [agents]);
+
+  const providerCards = useMemo<ProviderCardState[]>(
+    () =>
+      PROVIDERS.map(config =>
+        config.kind === 'local'
+          ? buildJarvisProviderState(groupedAgents[config.id], presenceMap)
+          : buildCloudProviderState(config, groupedAgents[config.id], presenceMap),
+      ),
+    [groupedAgents, presenceMap],
+  );
 
   return (
     <div className="sidebar">
       <section className="sidebar-section">
         <header>
-          <h2>Modelos locales</h2>
-          <p>Revisa rápidamente los modelos descargados en este equipo.</p>
+          <h2>Estado de agentes</h2>
+          <p>Monitoriza la disponibilidad de tus proveedores conectados y del runtime local.</p>
         </header>
 
-        <div className="model-panel">
-          <div className="model-panel__summary">
-            <span className="model-panel__summary-label">Modelo activo</span>
-            <strong>{summary.activeModel ? summary.activeModel.name : 'Ninguno'}</strong>
-            <span className="model-panel__summary-sub">
-              {summary.activeModel
-                ? summary.activeModel.provider
-                : 'Gestiona los modelos para activarlos en el orquestador local.'}
-            </span>
-          </div>
-
-          <div className="model-panel__counts">
-            <div>
-              <span className="model-panel__count-label">Listos</span>
-              <span className="model-panel__count-value">{summary.readyCount}</span>
-            </div>
-            <div>
-              <span className="model-panel__count-label">Descargando</span>
-              <span className="model-panel__count-value">{summary.downloadingCount}</span>
-            </div>
-          </div>
-
-          {isLoading && <p className="model-panel__loading">Sincronizando inventario…</p>}
-          {error && <p className="model-panel__error">{error}</p>}
-
-          <ul className="model-panel__list">
-            {models.map(model => (
-              <li
-                key={model.id}
-                className={`model-panel__item ${model.active ? 'is-active' : ''}`}
-                aria-label={`${model.name} · ${formatStatus(model.status, model.active, model.progress)}`}
-              >
-                <div className="model-panel__item-info">
-                  <span className="model-panel__name">{model.name}</span>
-                  <span className="model-panel__provider">{model.provider}</span>
+        <ul className="provider-status-list">
+          {providerCards.map(entry => (
+            <li
+              key={entry.id}
+              className="provider-card"
+              aria-label={`${entry.label}: ${entry.statusLabel} · ${entry.modelLabel}`}
+              data-testid={`provider-card-${entry.id}`}
+            >
+              <div className="provider-card__header">
+                <div className="provider-card__identity">
+                  <span
+                    className={`provider-led is-${entry.tone}`}
+                    data-testid={`provider-led-${entry.id}`}
+                    aria-hidden="true"
+                  />
+                  <div className="provider-card__identity-text">
+                    <span className="provider-card__name">{entry.label}</span>
+                    <span className="provider-card__model">{entry.modelLabel}</span>
+                  </div>
                 </div>
-                <span className={`model-panel__status status-${model.status}`}>
-                  {formatStatus(model.status, model.active, model.progress)}
-                </span>
-              </li>
-            ))}
-          </ul>
+                <span className={`provider-card__state is-${entry.tone}`}>{entry.statusLabel}</span>
+              </div>
+              {entry.description && <p className="provider-card__description">{entry.description}</p>}
+              {entry.showManageModels && (
+                <div className="provider-card__actions">
+                  <button type="button" onClick={onOpenModelManager}>
+                    Gestionar modelos
+                  </button>
+                </div>
+              )}
+            </li>
+          ))}
+        </ul>
 
-          {!models.length && !isLoading && (
-            <p className="model-panel__empty">No hay modelos locales instalados.</p>
-          )}
-        </div>
-
-        <div className="model-panel__actions">
-          <button type="button" onClick={() => void refresh()} disabled={isLoading}>
-            Actualizar
+        <div className="sidebar-actions">
+          <button type="button" onClick={() => void refresh()}>
+            Actualizar estado
           </button>
           <button type="button" className="primary" onClick={onOpenGlobalSettings}>
-            Gestionar descargas
+            Gestionar credenciales
           </button>
         </div>
       </section>


### PR DESCRIPTION
## Summary
- Replace the local model inventory with provider status cards that combine `useAgents` and `useAgentPresence`, including Jarvis-specific handling and manage-models action.
- Refresh the side panel layout and styling to accommodate the new provider overview and actions.
- Wire the model manager callback into the side panel and update the unit tests to exercise the new behaviour.

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68cfb80e9208833394033d765e14c2cb