### PR TITLE
Integrate Jarvis Core streaming actions

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -26,6 +26,7 @@ import { PluginManagerModal } from './components/settings/PluginManagerModal';
 import { McpManagerModal } from './components/settings/McpManagerModal';
 import { ProjectProvider } from './core/projects/ProjectContext';
 import { ModelManagerModal } from './components/models/ModelManagerModal';
+import { JarvisCoreProvider } from './core/jarvis/JarvisCoreContext';
 
 interface AppContentProps {
   apiKeys: ApiKeySettings;
@@ -216,16 +217,18 @@ const App: React.FC = () => {
           enabledPlugins={globalSettings.enabledPlugins}
           approvedManifests={globalSettings.approvedManifests}
         >
-          <MessageProvider apiKeys={globalSettings.apiKeys}>
-            <RepoWorkflowProvider>
-              <AppContent
-                apiKeys={globalSettings.apiKeys}
-                settings={globalSettings}
-                onApiKeyChange={handleApiKeyChange}
-                onSettingsChange={setGlobalSettings}
-              />
-            </RepoWorkflowProvider>
-          </MessageProvider>
+          <JarvisCoreProvider settings={globalSettings} onSettingsChange={setGlobalSettings}>
+            <MessageProvider apiKeys={globalSettings.apiKeys}>
+              <RepoWorkflowProvider>
+                <AppContent
+                  apiKeys={globalSettings.apiKeys}
+                  settings={globalSettings}
+                  onApiKeyChange={handleApiKeyChange}
+                  onSettingsChange={setGlobalSettings}
+                />
+              </RepoWorkflowProvider>
+            </MessageProvider>
+          </JarvisCoreProvider>
         </AgentProvider>
       </ProjectProvider>
     </PluginHostProvider>

--- a/src/components/chat/ChatInterface.css
+++ b/src/components/chat/ChatInterface.css
@@ -598,6 +598,84 @@
   gap: 10px;
 }
 
+.message-card-jarvis-actions {
+  margin-top: 4px;
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+}
+
+.jarvis-action-card {
+  border: 1px solid rgba(142, 141, 255, 0.18);
+  border-radius: 10px;
+  padding: 12px 14px;
+  background: linear-gradient(120deg, rgba(18, 20, 40, 0.75), rgba(24, 28, 52, 0.55));
+  box-shadow: 0 4px 10px rgba(10, 12, 24, 0.35);
+}
+
+.jarvis-action-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 8px;
+}
+
+.jarvis-action-label {
+  font-weight: 600;
+  font-size: 13px;
+  color: rgba(233, 236, 255, 0.92);
+}
+
+.jarvis-action-status {
+  font-size: 11px;
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
+  color: rgba(166, 170, 210, 0.85);
+}
+
+.jarvis-action-description {
+  margin: 4px 0 0;
+  font-size: 12px;
+  color: rgba(214, 218, 255, 0.75);
+}
+
+.jarvis-action-controls {
+  margin-top: 8px;
+  display: flex;
+  align-items: center;
+  flex-wrap: wrap;
+  gap: 8px;
+}
+
+.jarvis-action-progress {
+  font-size: 12px;
+  color: rgba(214, 218, 255, 0.8);
+}
+
+.jarvis-action-result-label {
+  font-size: 11px;
+  color: rgba(166, 170, 210, 0.85);
+}
+
+.jarvis-action-result {
+  margin-top: 8px;
+  padding: 10px 12px;
+  border-radius: 8px;
+  background: rgba(12, 14, 28, 0.78);
+  border: 1px solid rgba(142, 141, 255, 0.14);
+  font-family: 'JetBrains Mono', 'Fira Code', monospace;
+  font-size: 12px;
+  line-height: 1.6;
+  white-space: pre-wrap;
+  color: rgba(219, 222, 255, 0.92);
+}
+
+.jarvis-action-error,
+.jarvis-action-error-message {
+  font-size: 12px;
+  color: #ff8c8c;
+}
+
 .message-card-media {
   display: flex;
   flex-direction: column;

--- a/src/components/chat/ChatWorkspace.tsx
+++ b/src/components/chat/ChatWorkspace.tsx
@@ -63,6 +63,8 @@ export const ChatWorkspace: React.FC<ChatWorkspaceProps> = ({
     setComposerTargetAgentIds,
     composerTargetMode,
     setComposerTargetMode,
+    triggerAction,
+    rejectAction,
   } = useMessages();
   const { dynamicSuggestions, recentCommands } = useConversationSuggestions();
 
@@ -508,6 +510,8 @@ export const ChatWorkspace: React.FC<ChatWorkspaceProps> = ({
                     shareMessageWithAgent(agentId, messageId, { canonicalCode })
                   }
                   onLoadIntoDraft={loadMessageIntoDraft}
+                  onTriggerAction={triggerAction}
+                  onRejectAction={rejectAction}
                 />
               );
             })

