### PR TITLE
Refactor local model management to use Jarvis Core client

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -138,6 +138,7 @@ const AppContent: React.FC<AppContentProps> = ({
         storageDir={settings.modelPreferences.storageDir}
         huggingFacePreferences={settings.modelPreferences.huggingFace}
         onStorageDirChange={handleModelStorageDirChange}
+        huggingFaceToken={apiKeys['huggingface']}
       />
 
       <OverlayModal

--- a/src/components/models/ModelGallery.css
+++ b/src/components/models/ModelGallery.css
@@ -42,6 +42,38 @@
   background: rgba(255, 255, 255, 0.12);
 }
 
+.model-gallery__notice {
+  padding: 0.75rem 1rem;
+  border-radius: 0.75rem;
+  background: rgba(77, 208, 225, 0.08);
+  border: 1px solid rgba(77, 208, 225, 0.35);
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 1rem;
+  font-size: 0.9rem;
+  color: rgba(226, 244, 255, 0.85);
+}
+
+.model-gallery__notice button {
+  padding: 0.4rem 0.9rem;
+  border-radius: 999px;
+  border: 1px solid rgba(77, 208, 225, 0.6);
+  background: rgba(77, 208, 225, 0.12);
+  color: inherit;
+  cursor: pointer;
+  transition: background 0.2s ease;
+}
+
+.model-gallery__notice button:disabled {
+  opacity: 0.6;
+  cursor: not-allowed;
+}
+
+.model-gallery__notice button:not(:disabled):hover {
+  background: rgba(77, 208, 225, 0.25);
+}
+
 .model-gallery__error {
   padding: 0.75rem 1rem;
   border-radius: 0.75rem;

--- a/src/components/models/ModelGallery.tsx
+++ b/src/components/models/ModelGallery.tsx
@@ -17,7 +17,20 @@ const formatSize = (size: number): string => {
 };
 
 export const ModelGallery: React.FC = () => {
-  const { models, isLoading, error, download, activate, refresh } = useLocalModels();
+  const {
+    models,
+    isLoading,
+    error,
+    download,
+    activate,
+    refresh,
+    connectionState,
+    startJarvis,
+    isRemote,
+  } = useLocalModels();
+
+  const isOnline = connectionState.status === 'online';
+  const isConnecting = connectionState.status === 'connecting';
 
   return (
     <div className="model-gallery">
@@ -32,6 +45,15 @@ export const ModelGallery: React.FC = () => {
           </button>
         </div>
       </header>
+
+      {!isOnline && (
+        <div className="model-gallery__notice" role="status">
+          <p>{connectionState.message}</p>
+          <button type="button" onClick={() => void startJarvis()} disabled={isConnecting}>
+            Conectar JarvisCore
+          </button>
+        </div>
+      )}
 
       {error && <div className="model-gallery__error">{error}</div>}
 
@@ -84,7 +106,11 @@ export const ModelGallery: React.FC = () => {
 
               <footer className="model-card__actions">
                 {model.status === 'not_installed' && (
-                  <button type="button" onClick={() => void download(model.id)} disabled={isLoading}>
+                  <button
+                    type="button"
+                    onClick={() => void download(model.id)}
+                    disabled={isLoading || !isRemote || !isOnline}
+                  >
                     Descargar
                   </button>
                 )}
@@ -95,7 +121,7 @@ export const ModelGallery: React.FC = () => {
                   </div>
                 )}
                 {model.status === 'ready' && !model.active && (
-                  <button type="button" onClick={() => void activate(model.id)}>
+                  <button type="button" onClick={() => void activate(model.id)} disabled={!isOnline}>
                     Activar
                   </button>
                 )}

--- a/src/components/models/ModelManagerModal.css
+++ b/src/components/models/ModelManagerModal.css
@@ -203,6 +203,38 @@
   font-size: 0.9rem;
 }
 
+.model-manager__notice {
+  padding: 0.75rem 1rem;
+  border-radius: 10px;
+  background: rgba(77, 208, 225, 0.1);
+  border: 1px solid rgba(77, 208, 225, 0.35);
+  display: flex;
+  flex-direction: column;
+  gap: 0.6rem;
+  font-size: 0.9rem;
+  color: rgba(226, 244, 255, 0.85);
+}
+
+.model-manager__notice button {
+  align-self: flex-start;
+  padding: 0.4rem 0.85rem;
+  border-radius: 999px;
+  border: 1px solid rgba(77, 208, 225, 0.6);
+  background: rgba(77, 208, 225, 0.18);
+  color: inherit;
+  cursor: pointer;
+  transition: background 0.2s ease;
+}
+
+.model-manager__notice button:disabled {
+  opacity: 0.6;
+  cursor: not-allowed;
+}
+
+.model-manager__notice button:not(:disabled):hover {
+  background: rgba(77, 208, 225, 0.3);
+}
+
 .model-manager__empty,
 .model-manager__loading {
   padding: 1rem;

--- a/src/components/models/__tests__/ModelManagerModal.test.tsx
+++ b/src/components/models/__tests__/ModelManagerModal.test.tsx
@@ -19,6 +19,9 @@ vi.mock('../../../hooks/useHuggingFaceCatalog', () => ({
         likes: 230,
         lastModified: '2024-04-01T00:00:00Z',
         tags: [],
+        files: [
+          { fileName: 'remote-1.gguf', size: 1024, checksum: 'sha256-remote-1' },
+        ],
       },
     ],
     isLoading: false,
@@ -41,12 +44,12 @@ vi.mock('../../../hooks/useLocalModels', () => ({
       {
         id: 'remote-1',
         name: 'Remote Model',
-        description: 'ready model',
+        description: 'pending model',
         provider: 'Local',
         tags: [],
         size: 0,
         checksum: 'abc',
-        status: 'ready',
+        status: 'not_installed',
         localPath: '/models/remote-1',
         active: false,
         progress: 1,
@@ -59,7 +62,7 @@ vi.mock('../../../hooks/useLocalModels', () => ({
         tags: [],
         size: 0,
         checksum: 'def',
-        status: 'downloading',
+        status: 'ready',
         localPath: '/models/local-2',
         active: false,
         progress: 0.4,
@@ -70,6 +73,9 @@ vi.mock('../../../hooks/useLocalModels', () => ({
     refresh: refreshMock,
     download: downloadMock,
     activate: activateMock,
+    connectionState: { status: 'online', message: null, lastError: null },
+    startJarvis: vi.fn(),
+    isRemote: true,
   })),
 }));
 
@@ -101,10 +107,19 @@ describe('ModelManagerModal', () => {
     });
     expect(handleStorageChange).toHaveBeenCalledWith('/data/models');
 
+    fireEvent.click(screen.getAllByText('Descargar')[0]);
+
+    await waitFor(() => {
+      expect(downloadMock).toHaveBeenCalledWith(
+        'remote-1',
+        expect.objectContaining({ filename: 'remote-1.gguf', repoId: 'remote-1' }),
+      );
+    });
+
     fireEvent.click(screen.getAllByText('Activar')[0]);
 
     await waitFor(() => {
-      expect(activateMock).toHaveBeenCalledWith('remote-1');
+      expect(activateMock).toHaveBeenCalledWith('local-2');
     });
   });
 });

--- a/src/core/jarvis/__tests__/JarvisCoreContext.test.tsx
+++ b/src/core/jarvis/__tests__/JarvisCoreContext.test.tsx
@@ -122,6 +122,8 @@ describe('JarvisCoreContext', () => {
 
     expect(result.current.activeModel).toBe('phi');
     expect(result.current.downloads.phi.percent).toBe(100);
+    expect(result.current.models).toHaveLength(1);
+    expect(result.current.models[0].model_id).toBe('phi');
   });
 
   it('integra actualizaciones de progreso provenientes del streaming', async () => {


### PR DESCRIPTION
## Summary
- hook the local model hook into Jarvis Core, exposing connection state, download/activation helpers and HTTP-aware error feedback
- surface Jarvis Core models and download actions through the UI with connection prompts and new styling updates
- enrich the Hugging Face catalog with file metadata and optional tokens, wiring the stored token into the model manager

## Testing
- npx vitest run

------
https://chatgpt.com/codex/tasks/task_e_68cfd0c4c4c08333a5d0c00958f00f74