### PR TITLE
feat: enhance Jarvis Core monitoring UI

### DIFF
--- a/src/components/StatusBar.css
+++ b/src/components/StatusBar.css
@@ -36,6 +36,22 @@
   font-weight: 500;
 }
 
+.status-value.tone-positive {
+  color: #4ade80;
+}
+
+.status-value.tone-warning {
+  color: #facc15;
+}
+
+.status-value.tone-critical {
+  color: #f87171;
+}
+
+.status-value.tone-neutral {
+  color: #e2e8f0;
+}
+
 .audio-levels {
   display: flex;
   gap: 15px;

--- a/src/components/StatusBar.tsx
+++ b/src/components/StatusBar.tsx
@@ -9,48 +9,47 @@ interface StatusBarProps {
   audioData: AudioData;
 }
 
-export const StatusBar: React.FC<StatusBarProps> = ({
-  status,
-  fps,
-  currentPreset,
-  audioData
-}) => {
-  const getStatusColor = (status: string): string => {
-    if (status.includes('Error')) return '#ff4444';
-    if (status.includes('Ready')) return '#44ff44';
-    if (status.includes('Loading') || status.includes('Initializing')) return '#ffaa44';
-    return '#ffffff';
+export const StatusBar: React.FC<StatusBarProps> = ({ status, fps, currentPreset, audioData }) => {
+  const resolveToneFromStatus = (value: string): 'critical' | 'warning' | 'positive' | 'neutral' => {
+    const normalized = value.toLowerCase();
+    if (normalized.includes('error') || normalized.includes('fail')) {
+      return 'critical';
+    }
+    if (normalized.includes('ready') || normalized.includes('ok')) {
+      return 'positive';
+    }
+    if (normalized.includes('load') || normalized.includes('init')) {
+      return 'warning';
+    }
+    return 'neutral';
   };
 
-  const getFPSColor = (fps: number): string => {
-    if (fps >= 55) return '#44ff44';
-    if (fps >= 30) return '#ffaa44';
-    return '#ff4444';
+  const resolveToneFromFps = (value: number): 'critical' | 'warning' | 'positive' => {
+    if (value >= 55) {
+      return 'positive';
+    }
+    if (value >= 30) {
+      return 'warning';
+    }
+    return 'critical';
   };
+
+  const statusTone = resolveToneFromStatus(status);
+  const fpsTone = resolveToneFromFps(fps);
 
   return (
     <div className="status-bar">
       <div className="status-section">
         <div className="status-item">
           <span className="status-label">Status:</span>
-          <span 
-            className="status-value" 
-            style={{ color: getStatusColor(status) }}
-          >
-            {status}
-          </span>
+          <span className={`status-value tone-${statusTone}`}>{status}</span>
         </div>
-        
+
         <div className="status-item">
           <span className="status-label">FPS:</span>
-          <span 
-            className="status-value" 
-            style={{ color: getFPSColor(fps) }}
-          >
-            {fps}
-          </span>
+          <span className={`status-value tone-${fpsTone}`}>{fps}</span>
         </div>
-        
+
         <div className="status-item">
           <span className="status-label">Preset:</span>
           <span className="status-value">

--- a/src/components/chat/ChatInterface.css
+++ b/src/components/chat/ChatInterface.css
@@ -2074,9 +2074,93 @@
   font-size: 16px;
 }
 
+.icon-button.jarvis-runtime-button {
+  min-width: 40px;
+  width: auto;
+  height: 36px;
+  padding: 0 14px 0 10px;
+  border-radius: 999px;
+  display: inline-flex;
+  align-items: center;
+  justify-content: flex-start;
+  gap: 10px;
+  font-size: 13px;
+  line-height: 1.1;
+  background: rgba(255, 255, 255, 0.07);
+  border: 1px solid rgba(255, 255, 255, 0.12);
+}
+
+.icon-button.jarvis-runtime-button .jarvis-runtime-icon {
+  width: 24px;
+  height: 24px;
+  display: grid;
+  place-items: center;
+  border-radius: 999px;
+  background: rgba(255, 255, 255, 0.12);
+  font-size: 15px;
+}
+
+.icon-button.jarvis-runtime-button .jarvis-runtime-copy {
+  display: flex;
+  flex-direction: column;
+  align-items: flex-start;
+  gap: 2px;
+  color: inherit;
+}
+
+.jarvis-runtime-status {
+  font-size: 10px;
+  text-transform: uppercase;
+  letter-spacing: 0.6px;
+  opacity: 0.85;
+}
+
+.jarvis-runtime-uptime {
+  font-size: 13px;
+  font-weight: 600;
+  letter-spacing: 0.3px;
+}
+
+.icon-button.jarvis-runtime-button.status-ready {
+  background: rgba(52, 211, 153, 0.14);
+  border-color: rgba(52, 211, 153, 0.6);
+  color: #d1fae5;
+}
+
+.icon-button.jarvis-runtime-button.status-starting {
+  background: rgba(251, 191, 36, 0.18);
+  border-color: rgba(251, 191, 36, 0.6);
+  color: #fff3cd;
+}
+
+.icon-button.jarvis-runtime-button.status-offline,
+.icon-button.jarvis-runtime-button.status-error {
+  background: rgba(248, 113, 113, 0.18);
+  border-color: rgba(248, 113, 113, 0.6);
+  color: #fee2e2;
+}
+
+.icon-button.jarvis-runtime-button.is-busy {
+  cursor: progress;
+  opacity: 0.9;
+}
+
 .icon-button:hover {
   transform: translateY(-1px);
   background: rgba(142, 141, 255, 0.35);
+}
+
+.icon-button.jarvis-runtime-button.status-ready:hover {
+  background: rgba(52, 211, 153, 0.24);
+}
+
+.icon-button.jarvis-runtime-button.status-starting:hover {
+  background: rgba(251, 191, 36, 0.28);
+}
+
+.icon-button.jarvis-runtime-button.status-offline:hover,
+.icon-button.jarvis-runtime-button.status-error:hover {
+  background: rgba(248, 113, 113, 0.28);
 }
 
 .icon-button:disabled {

--- a/src/components/chat/ConversationStatsModal.css
+++ b/src/components/chat/ConversationStatsModal.css
@@ -119,3 +119,143 @@
   text-transform: uppercase;
   letter-spacing: 0.6px;
 }
+
+.conversation-stats__jarvis {
+  display: flex;
+  flex-direction: column;
+  gap: 14px;
+  padding: 16px;
+  border-radius: 14px;
+  background: rgba(255, 255, 255, 0.04);
+  border: 1px solid rgba(255, 255, 255, 0.08);
+}
+
+.conversation-stats__section-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  gap: 12px;
+}
+
+.conversation-stats__section-title {
+  font-size: 13px;
+  letter-spacing: 0.6px;
+  text-transform: uppercase;
+  color: rgba(255, 255, 255, 0.75);
+}
+
+.status-pill {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  padding: 4px 10px;
+  border-radius: 999px;
+  font-size: 11px;
+  font-weight: 600;
+  letter-spacing: 0.5px;
+  text-transform: uppercase;
+  background: rgba(255, 255, 255, 0.08);
+  color: rgba(255, 255, 255, 0.85);
+}
+
+.status-pill--success {
+  background: rgba(52, 211, 153, 0.18);
+  color: #d1fae5;
+}
+
+.status-pill--warning {
+  background: rgba(251, 191, 36, 0.22);
+  color: #fde68a;
+}
+
+.status-pill--danger {
+  background: rgba(248, 113, 113, 0.25);
+  color: #fecaca;
+}
+
+.status-pill--muted {
+  background: rgba(148, 163, 184, 0.18);
+  color: #e2e8f0;
+}
+
+.conversation-stats__jarvis-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(140px, 1fr));
+  gap: 12px;
+}
+
+.conversation-stats__jarvis-item {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+  padding: 10px 12px;
+  border-radius: 12px;
+  background: rgba(255, 255, 255, 0.03);
+  border: 1px solid rgba(255, 255, 255, 0.08);
+}
+
+.conversation-stats__downloads {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+}
+
+.conversation-stats__download-list {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+}
+
+.conversation-stats__download-item {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  gap: 12px;
+  padding: 8px 10px;
+  border-radius: 10px;
+  background: rgba(255, 255, 255, 0.05);
+}
+
+.conversation-stats__download-name {
+  font-size: 13px;
+  color: rgba(255, 255, 255, 0.88);
+}
+
+.conversation-stats__download-progress {
+  font-size: 12px;
+  font-weight: 600;
+  color: rgba(255, 255, 255, 0.78);
+}
+
+.conversation-stats__downloads-empty {
+  font-size: 12px;
+  color: rgba(255, 255, 255, 0.6);
+}
+
+.conversation-stats__jarvis-action {
+  align-self: flex-start;
+  padding: 8px 16px;
+  border-radius: 999px;
+  border: 1px solid rgba(255, 255, 255, 0.2);
+  background: rgba(255, 255, 255, 0.08);
+  color: rgba(255, 255, 255, 0.92);
+  font-size: 12px;
+  text-transform: uppercase;
+  letter-spacing: 0.8px;
+  cursor: pointer;
+  transition: background 0.2s ease, border 0.2s ease, transform 0.2s ease;
+}
+
+.conversation-stats__jarvis-action:hover:not(:disabled) {
+  transform: translateY(-1px);
+  background: rgba(142, 141, 255, 0.25);
+  border-color: rgba(142, 141, 255, 0.5);
+}
+
+.conversation-stats__jarvis-action:disabled {
+  opacity: 0.6;
+  cursor: progress;
+}

--- a/src/components/chat/ConversationStatsModal.tsx
+++ b/src/components/chat/ConversationStatsModal.tsx
@@ -1,8 +1,9 @@
-import React, { useMemo } from 'react';
+import React, { useCallback, useMemo, useState } from 'react';
 import './ConversationStatsModal.css';
 import { OverlayModal } from '../common/OverlayModal';
 import { useMessages } from '../../core/messages/MessageContext';
 import { ChatAuthor } from '../../core/messages/messageTypes';
+import { useJarvisCore } from '../../core/jarvis/JarvisCoreContext';
 
 interface ConversationStatsModalProps {
   isOpen: boolean;
@@ -17,6 +18,17 @@ interface AuthorBreakdown {
 
 export const ConversationStatsModal: React.FC<ConversationStatsModalProps> = ({ isOpen, onClose }) => {
   const { messages, pendingResponses, formatTimestamp } = useMessages();
+  const {
+    config,
+    runtimeStatus,
+    lastError,
+    lastHealthMessage,
+    activeModel,
+    downloads,
+    uptimeMs,
+    ensureOnline,
+  } = useJarvisCore();
+  const [retrying, setRetrying] = useState(false);
 
   const stats = useMemo(() => {
     const publicMessages = messages.filter(message => message.visibility !== 'internal');
@@ -49,6 +61,51 @@ export const ConversationStatsModal: React.FC<ConversationStatsModalProps> = ({ 
   const lastDate = stats.lastMessage ? new Date(stats.lastMessage.timestamp) : null;
   const lastAbsoluteTimestamp =
     lastDate && !Number.isNaN(lastDate.getTime()) ? lastDate.toLocaleString() : null;
+
+  const jarvisStatusLabel = useMemo(() => {
+    switch (runtimeStatus) {
+      case 'ready':
+        return { label: 'Operativo', tone: 'success' } as const;
+      case 'starting':
+        return { label: 'Iniciando', tone: 'warning' } as const;
+      case 'error':
+        return { label: 'Con incidencias', tone: 'danger' } as const;
+      default:
+        return { label: 'Sin conexión', tone: 'muted' } as const;
+    }
+  }, [runtimeStatus]);
+
+  const jarvisHint = lastError ?? lastHealthMessage ?? 'Servicio listo para recibir peticiones.';
+
+  const activeDownloads = useMemo(() => Object.values(downloads), [downloads]);
+
+  const uptimeLabel = useMemo(() => {
+    if (!uptimeMs || uptimeMs <= 0) {
+      return 'Sin datos de actividad';
+    }
+    const totalSeconds = Math.floor(uptimeMs / 1000);
+    const days = Math.floor(totalSeconds / 86400);
+    const hours = Math.floor((totalSeconds % 86400) / 3600);
+    const minutes = Math.floor((totalSeconds % 3600) / 60);
+    const seconds = totalSeconds % 60;
+
+    if (days > 0) {
+      return `${days} día${days === 1 ? '' : 's'} · ${hours.toString().padStart(2, '0')}h`;
+    }
+    if (hours > 0) {
+      return `${hours}h ${minutes.toString().padStart(2, '0')}m`;
+    }
+    return `${minutes}m ${seconds.toString().padStart(2, '0')}s`;
+  }, [uptimeMs]);
+
+  const handleRetry = useCallback(async () => {
+    setRetrying(true);
+    try {
+      await ensureOnline();
+    } finally {
+      setRetrying(false);
+    }
+  }, [ensureOnline]);
 
   return (
     <OverlayModal
@@ -99,6 +156,64 @@ export const ConversationStatsModal: React.FC<ConversationStatsModalProps> = ({ 
               )}
             </span>
           </div>
+        </div>
+
+        <div className="conversation-stats__jarvis" role="region" aria-label="Estado de Jarvis Core">
+          <div className="conversation-stats__section-header">
+            <span className="conversation-stats__section-title">JarvisCore</span>
+            <span className={`status-pill status-pill--${jarvisStatusLabel.tone}`} title={jarvisHint}>
+              {jarvisStatusLabel.label}
+            </span>
+          </div>
+          <div className="conversation-stats__jarvis-grid">
+            <div className="conversation-stats__jarvis-item">
+              <span className="conversation-stats__meta-label">Host</span>
+              <span className="conversation-stats__meta-value">{config.host || '127.0.0.1'}</span>
+            </div>
+            <div className="conversation-stats__jarvis-item">
+              <span className="conversation-stats__meta-label">Puerto</span>
+              <span className="conversation-stats__meta-value">{config.port}</span>
+            </div>
+            <div className="conversation-stats__jarvis-item">
+              <span className="conversation-stats__meta-label">Modelo activo</span>
+              <span className="conversation-stats__meta-value">{activeModel ?? 'Sin asignar'}</span>
+            </div>
+            <div className="conversation-stats__jarvis-item">
+              <span className="conversation-stats__meta-label">Actividad</span>
+              <span className="conversation-stats__meta-value">{uptimeLabel}</span>
+            </div>
+          </div>
+          <div className="conversation-stats__downloads">
+            <span className="conversation-stats__meta-label">Descargas en curso</span>
+            {activeDownloads.length ? (
+              <ul className="conversation-stats__download-list">
+                {activeDownloads.map(entry => {
+                  const progress =
+                    typeof entry.percent === 'number' && Number.isFinite(entry.percent)
+                      ? `${Math.round(entry.percent)}%`
+                      : entry.total && entry.total > 0
+                      ? `${Math.round((entry.downloaded / entry.total) * 100)}%`
+                      : entry.status;
+                  return (
+                    <li key={entry.modelId} className="conversation-stats__download-item">
+                      <span className="conversation-stats__download-name">{entry.modelId}</span>
+                      <span className="conversation-stats__download-progress">{progress}</span>
+                    </li>
+                  );
+                })}
+              </ul>
+            ) : (
+              <span className="conversation-stats__downloads-empty">Sin transferencias activas</span>
+            )}
+          </div>
+          <button
+            type="button"
+            className="conversation-stats__jarvis-action"
+            onClick={handleRetry}
+            disabled={retrying}
+          >
+            {retrying ? 'Reconectando…' : 'Reintentar conexión'}
+          </button>
         </div>
       </div>
     </OverlayModal>

--- a/src/components/chat/__tests__/ChatTopBar.test.tsx
+++ b/src/components/chat/__tests__/ChatTopBar.test.tsx
@@ -1,0 +1,133 @@
+import React from 'react';
+import { describe, it, expect, afterEach, beforeEach, vi } from 'vitest';
+import { fireEvent, render, screen } from '@testing-library/react';
+import '@testing-library/jest-dom/vitest';
+import { ChatTopBar } from '../ChatTopBar';
+import type { AgentDefinition } from '../../../core/agents/agentRegistry';
+import type { AgentPresenceSummary } from '../../../core/agents/presence';
+import type { ChatActorFilter } from '../../../types/chat';
+import type { JarvisCoreContextValue, JarvisRuntimeStatus } from '../../../core/jarvis/JarvisCoreContext';
+import { DEFAULT_GLOBAL_SETTINGS } from '../../../utils/globalSettings';
+
+const useJarvisCoreMock = vi.fn<JarvisCoreContextValue, []>();
+const useProjectsMock = vi.fn();
+
+vi.mock('../../../core/jarvis/JarvisCoreContext', async () => {
+  const actual = await vi.importActual<typeof import('../../../core/jarvis/JarvisCoreContext')>(
+    '../../../core/jarvis/JarvisCoreContext',
+  );
+  return {
+    ...actual,
+    useJarvisCore: () => useJarvisCoreMock(),
+  };
+});
+
+vi.mock('../../../core/projects/ProjectContext', () => ({
+  useProjects: () => useProjectsMock(),
+}));
+
+const basePresence: AgentPresenceSummary = {
+  totals: { online: 0, offline: 0, loading: 0, error: 0 },
+  byKind: {
+    cloud: { total: 0, active: 0, online: 0, offline: 0, loading: 0, error: 0 },
+    local: { total: 0, active: 0, online: 0, offline: 0, loading: 0, error: 0 },
+  },
+};
+
+const defaultJarvisState = (overrides: Partial<JarvisCoreContextValue> = {}): JarvisCoreContextValue => ({
+  connected: false,
+  lastError: null,
+  activeModel: null,
+  downloads: {},
+  models: [],
+  runtimeStatus: 'offline',
+  uptimeMs: null,
+  config: DEFAULT_GLOBAL_SETTINGS.jarvisCore,
+  baseUrl: 'http://127.0.0.1:8000',
+  lastHealthMessage: null,
+  ensureOnline: vi.fn(),
+  refreshModels: vi.fn(),
+  downloadModel: vi.fn(),
+  activateModel: vi.fn(),
+  invokeChat: vi.fn(),
+  launchAction: vi.fn(),
+  ...overrides,
+});
+
+const renderComponent = (props?: Partial<{ filter: ChatActorFilter; presence: AgentPresenceSummary }>) => {
+  return render(
+    <ChatTopBar
+      agents={[] as AgentDefinition[]}
+      presenceSummary={props?.presence ?? basePresence}
+      activeAgents={0}
+      totalAgents={0}
+      pendingResponses={0}
+      activeFilter={props?.filter ?? 'all'}
+      onFilterChange={vi.fn()}
+      onRefreshPresence={vi.fn()}
+      onOpenStats={vi.fn()}
+      onOpenGlobalSettings={vi.fn()}
+      onOpenPlugins={vi.fn()}
+      onOpenMcp={vi.fn()}
+      onOpenModelManager={vi.fn()}
+      activeView="chat"
+      onChangeView={vi.fn()}
+    />,
+  );
+};
+
+describe('ChatTopBar', () => {
+  beforeEach(() => {
+    useProjectsMock.mockReturnValue({
+      projects: [],
+      activeProjectId: null,
+      activeProject: null,
+      selectProject: vi.fn(),
+    });
+  });
+
+  afterEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('permite relanzar la conexión de Jarvis Core', async () => {
+    const ensureOnline = vi.fn().mockResolvedValue(undefined);
+    useJarvisCoreMock.mockReturnValue(defaultJarvisState({ ensureOnline }));
+
+    renderComponent();
+
+    const jarvisButton = screen.getByRole('button', { name: /Jarvis Core desconectado/i });
+    fireEvent.click(jarvisButton);
+
+    expect(ensureOnline).toHaveBeenCalled();
+  });
+
+  const jarvisStates: Array<{ status: JarvisRuntimeStatus; uptimeMs: number | null; snapshot: string }>
+    = [
+      { status: 'ready', uptimeMs: 90 * 60 * 1000, snapshot: 'ready-state' },
+      { status: 'starting', uptimeMs: null, snapshot: 'starting-state' },
+      { status: 'error', uptimeMs: 5 * 1000, snapshot: 'error-state' },
+    ];
+
+  it.each(jarvisStates)(
+    'renderiza el estado visual de Jarvis Core: %s',
+    ({ status, uptimeMs, snapshot }) => {
+      useJarvisCoreMock.mockReturnValue(
+        defaultJarvisState({ runtimeStatus: status, uptimeMs, lastError: status === 'error' ? 'Fallo' : null }),
+      );
+
+      const { container } = renderComponent();
+      const runtimeButton = container.querySelector('.jarvis-runtime-button');
+      expect(runtimeButton).toBeInTheDocument();
+      expect(runtimeButton).toMatchSnapshot(snapshot);
+    },
+  );
+
+  it('muestra el contador de actividad cuando está disponible', () => {
+    useJarvisCoreMock.mockReturnValue(defaultJarvisState({ runtimeStatus: 'ready', uptimeMs: 3_650_000 }));
+
+    renderComponent();
+
+    expect(screen.getByText(/↑ 1h 00m/i)).toBeInTheDocument();
+  });
+});

--- a/src/components/chat/__tests__/ConversationStatsModal.test.tsx
+++ b/src/components/chat/__tests__/ConversationStatsModal.test.tsx
@@ -1,0 +1,73 @@
+import React from 'react';
+import { describe, expect, it, vi } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import '@testing-library/jest-dom/vitest';
+import { ConversationStatsModal } from '../ConversationStatsModal';
+import type { JarvisCoreContextValue } from '../../../core/jarvis/JarvisCoreContext';
+import { DEFAULT_GLOBAL_SETTINGS } from '../../../utils/globalSettings';
+
+const useMessagesMock = vi.fn();
+const useJarvisCoreMock = vi.fn<JarvisCoreContextValue, []>();
+
+vi.mock('../../../core/messages/MessageContext', () => ({
+  useMessages: () => useMessagesMock(),
+}));
+
+vi.mock('../../../core/jarvis/JarvisCoreContext', async () => {
+  const actual = await vi.importActual<typeof import('../../../core/jarvis/JarvisCoreContext')>(
+    '../../../core/jarvis/JarvisCoreContext',
+  );
+  return {
+    ...actual,
+    useJarvisCore: () => useJarvisCoreMock(),
+  };
+});
+
+describe('ConversationStatsModal', () => {
+  it('muestra el estado de Jarvis Core y permite reintentar la conexión', () => {
+    const now = new Date().toISOString();
+    const later = new Date(Date.now() + 1000).toISOString();
+    useMessagesMock.mockReturnValue({
+      messages: [
+        { id: '1', author: 'user', content: 'hola', timestamp: now, visibility: 'public' },
+        { id: '2', author: 'agent', content: 'respuesta', timestamp: later, visibility: 'public' },
+      ],
+      pendingResponses: 1,
+      formatTimestamp: (value: number) => new Date(value).toLocaleTimeString('es-ES'),
+    });
+
+    const ensureOnline = vi.fn().mockResolvedValue(undefined);
+    useJarvisCoreMock.mockReturnValue({
+      connected: true,
+      lastError: null,
+      activeModel: 'phi-2',
+      downloads: {
+        phi: { modelId: 'phi', status: 'downloading', downloaded: 512, total: 1024, percent: 50, error: null, errorCode: null },
+      },
+      models: [],
+      runtimeStatus: 'ready',
+      uptimeMs: 12_000,
+      config: DEFAULT_GLOBAL_SETTINGS.jarvisCore,
+      baseUrl: 'http://127.0.0.1:8000',
+      lastHealthMessage: 'ok',
+      ensureOnline,
+      refreshModels: vi.fn(),
+      downloadModel: vi.fn(),
+      activateModel: vi.fn(),
+      invokeChat: vi.fn(),
+      launchAction: vi.fn(),
+    });
+
+    const { container } = render(<ConversationStatsModal isOpen onClose={vi.fn()} />);
+
+    expect(screen.getByText('JarvisCore')).toBeInTheDocument();
+    expect(screen.getByText(/phi-2/)).toBeInTheDocument();
+    expect(screen.getByText(/50%/)).toBeInTheDocument();
+
+    const button = screen.getByRole('button', { name: /Reintentar conexión/i });
+    button.click();
+    expect(ensureOnline).toHaveBeenCalled();
+
+    expect(container.querySelector('.conversation-stats__jarvis')).toMatchSnapshot('jarvis-section');
+  });
+});

--- a/src/components/chat/__tests__/SidePanel.test.tsx
+++ b/src/components/chat/__tests__/SidePanel.test.tsx
@@ -9,9 +9,11 @@ import { ProjectProvider, useProjects } from '../../../core/projects/ProjectCont
 import { DEFAULT_GLOBAL_SETTINGS } from '../../../utils/globalSettings';
 import type { AgentPresenceEntry, AgentPresenceSummary } from '../../../core/agents/presence';
 import type { AgentDefinition } from '../../../core/agents/agentRegistry';
+import type { JarvisCoreContextValue } from '../../../core/jarvis/JarvisCoreContext';
 
 const mockUseAgents = vi.fn();
 const mockUseAgentPresence = vi.fn();
+const useJarvisCoreMock = vi.fn<JarvisCoreContextValue, []>();
 
 vi.mock('../../../core/agents/AgentContext', () => ({
   useAgents: () => mockUseAgents(),
@@ -30,6 +32,16 @@ vi.mock('../../../core/plugins/PluginHostProvider', () => ({
     updatePluginSettings: vi.fn(),
   }),
 }));
+
+vi.mock('../../../core/jarvis/JarvisCoreContext', async () => {
+  const actual = await vi.importActual<typeof import('../../../core/jarvis/JarvisCoreContext')>(
+    '../../../core/jarvis/JarvisCoreContext',
+  );
+  return {
+    ...actual,
+    useJarvisCore: () => useJarvisCoreMock(),
+  };
+});
 
 const ProjectProbe: React.FC = () => {
   const { activeProject, projects } = useProjects();
@@ -76,6 +88,27 @@ const presenceSummary: AgentPresenceSummary = {
     local: { total: 0, online: 0, loading: 0, offline: 0, error: 0 },
   },
 };
+
+beforeEach(() => {
+  useJarvisCoreMock.mockReturnValue({
+    connected: false,
+    lastError: null,
+    activeModel: null,
+    downloads: {},
+    models: [],
+    runtimeStatus: 'offline',
+    uptimeMs: null,
+    config: DEFAULT_GLOBAL_SETTINGS.jarvisCore,
+    baseUrl: 'http://127.0.0.1:8000',
+    lastHealthMessage: null,
+    ensureOnline: vi.fn(),
+    refreshModels: vi.fn(),
+    downloadModel: vi.fn(),
+    activateModel: vi.fn(),
+    invokeChat: vi.fn(),
+    launchAction: vi.fn(),
+  });
+});
 
 const buildAgent = (overrides: Partial<AgentDefinition>): AgentDefinition => ({
   id: 'agent-id',

--- a/src/components/chat/__tests__/__snapshots__/ChatTopBar.test.tsx.snap
+++ b/src/components/chat/__tests__/__snapshots__/ChatTopBar.test.tsx.snap
@@ -1,0 +1,89 @@
+// Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
+
+exports[`ChatTopBar > renderiza el estado visual de Jarvis Core: { status: 'error', uptimeMs: 5000, snapshot: 'error-state' } > error-state 1`] = `
+<button
+  aria-label="Jarvis Core con incidencias. Tiempo en línea: 0 minutos y 5 segundos"
+  class="icon-button jarvis-runtime-button status-error"
+  title="Jarvis Core con incidencias · Fallo"
+  type="button"
+>
+  <span
+    aria-hidden="true"
+    class="jarvis-runtime-icon"
+  >
+    🤖
+  </span>
+  <span
+    aria-hidden="true"
+    class="jarvis-runtime-copy"
+  >
+    <span
+      class="jarvis-runtime-status"
+    >
+      Jarvis Core con incidencias
+    </span>
+    <span
+      class="jarvis-runtime-uptime"
+    >
+      ↑ 0m 05s
+    </span>
+  </span>
+</button>
+`;
+
+exports[`ChatTopBar > renderiza el estado visual de Jarvis Core: { status: 'ready', uptimeMs: 5400000, snapshot: 'ready-state' } > ready-state 1`] = `
+<button
+  aria-label="Jarvis Core operativo. Tiempo en línea: 1 hora y 30 minutos"
+  class="icon-button jarvis-runtime-button status-ready"
+  title="Jarvis Core operativo"
+  type="button"
+>
+  <span
+    aria-hidden="true"
+    class="jarvis-runtime-icon"
+  >
+    🤖
+  </span>
+  <span
+    aria-hidden="true"
+    class="jarvis-runtime-copy"
+  >
+    <span
+      class="jarvis-runtime-status"
+    >
+      Jarvis Core operativo
+    </span>
+    <span
+      class="jarvis-runtime-uptime"
+    >
+      ↑ 1h 30m
+    </span>
+  </span>
+</button>
+`;
+
+exports[`ChatTopBar > renderiza el estado visual de Jarvis Core: { status: 'starting', uptimeMs: null, snapshot: 'starting-state' } > starting-state 1`] = `
+<button
+  aria-label="Jarvis Core iniciando…"
+  class="icon-button jarvis-runtime-button status-starting"
+  title="Jarvis Core iniciando…"
+  type="button"
+>
+  <span
+    aria-hidden="true"
+    class="jarvis-runtime-icon"
+  >
+    🤖
+  </span>
+  <span
+    aria-hidden="true"
+    class="jarvis-runtime-copy"
+  >
+    <span
+      class="jarvis-runtime-status"
+    >
+      Jarvis Core iniciando…
+    </span>
+  </span>
+</button>
+`;

--- a/src/components/chat/__tests__/__snapshots__/ConversationStatsModal.test.tsx.snap
+++ b/src/components/chat/__tests__/__snapshots__/ConversationStatsModal.test.tsx.snap
@@ -1,0 +1,118 @@
+// Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
+
+exports[`ConversationStatsModal > muestra el estado de Jarvis Core y permite reintentar la conexión > jarvis-section 1`] = `
+<div
+  aria-label="Estado de Jarvis Core"
+  class="conversation-stats__jarvis"
+  role="region"
+>
+  <div
+    class="conversation-stats__section-header"
+  >
+    <span
+      class="conversation-stats__section-title"
+    >
+      JarvisCore
+    </span>
+    <span
+      class="status-pill status-pill--success"
+      title="ok"
+    >
+      Operativo
+    </span>
+  </div>
+  <div
+    class="conversation-stats__jarvis-grid"
+  >
+    <div
+      class="conversation-stats__jarvis-item"
+    >
+      <span
+        class="conversation-stats__meta-label"
+      >
+        Host
+      </span>
+      <span
+        class="conversation-stats__meta-value"
+      >
+        127.0.0.1
+      </span>
+    </div>
+    <div
+      class="conversation-stats__jarvis-item"
+    >
+      <span
+        class="conversation-stats__meta-label"
+      >
+        Puerto
+      </span>
+      <span
+        class="conversation-stats__meta-value"
+      >
+        8000
+      </span>
+    </div>
+    <div
+      class="conversation-stats__jarvis-item"
+    >
+      <span
+        class="conversation-stats__meta-label"
+      >
+        Modelo activo
+      </span>
+      <span
+        class="conversation-stats__meta-value"
+      >
+        phi-2
+      </span>
+    </div>
+    <div
+      class="conversation-stats__jarvis-item"
+    >
+      <span
+        class="conversation-stats__meta-label"
+      >
+        Actividad
+      </span>
+      <span
+        class="conversation-stats__meta-value"
+      >
+        0m 12s
+      </span>
+    </div>
+  </div>
+  <div
+    class="conversation-stats__downloads"
+  >
+    <span
+      class="conversation-stats__meta-label"
+    >
+      Descargas en curso
+    </span>
+    <ul
+      class="conversation-stats__download-list"
+    >
+      <li
+        class="conversation-stats__download-item"
+      >
+        <span
+          class="conversation-stats__download-name"
+        >
+          phi
+        </span>
+        <span
+          class="conversation-stats__download-progress"
+        >
+          50%
+        </span>
+      </li>
+    </ul>
+  </div>
+  <button
+    class="conversation-stats__jarvis-action"
+    type="button"
+  >
+    Reintentar conexión
+  </button>
+</div>
+`;

--- a/src/core/jarvis/__tests__/JarvisCoreContext.test.tsx
+++ b/src/core/jarvis/__tests__/JarvisCoreContext.test.tsx
@@ -21,7 +21,7 @@ type ClientMock = {
 };
 
 const createClientStub = (): ClientMock => ({
-  getHealth: vi.fn().mockResolvedValue({ status: 'ok' }),
+  getHealth: vi.fn().mockResolvedValue({ status: 'ok', uptime_seconds: 12 }),
   listModels: vi.fn().mockResolvedValue([] as JarvisModelInfo[]),
   downloadModel: vi.fn(),
   activateModel: vi.fn(),
@@ -178,5 +178,20 @@ describe('JarvisCoreContext', () => {
 
     expect(client.listModels).toHaveBeenCalledTimes(2);
     vi.useRealTimers();
+  });
+
+  it('normaliza el estado del runtime y el tiempo de actividad', async () => {
+    const client = createClientStub();
+    const wrapper = createWrapper(client);
+
+    const { result } = renderHook(() => useJarvisCore(), { wrapper });
+
+    await act(async () => {
+      await result.current.ensureOnline();
+    });
+
+    expect(result.current.runtimeStatus).toBe('ready');
+    expect(result.current.uptimeMs).toBe(12000);
+    expect(result.current.lastHealthMessage).toBeNull();
   });
 });

--- a/src/services/jarvisCoreClient.ts
+++ b/src/services/jarvisCoreClient.ts
@@ -67,8 +67,18 @@ export interface RequestOptions {
   signal?: AbortSignal;
 }
 
+export interface JarvisHealthResponse {
+  status?: string;
+  uptime?: number | null;
+  uptime_seconds?: number | null;
+  uptime_ms?: number | null;
+  uptimeMs?: number | null;
+  message?: string;
+  detail?: string;
+}
+
 export interface JarvisCoreClient {
-  getHealth: (options?: RequestOptions) => Promise<{ status: string }>;
+  getHealth: (options?: RequestOptions) => Promise<JarvisHealthResponse>;
   listModels: (options?: RequestOptions) => Promise<JarvisModelInfo[]>;
   downloadModel: (
     modelId: string,
@@ -242,7 +252,7 @@ export const createJarvisCoreClient = ({
         method: 'GET',
         signal: options?.signal,
       });
-      return parseJson<{ status: string }>(response);
+      return parseJson<JarvisHealthResponse>(response);
     },
 
     async listModels(options) {


### PR DESCRIPTION
## Summary
- expose runtime status, uptime and host information from the Jarvis Core context to drive UI feedback and retries
- add a Jarvis Core control in the chat top bar with state-aware styling plus updated status bar tones
- surface Jarvis Core diagnostics inside the conversation statistics modal and add snapshot coverage for new visual states

## Testing
- npm test -- --run

------
https://chatgpt.com/codex/tasks/task_e_68cfe1d014788333969c2f5244888059