--- a/src/components/chat/messages/MessageCard.tsx
+++ b/src/components/chat/messages/MessageCard.tsx
@@ -2,6 +2,7 @@ import React, { useCallback } from 'react';
 import { ChatMessage } from '../../../core/messages/messageTypes';
 import { MessageContent } from './MessageContent';
 import { MessageAttachment } from './MessageAttachment';
+import { JarvisActionControls } from './MessageActions';
 
 interface MessageCardProps {
   message: ChatMessage;
@@ -12,6 +13,8 @@ interface MessageCardProps {
   onAppendToComposer?: (value: string) => void;
   onShareMessage?: (agentId: string, messageId: string, canonicalCode?: string) => void;
   onLoadIntoDraft?: (messageId: string) => void;
+  onTriggerAction?: (actionId: string) => void;
+  onRejectAction?: (actionId: string) => void;
 }
 
 export const MessageCard: React.FC<MessageCardProps> = ({
@@ -23,6 +26,8 @@ export const MessageCard: React.FC<MessageCardProps> = ({
   onAppendToComposer,
   onShareMessage,
   onLoadIntoDraft,
+  onTriggerAction,
+  onRejectAction,
 }) => {
   const isUser = message.author === 'user';
   const isSystem = message.author === 'system';
@@ -89,6 +94,19 @@ export const MessageCard: React.FC<MessageCardProps> = ({
             <span key={modality} className="modality-chip">
               {modality}
             </span>
+          ))}
+        </div>
+      ) : null}
+
+      {message.actions?.length ? (
+        <div className="message-card-jarvis-actions">
+          {message.actions.map(action => (
+            <JarvisActionControls
+              key={action.id}
+              action={action}
+              onTrigger={onTriggerAction}
+              onReject={onRejectAction}
+            />
           ))}
         </div>
       ) : null}

--- a/src/components/chat/messages/__tests__/MessageContent.test.tsx
+++ b/src/components/chat/messages/__tests__/MessageContent.test.tsx
@@ -8,6 +8,8 @@ import { RepoWorkflowProvider } from '../../../../core/codex';
 import { PluginHostProvider } from '../../../../core/plugins/PluginHostProvider';
 import { DEFAULT_GLOBAL_SETTINGS } from '../../../../utils/globalSettings';
 import { ProjectProvider } from '../../../../core/projects/ProjectContext';
+import { JarvisCoreProvider } from '../../../../core/jarvis/JarvisCoreContext';
+import type { JarvisCoreClient } from '../../../../services/jarvisCoreClient';
 
 const noop = vi.fn();
 
@@ -15,16 +17,29 @@ const ProviderHarness: React.FC<{ children: React.ReactNode }> = ({ children }) 
   const [settings, setSettings] = React.useState(() => ({
     ...JSON.parse(JSON.stringify(DEFAULT_GLOBAL_SETTINGS)),
   }));
+  const jarvisClient = React.useMemo<JarvisCoreClient>(
+    () => ({
+      getHealth: vi.fn().mockResolvedValue({ status: 'ok' }),
+      listModels: vi.fn().mockResolvedValue([]),
+      downloadModel: vi.fn().mockResolvedValue({} as any),
+      activateModel: vi.fn().mockResolvedValue({} as any),
+      sendChat: vi.fn().mockResolvedValue({ message: 'demo', actions: [] }),
+      triggerAction: vi.fn().mockResolvedValue(undefined),
+    }),
+    [],
+  );
 
   return (
     <ProjectProvider settings={settings} onSettingsChange={setSettings}>
-      <AgentProvider apiKeys={{}}>
-        <PluginHostProvider settings={settings} onSettingsChange={setSettings}>
-          <MessageProvider apiKeys={{}}>
-            <RepoWorkflowProvider>{children}</RepoWorkflowProvider>
-          </MessageProvider>
-        </PluginHostProvider>
-      </AgentProvider>
+      <JarvisCoreProvider settings={settings} onSettingsChange={setSettings} clientOverride={jarvisClient}>
+        <AgentProvider apiKeys={{}}>
+          <PluginHostProvider settings={settings} onSettingsChange={setSettings}>
+            <MessageProvider apiKeys={{}}>
+              <RepoWorkflowProvider>{children}</RepoWorkflowProvider>
+            </MessageProvider>
+          </PluginHostProvider>
+        </AgentProvider>
+      </JarvisCoreProvider>
     </ProjectProvider>
   );
 };

--- a/src/components/repo/__tests__/RepoWorkflow.integration.test.tsx
+++ b/src/components/repo/__tests__/RepoWorkflow.integration.test.tsx
@@ -31,7 +31,12 @@ const messagesRef: { current: ChatMessage[] } = { current: [] };
 let setMockMessages: ((messages: ChatMessage[]) => void) | undefined;
 
 vi.mock('../../../core/messages/MessageContext', () => ({
-  useMessages: () => ({ messages: messagesRef.current }),
+  useMessages: () => ({
+    messages: messagesRef.current,
+    pendingActions: [],
+    triggerAction: vi.fn(),
+    rejectAction: vi.fn(),
+  }),
   MessageProvider: ({ children }: { children: React.ReactNode }) => <>{children}</>,
   __setMockMessages: (messages: ChatMessage[]) => {
     messagesRef.current = messages;

--- a/src/core/codex/__tests__/RepoWorkflowContext.test.tsx
+++ b/src/core/codex/__tests__/RepoWorkflowContext.test.tsx
@@ -18,6 +18,9 @@ vi.mock('../../messages/MessageContext', () => ({
         agentId: 'jarvis',
       },
     ],
+    pendingActions: [],
+    triggerAction: vi.fn(),
+    rejectAction: vi.fn(),
   }),
 }));
 

