### PR TITLE
Update Groq recommended model to llama-3.2-90b-text

### DIFF
--- a/docs/release-notes.md
+++ b/docs/release-notes.md
@@ -1,0 +1,7 @@
+# Notas de la versión
+
+## Migración de modelo Groq recomendado
+
+- Se actualizó el modelo sugerido para Groq a `llama-3.2-90b-text` para alinearse con la lista vigente de la API.
+- Los agentes y diagnósticos ahora utilizan este modelo por defecto y ofrecerán un fallback automático en caso de deprecaciones.
+- Si tus presets hacen referencia a identificadores antiguos (`llama-3.1-70b-versatile`, `llama3-70b-8192`, etc.), se redirigirán al nuevo modelo. También puedes optar por `mixtral-8x7b-32768` si necesitas una alternativa compatible.

--- a/src/components/chat/__tests__/SidePanel.test.tsx
+++ b/src/components/chat/__tests__/SidePanel.test.tsx
@@ -115,7 +115,14 @@ describe('Resumen de proveedores en SidePanel', () => {
         channel: 'claude',
         apiKey: 'sk-anthropic',
       }),
-      buildAgent({ id: 'groq-agent', name: 'LLaMA 3.1 70B', model: 'llama-3.1-70b', provider: 'Groq', channel: 'groq', apiKey: 'sk-groq' }),
+      buildAgent({
+        id: 'groq-agent',
+        name: 'LLaMA 3.2 90B',
+        model: 'llama-3.2-90b-text',
+        provider: 'Groq',
+        channel: 'groq',
+        apiKey: 'sk-groq',
+      }),
       buildAgent({
         id: 'jarvis-phi',
         name: 'Phi-3 Mini',
@@ -163,8 +170,8 @@ describe('Resumen de proveedores en SidePanel', () => {
       }),
       buildAgent({
         id: 'groq-agent',
-        name: 'LLaMA 3.1 70B',
-        model: 'llama-3.1-70b',
+        name: 'LLaMA 3.2 90B',
+        model: 'llama-3.2-90b-text',
         provider: 'Groq',
         channel: 'groq',
         apiKey: 'sk-groq',

--- a/src/core/agents/agentRegistry.ts
+++ b/src/core/agents/agentRegistry.ts
@@ -54,9 +54,9 @@ export const INITIAL_AGENTS: AgentDefinition[] = [
     channel: 'claude',
   },
   {
-    id: 'groq-llama3-70b',
-    model: 'llama-3.1-70b-versatile',
-    name: 'LLaMA 3.1 70B',
+    id: 'groq-llama3-90b',
+    model: 'llama-3.2-90b-text',
+    name: 'LLaMA 3.2 90B',
     provider: 'Groq',
     description: 'Respuesta ultrarrápida para tareas analíticas y técnicas.',
     kind: 'cloud',

--- a/src/hooks/__tests__/useProviderDiagnostics.test.tsx
+++ b/src/hooks/__tests__/useProviderDiagnostics.test.tsx
@@ -32,7 +32,7 @@ describe('useProviderDiagnostics', () => {
 
   it('expone el modelo recomendado actualizado para Groq', () => {
     const { result } = renderHook(() => useProviderDiagnostics());
-    expect(result.current.getDefaultModel('groq')).toBe('llama-3.1-70b-versatile');
+    expect(result.current.getDefaultModel('groq')).toBe('llama-3.2-90b-text');
   });
 
   it('utiliza el modelo recomendado de Groq al probar conectividad', async () => {
@@ -45,10 +45,10 @@ describe('useProviderDiagnostics', () => {
     });
 
     expect(aiProviderMocks.callGroqChat).toHaveBeenCalledWith(
-      expect.objectContaining({ model: 'llama-3.1-70b-versatile' }),
+      expect.objectContaining({ model: 'llama-3.2-90b-text' }),
     );
     expect(response!.ok).toBe(true);
-    expect(response!.modelUsed).toBe('llama-3.1-70b-versatile');
+    expect(response!.modelUsed).toBe('llama-3.2-90b-text');
   });
 
   it('propaga el error de concurrencia de Anthropic', async () => {

--- a/src/hooks/useProviderDiagnostics.ts
+++ b/src/hooks/useProviderDiagnostics.ts
@@ -24,7 +24,7 @@ const PROVIDER_PATTERNS: Partial<Record<BuiltinProvider, RegExp>> = {
 const PROVIDER_TEST_MODELS: Record<BuiltinProvider, string> = {
   openai: 'gpt-4o-mini',
   anthropic: 'claude-3-5-sonnet-20241022',
-  groq: 'llama-3.1-70b-versatile',
+  groq: 'llama-3.2-90b-text',
 };
 
 const TEST_PROMPT = 'Responde únicamente con "OK".';

--- a/src/utils/aiProviders.ts
+++ b/src/utils/aiProviders.ts
@@ -72,12 +72,16 @@ const maskApiKey = (apiKey: string): string => {
   return `${trimmed.slice(0, 4)}…${trimmed.slice(-4)}`;
 };
 
-const GROQ_RECOMMENDED_MODEL = 'llama-3.1-70b-versatile';
+const GROQ_RECOMMENDED_MODEL = 'llama-3.2-90b-text';
 
 const GROQ_MODEL_ALIASES: Record<string, string> = {
+  'llama-3.2-90b': GROQ_RECOMMENDED_MODEL,
+  'llama3-90b': GROQ_RECOMMENDED_MODEL,
+  'llama3-90b-text': GROQ_RECOMMENDED_MODEL,
   'llama3-70b-8192': GROQ_RECOMMENDED_MODEL,
   'llama-3-70b-8192': GROQ_RECOMMENDED_MODEL,
   'llama3-70b': GROQ_RECOMMENDED_MODEL,
+  'llama-3.1-70b-versatile': GROQ_RECOMMENDED_MODEL,
   'mixtral-8x7b-32768': 'mixtral-8x7b-32768',
 };
 
@@ -489,11 +493,19 @@ export const callGroqChat = async ({
 
       if (shouldRetryWithRecommended) {
         console.warn(
-          `Groq indicó que el modelo "${activeModel}" está obsoleto. Reintentando con "${GROQ_RECOMMENDED_MODEL}".`,
+          `Groq indicó que el modelo "${activeModel}" está obsoleto. Reintentando con "${GROQ_RECOMMENDED_MODEL}". ` +
+            'Actualiza tus presets o prueba "mixtral-8x7b-32768" si necesitas una alternativa compatible.',
         );
         activeModel = GROQ_RECOMMENDED_MODEL;
         attemptedFallback = true;
         continue;
+      }
+
+      if (/deprecat/i.test(message)) {
+        throw new Error(
+          `Groq marcó el modelo "${activeModel}" como obsoleto. Cambia al modelo recomendado "${GROQ_RECOMMENDED_MODEL}" ` +
+            'o utiliza "mixtral-8x7b-32768" como alternativa temporal.',
+        );
       }
 
       throw error instanceof Error ? error : new Error(message || 'Groq rechazó la solicitud.');


### PR DESCRIPTION
## Summary
- update the Groq recommended model, agent metadata and diagnostics to `llama-3.2-90b-text`
- improve Groq deprecation handling by surfacing guidance and offering `mixtral-8x7b-32768` as an alternative
- add release notes describing the migration for end users

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68cfc135c7dc833389550a7d5c00d7c3