### PR TITLE
Add Jarvis Core configuration controls

### DIFF
--- a/src/components/settings/GlobalSettingsDialog.css
+++ b/src/components/settings/GlobalSettingsDialog.css
@@ -170,6 +170,19 @@
   color: #fff;
 }
 
+.jarvis-core-toggles {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+
+.jarvis-core-toggle {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  font-size: 13px;
+}
+
 .plugin-settings-empty,
 .mcp-settings-empty {
   font-size: 13px;

--- a/src/types/globalSettings.ts
+++ b/src/types/globalSettings.ts
@@ -11,7 +11,9 @@ export type ApiKeySettings = Record<string, string>;
 export interface JarvisCoreSettings {
   host: string;
   port: number;
+  useHttps?: boolean;
   autoStart: boolean;
+  apiKey?: string;
 }
 
 export type McpTransport = 'ws' | 'osc' | 'rest';


### PR DESCRIPTION
## Summary
- extend the global settings schema to track Jarvis Core HTTPS, API key and updated defaults
- add Jarvis Core configuration sections with validation to the settings panel and dialog
- refresh the Jarvis Core provider logic and tests to respect the new connection options

## Testing
- pnpm test -- --runInBand

------
https://chatgpt.com/codex/tasks/task_e_68cfe58f8a5c83338d36c32c6bfae439