--- a/src/core/messages/__tests__/MessageContext.test.tsx
+++ b/src/core/messages/__tests__/MessageContext.test.tsx
@@ -33,18 +33,37 @@ import { AgentProvider } from '../../agents/AgentContext';
 import { MessageProvider, useMessages } from '../MessageContext';
 import { ProjectProvider } from '../../projects/ProjectContext';
 import { DEFAULT_GLOBAL_SETTINGS } from '../../../utils/globalSettings';
+import { JarvisCoreProvider } from '../../jarvis/JarvisCoreContext';
+import type { JarvisCoreClient } from '../../services/jarvisCoreClient';
 
 const createWrapper = (
   settingsFactory: () => typeof DEFAULT_GLOBAL_SETTINGS,
 ): React.FC<{ children: React.ReactNode }> => {
   return ({ children }) => {
     const [settings, setSettings] = React.useState(settingsFactory);
+    const jarvisClient = React.useMemo<JarvisCoreClient>(
+      () => ({
+        getHealth: vi.fn().mockResolvedValue({ status: 'ok' }),
+        listModels: vi.fn().mockResolvedValue([]),
+        downloadModel: vi.fn().mockResolvedValue({} as any),
+        activateModel: vi.fn().mockResolvedValue({} as any),
+        sendChat: vi.fn().mockResolvedValue({ message: 'stub', actions: [] }),
+        triggerAction: vi.fn().mockResolvedValue(undefined),
+      }),
+      [],
+    );
 
     return (
       <ProjectProvider settings={settings} onSettingsChange={setSettings}>
-        <AgentProvider apiKeys={{}}>
-          <MessageProvider apiKeys={{}}>{children}</MessageProvider>
-        </AgentProvider>
+        <JarvisCoreProvider
+          settings={settings}
+          onSettingsChange={setSettings}
+          clientOverride={jarvisClient}
+        >
+          <AgentProvider apiKeys={{}}>
+            <MessageProvider apiKeys={{}}>{children}</MessageProvider>
+          </AgentProvider>
+        </JarvisCoreProvider>
       </ProjectProvider>
     );
   };

--- a/src/core/messages/messageTypes.ts
+++ b/src/core/messages/messageTypes.ts
@@ -6,6 +6,8 @@ export type ChatVisibility = 'public' | 'internal';
 
 export type ChatModality = 'text' | 'image' | 'audio' | 'video' | 'file';
 
+export type ChatActionKind = 'open' | 'read' | 'run' | string;
+
 export interface ChatAttachment {
   id: string;
   type: 'image' | 'audio' | 'file';
@@ -72,6 +74,26 @@ export interface ChatMessage {
   orchestrationContext?: MultiAgentContext;
   sharedByMessageId?: string;
   canonicalCode?: string;
+  actions?: ChatMessageAction[];
+}
+
+export interface ChatSuggestedAction {
+  kind: ChatActionKind;
+  payload: Record<string, unknown>;
+  label?: string;
+  description?: string;
+  requiresConfirmation?: boolean;
+}
+
+export interface ChatMessageAction extends ChatSuggestedAction {
+  id: string;
+  status: 'pending' | 'accepted' | 'executing' | 'completed' | 'rejected' | 'failed';
+  createdAt: string;
+  updatedAt: string;
+  agentId?: string;
+  resultPreview?: string;
+  errorMessage?: string;
+  messageId?: string;
 }
 
 export interface MessageFeedback {

--- a/src/utils/aiProviders.ts
+++ b/src/utils/aiProviders.ts
@@ -2,6 +2,7 @@ import {
   ChatAttachment,
   ChatContentPart,
   ChatModality,
+  ChatSuggestedAction,
   ChatTranscription,
 } from '../core/messages/messageTypes';
 
@@ -21,6 +22,7 @@ export interface ChatProviderResponse {
   modalities: ChatModality[];
   attachments?: ChatAttachment[];
   transcriptions?: ChatTranscription[];
+  actions?: ChatSuggestedAction[];
 }
 
 const DEFAULT_MAX_TOKENS = 1024;


### PR DESCRIPTION
## Summary
- route local agents through Jarvis Core with streaming updates, action metadata and trace propagation
- expand the message context to manage Jarvis actions, persist decisions and automatically reconnect the local runtime
- surface Jarvis actions in the chat UI, including execution controls and styling, and wrap the app/tests with the JarvisCore provider

## Testing
- npm run test

------
https://chatgpt.com/codex/tasks/task_e_68cfd8bec3a0833391dc6934bc5f92fd