### PR TITLE
feat: enhance global settings with plugin and MCP sections

### DIFF
--- a/src/components/chat/__tests__/SidePanel.test.tsx
+++ b/src/components/chat/__tests__/SidePanel.test.tsx
@@ -21,6 +21,16 @@ vi.mock('../../../core/agents/presence', () => ({
   useAgentPresence: (...args: unknown[]) => mockUseAgentPresence(...args),
 }));
 
+vi.mock('../../../core/plugins/PluginHostProvider', () => ({
+  usePluginHost: () => ({
+    plugins: [],
+    refresh: vi.fn(),
+    messageActions: [],
+    sidePanels: [],
+    updatePluginSettings: vi.fn(),
+  }),
+}));
+
 const ProjectProbe: React.FC = () => {
   const { activeProject, projects } = useProjects();
   return (

--- a/src/components/settings/GlobalSettingsDialog.css
+++ b/src/components/settings/GlobalSettingsDialog.css
@@ -21,11 +21,23 @@
   cursor: pointer;
   font-size: 14px;
   transition: background 0.2s ease, color 0.2s ease;
+  display: flex;
+  align-items: center;
+  gap: 8px;
 }
 
 .global-settings-tabs button.is-active {
   background: linear-gradient(135deg, rgba(142, 141, 255, 0.6), rgba(255, 183, 77, 0.6));
   color: #fff;
+}
+
+.global-settings-tab-icon {
+  font-size: 16px;
+  display: inline-flex;
+}
+
+.global-settings-tab-label {
+  flex: 1 1 auto;
 }
 
 .global-settings-content {
@@ -34,6 +46,17 @@
   gap: 24px;
   overflow-y: auto;
   padding-right: 8px;
+}
+
+.global-settings-content > section {
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+}
+
+.global-settings-empty {
+  color: rgba(255, 255, 255, 0.6);
+  font-size: 14px;
 }
 
 .settings-section {
@@ -114,6 +137,83 @@
 .settings-error {
   color: #ff8a65;
   font-size: 12px;
+}
+
+.plugin-settings-section header,
+.mcp-settings-section header {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+
+.plugin-settings-fields,
+.mcp-settings-fields {
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+}
+
+.plugin-settings-field label,
+.mcp-settings-field label {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+  font-size: 13px;
+}
+
+.plugin-settings-field input,
+.mcp-settings-field input {
+  border: 1px solid rgba(255, 255, 255, 0.12);
+  border-radius: 12px;
+  padding: 10px 14px;
+  background: rgba(0, 0, 0, 0.4);
+  color: #fff;
+}
+
+.plugin-settings-empty,
+.mcp-settings-empty {
+  font-size: 13px;
+  color: rgba(255, 255, 255, 0.65);
+}
+
+.mcp-settings-endpoints,
+.mcp-settings-scopes,
+.mcp-settings-credentials {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+
+.mcp-settings-endpoints ul,
+.mcp-settings-scopes ul {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+}
+
+.mcp-settings-endpoint-transport {
+  font-size: 11px;
+  font-weight: 600;
+  letter-spacing: 0.6px;
+  text-transform: uppercase;
+  color: rgba(255, 255, 255, 0.6);
+  margin-right: 6px;
+}
+
+.mcp-settings-endpoint-url {
+  font-family: 'JetBrains Mono', 'Fira Code', monospace;
+  font-size: 12px;
+}
+
+.mcp-settings-scopes ul li {
+  padding: 6px 10px;
+  border-radius: 10px;
+  background: rgba(255, 255, 255, 0.05);
+  font-size: 12px;
+  font-family: 'JetBrains Mono', 'Fira Code', monospace;
 }
 
 .project-manager {

--- a/src/components/settings/McpManagerModal.tsx
+++ b/src/components/settings/McpManagerModal.tsx
@@ -80,37 +80,7 @@ export const McpManagerModal: React.FC<McpManagerModalProps> = ({ settings, onSe
     });
   };
 
-  const handleCredentialChange = (
-    profile: PredefinedMcpProfile,
-    fieldId: string,
-    patch: Partial<Pick<McpCredentialEntry, 'value' | 'secretId'>>,
-  ) => {
-    onSettingsChange(prev => {
-      const entry = ensureCredentialRecord(profile, prev.mcpCredentials[profile.id]);
-      const current = entry[fieldId] ?? { id: fieldId, type: 'api-key' };
-      const updated: McpCredentialEntry = {
-        ...current,
-        id: fieldId,
-        type: current.type,
-        ...patch,
-      };
-      return {
-        ...prev,
-        mcpCredentials: {
-          ...prev.mcpCredentials,
-          [profile.id]: {
-            ...entry,
-            [fieldId]: updated,
-          },
-        },
-      };
-    });
-  };
-
   const selectedProfile = catalog.find(entry => entry.id === selectedProfileId) ?? null;
-  const selectedCredentialStore = selectedProfile
-    ? ensureCredentialRecord(selectedProfile, settings.mcpCredentials[selectedProfile.id])
-    : null;
 
   return (
     <div className="mcp-manager">
@@ -199,46 +169,9 @@ export const McpManagerModal: React.FC<McpManagerModalProps> = ({ settings, onSe
             {selectedProfile.credentialRequirements?.length ? (
               <section className="mcp-manager__details-block">
                 <h4>Credenciales</h4>
-                <ul className="mcp-manager__credentials">
-                  {selectedProfile.credentialRequirements.map(requirement => {
-                    const credential = selectedCredentialStore?.[requirement.id];
-                    const value = credential?.value ?? '';
-                    const secretId = credential?.secretId ?? '';
-                    return (
-                      <li key={requirement.id}>
-                        <label>
-                          <span>{requirement.label}</span>
-                          {requirement.type === 'api-key' ? (
-                            <input
-                              type="text"
-                              value={value}
-                              placeholder={requirement.placeholder ?? 'Introduce la API key'}
-                              onChange={event =>
-                                handleCredentialChange(selectedProfile, requirement.id, {
-                                  value: event.target.value,
-                                })
-                              }
-                            />
-                          ) : (
-                            <input
-                              type="text"
-                              value={secretId}
-                              placeholder={requirement.placeholder ?? 'Identificador en SecretManager'}
-                              onChange={event =>
-                                handleCredentialChange(selectedProfile, requirement.id, {
-                                  secretId: event.target.value,
-                                })
-                              }
-                            />
-                          )}
-                        </label>
-                        {requirement.helperText && (
-                          <p className="mcp-manager__helper">{requirement.helperText}</p>
-                        )}
-                      </li>
-                    );
-                  })}
-                </ul>
+                <p className="mcp-manager__credentials-empty">
+                  Configura las credenciales desde Ajustes globales → {selectedProfile.label}.
+                </p>
               </section>
             ) : (
               <p className="mcp-manager__credentials-empty">

--- a/src/components/settings/McpSettingsSection.tsx
+++ b/src/components/settings/McpSettingsSection.tsx
@@ -1,0 +1,143 @@
+import React, { useMemo, useState } from 'react';
+import type { McpCredentialEntry, McpProfile } from '../../types/globalSettings';
+import { getPredefinedMcpProfile } from '../../core/mcp/predefinedProfiles';
+
+interface McpSettingsSectionProps {
+  profile: McpProfile;
+  credentials: Record<string, McpCredentialEntry> | undefined;
+  onCredentialChange: (
+    fieldId: string,
+    type: McpCredentialEntry['type'],
+    patch: Partial<Pick<McpCredentialEntry, 'value' | 'secretId'>>,
+  ) => void;
+}
+
+export const McpSettingsSection: React.FC<McpSettingsSectionProps> = ({
+  profile,
+  credentials,
+  onCredentialChange,
+}) => {
+  const [touchedFields, setTouchedFields] = useState<Record<string, boolean>>({});
+
+  const definition = useMemo(() => getPredefinedMcpProfile(profile.id), [profile.id]);
+  const requirements = definition?.credentialRequirements ?? [];
+  const knownIds = useMemo(() => new Set(requirements.map(requirement => requirement.id)), [requirements]);
+
+  const orderedCredentials = useMemo(() => {
+    const fromRequirements = requirements.map(requirement => ({
+      requirement,
+      entry:
+        credentials?.[requirement.id] ?? {
+          id: requirement.id,
+          type: requirement.type,
+          value: '',
+          secretId: '',
+        },
+    }));
+
+    const extras = Object.values(credentials ?? {}).filter(entry => !knownIds.has(entry.id));
+
+    return { fromRequirements, extras };
+  }, [credentials, knownIds, requirements]);
+
+  const renderCredentialField = (
+    entry: McpCredentialEntry,
+    options?: { helperText?: string; label?: string; placeholder?: string },
+  ) => {
+    const fieldId = `mcp-${profile.id}-${entry.id}`;
+    const isSecret = entry.type === 'oauth';
+    const label = options?.label ?? entry.id;
+    const helper = options?.helperText;
+    const placeholder = options?.placeholder ?? (isSecret ? 'ID en SecretManager' : 'Introduce el valor');
+    const currentValue = isSecret ? entry.secretId ?? '' : entry.value ?? '';
+    const isTouched = touchedFields[entry.id];
+    const showError = isTouched && !currentValue.trim();
+
+    return (
+      <div className="mcp-settings-field" key={entry.id}>
+        <label htmlFor={fieldId}>
+          <span>{label}</span>
+          <input
+            id={fieldId}
+            type={isSecret ? 'text' : 'password'}
+            value={currentValue}
+            placeholder={placeholder}
+            required
+            aria-invalid={showError || undefined}
+            onChange={event =>
+              onCredentialChange(entry.id, entry.type, {
+                [isSecret ? 'secretId' : 'value']: event.target.value,
+              })
+            }
+            onBlur={() =>
+              setTouchedFields(prev => ({
+                ...prev,
+                [entry.id]: true,
+              }))
+            }
+          />
+        </label>
+        {helper && <p className="settings-hint">{helper}</p>}
+        {showError && <p className="settings-error">Este campo es obligatorio.</p>}
+      </div>
+    );
+  };
+
+  return (
+    <div className="settings-section mcp-settings-section">
+      <header>
+        <h3>{profile.label}</h3>
+        {profile.description && <p>{profile.description}</p>}
+      </header>
+
+      {profile.endpoints.length ? (
+        <section className="mcp-settings-endpoints" aria-label="Endpoints configurados">
+          <h4>Endpoints activos</h4>
+          <ul>
+            {profile.endpoints.map(endpoint => (
+              <li key={endpoint.id}>
+                <span className="mcp-settings-endpoint-transport">{endpoint.transport.toUpperCase()}</span>
+                <span className="mcp-settings-endpoint-url">{endpoint.url}</span>
+              </li>
+            ))}
+          </ul>
+        </section>
+      ) : null}
+
+      {profile.scopes?.length ? (
+        <section className="mcp-settings-scopes" aria-label="Scopes solicitados">
+          <h4>Scopes sugeridos</h4>
+          <ul>
+            {profile.scopes.map(scope => (
+              <li key={scope}>{scope}</li>
+            ))}
+          </ul>
+        </section>
+      ) : null}
+
+      <section className="mcp-settings-credentials" aria-label="Credenciales del perfil">
+        <h4>Credenciales</h4>
+        {orderedCredentials.fromRequirements.length ? (
+          <div className="mcp-settings-fields">
+            {orderedCredentials.fromRequirements.map(({ requirement, entry }) =>
+              renderCredentialField(entry, {
+                label: requirement.label,
+                helperText: requirement.helperText,
+                placeholder: requirement.placeholder,
+              }),
+            )}
+            {orderedCredentials.extras.map(entry => renderCredentialField(entry))}
+          </div>
+        ) : orderedCredentials.extras.length ? (
+          <div className="mcp-settings-fields">
+            {orderedCredentials.extras.map(entry => renderCredentialField(entry))}
+          </div>
+        ) : (
+          <p className="mcp-settings-empty">Este perfil no requiere credenciales adicionales.</p>
+        )}
+      </section>
+    </div>
+  );
+};
+
+export default McpSettingsSection;

--- a/src/components/settings/PluginManagerModal.tsx
+++ b/src/components/settings/PluginManagerModal.tsx
@@ -67,73 +67,6 @@ export const PluginManagerModal: React.FC<PluginManagerModalProps> = ({
     refresh();
   };
 
-  const handleCredentialChange = (pluginId: string, key: string, value: string) => {
-    onSettingsChange(prev => {
-      const entry = ensurePluginSettingsEntry(prev, pluginId);
-      return {
-        ...prev,
-        pluginSettings: {
-          ...prev.pluginSettings,
-          [pluginId]: {
-            ...entry,
-            credentials: {
-              ...entry.credentials,
-              [key]: value,
-            },
-          },
-        },
-      };
-    });
-  };
-
-  const handleRemoveCredential = (pluginId: string, key: string) => {
-    onSettingsChange(prev => {
-      const entry = ensurePluginSettingsEntry(prev, pluginId);
-      const credentials = { ...entry.credentials };
-      delete credentials[key];
-      return {
-        ...prev,
-        pluginSettings: {
-          ...prev.pluginSettings,
-          [pluginId]: {
-            ...entry,
-            credentials,
-          },
-        },
-      };
-    });
-  };
-
-  const handleAddCredential = (pluginId: string) => {
-    const key = window.prompt('Introduce un identificador para la credencial del plugin');
-    if (!key) {
-      return;
-    }
-    const trimmed = key.trim();
-    if (!trimmed) {
-      return;
-    }
-    onSettingsChange(prev => {
-      const entry = ensurePluginSettingsEntry(prev, pluginId);
-      if (entry.credentials[trimmed] !== undefined) {
-        return prev;
-      }
-      return {
-        ...prev,
-        pluginSettings: {
-          ...prev.pluginSettings,
-          [pluginId]: {
-            ...entry,
-            credentials: {
-              ...entry.credentials,
-              [trimmed]: '',
-            },
-          },
-        },
-      };
-    });
-  };
-
   if (!sortedPlugins.length) {
     return (
       <div className="plugin-manager__empty">
@@ -146,9 +79,6 @@ export const PluginManagerModal: React.FC<PluginManagerModalProps> = ({
   }
 
   const selectedPlugin = sortedPlugins.find(entry => entry.pluginId === selectedPluginId) ?? null;
-  const selectedSettings = selectedPlugin
-    ? ensurePluginSettingsEntry(settings, selectedPlugin.pluginId)
-    : null;
 
   return (
     <div className="plugin-manager">
@@ -207,7 +137,7 @@ export const PluginManagerModal: React.FC<PluginManagerModalProps> = ({
       </aside>
 
       <section className="plugin-manager__details" aria-live="polite">
-        {selectedPlugin && selectedSettings ? (
+        {selectedPlugin ? (
           <>
             <header>
               <h3>{selectedPlugin.manifest.name}</h3>
@@ -247,42 +177,15 @@ export const PluginManagerModal: React.FC<PluginManagerModalProps> = ({
 
             <section className="plugin-manager__details-block">
               <h4>Credenciales</h4>
-              {Object.keys(selectedSettings.credentials).length ? (
-                <ul className="plugin-manager__credentials">
-                  {Object.entries(selectedSettings.credentials).map(([key, value]) => (
-                    <li key={key} className="plugin-manager__credential">
-                      <label>
-                        <span>{key}</span>
-                        <input
-                          type="text"
-                          value={value}
-                          onChange={event => handleCredentialChange(selectedPlugin.pluginId, key, event.target.value)}
-                          placeholder="Introduce el valor"
-                        />
-                      </label>
-                      <button
-                        type="button"
-                        className="plugin-manager__credential-remove"
-                        onClick={() => handleRemoveCredential(selectedPlugin.pluginId, key)}
-                        aria-label={`Eliminar la credencial ${key}`}
-                      >
-                        ✕
-                      </button>
-                    </li>
-                  ))}
-                </ul>
+              {selectedPlugin.manifest.credentials?.length ? (
+                <p className="plugin-manager__credentials-empty">
+                  Gestiona las credenciales desde Ajustes globales → {selectedPlugin.manifest.name}.
+                </p>
               ) : (
                 <p className="plugin-manager__credentials-empty">
-                  No hay credenciales configuradas todavía para este plugin.
+                  Este plugin no requiere credenciales configurables.
                 </p>
               )}
-              <button
-                type="button"
-                className="plugin-manager__add-credential"
-                onClick={() => handleAddCredential(selectedPlugin.pluginId)}
-              >
-                Añadir credencial
-              </button>
             </section>
           </>
         ) : (

--- a/src/components/settings/PluginSettingsSection.tsx
+++ b/src/components/settings/PluginSettingsSection.tsx
@@ -1,0 +1,103 @@
+import React, { useMemo, useState } from 'react';
+import type { PluginCredentialField, PluginManifest } from '../../core/plugins';
+
+interface PluginSettingsSectionProps {
+  pluginId: string;
+  manifest: PluginManifest | null;
+  credentials: Record<string, string | undefined>;
+  onCredentialChange: (fieldId: string, value: string) => void;
+}
+
+interface FieldState {
+  field: PluginCredentialField;
+  value: string;
+  helperId?: string;
+}
+
+export const PluginSettingsSection: React.FC<PluginSettingsSectionProps> = ({
+  pluginId,
+  manifest,
+  credentials,
+  onCredentialChange,
+}) => {
+  const [touchedFields, setTouchedFields] = useState<Record<string, boolean>>({});
+
+  const fields = useMemo(() => manifest?.credentials ?? [], [manifest]);
+
+  const fieldStates = useMemo<FieldState[]>(
+    () =>
+      fields.map(field => ({
+        field,
+        value: credentials[field.id] ?? '',
+        helperId: field.description ? `plugin-${pluginId}-${field.id}-helper` : undefined,
+      })),
+    [credentials, fields, pluginId],
+  );
+
+  if (!manifest) {
+    return (
+      <div className="settings-section plugin-settings-section">
+        <h3>Plugin desconocido</h3>
+        <p>
+          No se pudo cargar la información del plugin <code>{pluginId}</code>. Asegúrate de que esté
+          instalado correctamente.
+        </p>
+      </div>
+    );
+  }
+
+  return (
+    <div className="settings-section plugin-settings-section">
+      <header>
+        <h3>{manifest.name}</h3>
+        {manifest.description && <p>{manifest.description}</p>}
+      </header>
+
+      {fieldStates.length ? (
+        <div className="plugin-settings-fields">
+          {fieldStates.map(({ field, value, helperId }) => {
+            const inputId = `plugin-${pluginId}-${field.id}`;
+            const isRequired = Boolean(field.required);
+            const isTouched = touchedFields[field.id];
+            const showError = isRequired && isTouched && !value.trim();
+
+            return (
+              <div className="plugin-settings-field" key={field.id}>
+                <label htmlFor={inputId}>
+                  <span>{field.label}</span>
+                  <input
+                    id={inputId}
+                    type={field.secret ? 'password' : 'text'}
+                    value={value}
+                    onChange={event => onCredentialChange(field.id, event.target.value)}
+                    onBlur={() =>
+                      setTouchedFields(prev => ({
+                        ...prev,
+                        [field.id]: true,
+                      }))
+                    }
+                    aria-describedby={helperId}
+                    aria-invalid={showError || undefined}
+                    required={isRequired}
+                  />
+                </label>
+                {field.description && (
+                  <p id={helperId} className="settings-hint">
+                    {field.description}
+                  </p>
+                )}
+                {showError && <p className="settings-error">Este campo es obligatorio.</p>}
+              </div>
+            );
+          })}
+        </div>
+      ) : (
+        <p className="plugin-settings-empty">
+          Este plugin no declara credenciales configurables. Solo necesitas mantenerlo activado.
+        </p>
+      )}
+    </div>
+  );
+};
+
+export default PluginSettingsSection;


### PR DESCRIPTION
## Summary
- build dynamic tabbed navigation in the global settings dialog with plugin and MCP sections, including new validation UX
- move plugin and MCP credential editing into the global dialog using manifest and profile metadata, while simplifying manager modals
- add dedicated settings sections, update styles, and extend tests to cover plugin credential workflows

## Testing
- npm test -- --run

------
https://chatgpt.com/codex/tasks/task_e_68cfbad0fbac8333a70fcc7eabef7df7