### PR TITLE
Add automated Jarvis Core tests and documentation

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,39 @@
+name: CI
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+          cache: 'npm'
+
+      - name: Install npm dependencies
+        run: npm ci
+
+      - name: Run frontend tests
+        run: npm test
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.10'
+
+      - name: Install Python dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install -r requirements.txt
+
+      - name: Run Jarvis Core tests
+        run: pytest

--- a/README.md
+++ b/README.md
@@ -39,6 +39,8 @@ Al iniciar la versión de escritorio se detectan instalaciones previas en el dir
 - Las builds de escritorio incluyen la carpeta `jarvis_core` como recurso cuando está presente en el repositorio. En desarrollo puedes forzar una ubicación distinta mediante `JARVISCORE_DIR=/ruta/a/JarvisCore npm run dev`.
 - El intérprete de Python se resuelve con la variable `JARVISCORE_PYTHON`. Si no está definida se prueban `python3` y `python`. Asegúrate de instalar las dependencias listadas en `requirements.txt` antes de iniciar el servicio.
 - Cuando **Auto-arranque** está activado, la aplicación invoca los comandos `jarvis_start`, `jarvis_stop` y `jarvis_status` (o sus equivalentes IPC en Electron) para crear, supervisar y apagar el proceso de Jarvis Core. Al cerrar la app se envía un `shutdown` automático para evitar procesos huérfanos.
+- Consulta la guía [Jarvis Core en desarrollo local](docs/jarvis-core.md) para ver los requisitos, opciones de configuración y consejos de seguridad.
+- Para ejecutar Jarvis Core manualmente en paralelo a la interfaz puedes usar `npm run jarvis:dev` en una terminal y `npm run dev` en otra.
 
 ## Tokens y credenciales seguras
 
@@ -52,4 +54,10 @@ Ejecuta toda la batería de tests con:
 
 ```bash
 npm test
+```
+
+Los tests de la API de Jarvis Core se ejecutan con `pytest`:
+
+```bash
+pytest
 ```

--- a/docs/jarvis-core.md
+++ b/docs/jarvis-core.md
@@ -1,0 +1,65 @@
+# Jarvis Core en desarrollo local
+
+Jarvis Core es un servicio FastAPI que expone los modelos locales y utilidades de automatización para la interfaz de JungleMonkAI. Esta guía resume los requisitos y el flujo básico para ejecutarlo en paralelo al frontend durante el desarrollo.
+
+## Requisitos
+
+- Python **3.10** o superior.
+- Herramientas de compilación adecuadas para los bindings utilizados por los modelos (por ejemplo, `build-essential` en Linux).
+- Dependencias listadas en [`requirements.txt`](../requirements.txt).
+
+Se recomienda crear un entorno virtual dedicado:
+
+```bash
+python3 -m venv .venv
+source .venv/bin/activate  # En Windows usa `.venv\\Scripts\\activate`
+python -m pip install --upgrade pip
+pip install -r requirements.txt
+```
+
+## Estructura y directorios
+
+Jarvis Core espera encontrar los modelos descargados en un directorio dedicado. Por defecto el servicio utiliza la ruta indicada en el parámetro `--models-dir`. El repositorio incluye una carpeta `models/` vacía para facilitar las pruebas locales.
+
+## Inicio del servicio
+
+Puedes lanzar el servicio manualmente con:
+
+```bash
+python jarvis_core/JarvisCore.py --models-dir ./models
+```
+
+Parámetros útiles:
+
+- `--host` y `--port` controlan la IP y el puerto de escucha (por defecto `0.0.0.0:8000`).
+- `--token` activa la autenticación por cabecera `Authorization`.
+- `--no-auto-start` valida la configuración sin arrancar el servidor (útil en CI).
+
+Las mismas opciones pueden definirse mediante variables de entorno con el prefijo `JARVIS_CORE_` (por ejemplo, `JARVIS_CORE_PORT=9000`). Cuando existe un fichero `jarvis_core/config.json`, sus valores se combinan con los de entorno y CLI siguiendo el orden descrito en el propio módulo.
+
+## Ejecución junto al frontend
+
+El paquete `package.json` expone el script `jarvis:dev` para arrancar Jarvis Core mientras se trabaja en la interfaz:
+
+```bash
+npm run jarvis:dev
+```
+
+En otra terminal inicia la aplicación web o de escritorio con `npm run dev` o `npm run tauri dev`. El frontend detectará el backend local usando la configuración almacenada en **Ajustes globales → Jarvis Core**.
+
+## Configuración desde la aplicación
+
+Desde la UI puedes indicar:
+
+- Host, puerto y protocolo (`http`/`https`).
+- Si la app debe intentar iniciar Jarvis Core automáticamente.
+- El token de autenticación (se envía en la cabecera `Authorization`).
+
+Los cambios se guardan en la configuración global de JungleMonkAI y se utilizan para construir la URL base del cliente (`http[s]://host:puerto`).
+
+## Consideraciones de seguridad
+
+- Define un token (`--token` o `JARVIS_CORE_TOKEN`) cuando expongas el servicio fuera de `localhost`.
+- Limita el puerto a redes de confianza o utiliza un túnel seguro si necesitas acceso remoto.
+- Revisa los permisos de los directorios compartidos: Jarvis Core solo puede operar dentro de `cwd` y del directorio de modelos configurado.
+- Los registros (`/logs`) ocultan el token automáticamente para evitar filtraciones accidentales.

--- a/package.json
+++ b/package.json
@@ -10,7 +10,8 @@
     "tauri": "tauri",
     "electron": "vite build && electron ./electron.cjs",
     "electron:package": "vite build && electron-builder",
-    "test": "vitest"
+    "test": "vitest",
+    "jarvis:dev": "python jarvis_core/JarvisCore.py --models-dir ./models"
   },
   "dependencies": {
     "@tauri-apps/api": "^1.5.0",

--- a/requirements.txt
+++ b/requirements.txt
@@ -9,3 +9,4 @@ pydantic>=2.8.2
 huggingface_hub>=0.25.2
 anyio>=4.4.0
 psutil>=5.9.8
+pytest>=7.4

--- a/src/components/chat/messages/__tests__/JarvisActionControls.test.tsx
+++ b/src/components/chat/messages/__tests__/JarvisActionControls.test.tsx
@@ -1,0 +1,71 @@
+import React from 'react';
+import { describe, it, expect, vi, afterEach } from 'vitest';
+import { cleanup, fireEvent, render, screen } from '@testing-library/react';
+import '@testing-library/jest-dom/vitest';
+
+import { JarvisActionControls } from '../MessageActions';
+import type { ChatMessageAction } from '../../../../core/messages/messageTypes';
+
+const baseAction = (overrides: Partial<ChatMessageAction> = {}): ChatMessageAction => ({
+  id: 'action-1',
+  kind: 'open',
+  payload: { path: '/tmp' },
+  label: 'Abrir archivo',
+  description: 'Abre el recurso en el explorador',
+  status: 'pending',
+  createdAt: new Date().toISOString(),
+  updatedAt: new Date().toISOString(),
+  ...overrides,
+});
+
+afterEach(() => {
+  cleanup();
+});
+
+describe('JarvisActionControls', () => {
+  it('muestra las acciones disponibles y permite ejecutarlas', () => {
+    const handleTrigger = vi.fn();
+    const handleReject = vi.fn();
+
+    render(
+      <JarvisActionControls action={baseAction()} onTrigger={handleTrigger} onReject={handleReject} />,
+    );
+
+    const triggerButton = screen.getByRole('button', { name: 'Ejecutar' });
+    const rejectButton = screen.getByRole('button', { name: 'Descartar' });
+
+    fireEvent.click(triggerButton);
+    fireEvent.click(rejectButton);
+
+    expect(handleTrigger).toHaveBeenCalledWith('action-1');
+    expect(handleReject).toHaveBeenCalledWith('action-1');
+  });
+
+  it('indica el progreso cuando la acción está en ejecución', () => {
+    render(
+      <JarvisActionControls
+        action={baseAction({ status: 'executing', label: 'Sincronizar', description: undefined })}
+      />,
+    );
+
+    expect(screen.queryByRole('button', { name: 'Descartar' })).not.toBeInTheDocument();
+    expect(screen.getByText('Procesando…')).toBeInTheDocument();
+  });
+
+  it('muestra el resultado y el mensaje de error cuando corresponda', () => {
+    render(
+      <JarvisActionControls
+        action={baseAction({
+          status: 'completed',
+          resultPreview: 'Archivo leído correctamente',
+          errorMessage: 'Se encontraron advertencias',
+        })}
+      />,
+    );
+
+    expect(screen.getByLabelText('Resultado de Abrir archivo')).toHaveTextContent(
+      'Archivo leído correctamente',
+    );
+    expect(screen.getByText('Se encontraron advertencias')).toBeInTheDocument();
+  });
+});

--- a/tests/python/test_jarvis_core_endpoints.py
+++ b/tests/python/test_jarvis_core_endpoints.py
@@ -1,0 +1,166 @@
+from pathlib import Path
+from types import SimpleNamespace
+import sys
+
+PROJECT_ROOT = Path(__file__).resolve().parents[2]
+if str(PROJECT_ROOT) not in sys.path:
+    sys.path.insert(0, str(PROJECT_ROOT))
+
+import pytest
+from fastapi.testclient import TestClient
+
+from jarvis_core.JarvisCore import AppConfig, configure_logging, create_app
+from jarvis_core.llm import GenerationResult, ModelNotLoadedError
+
+
+class DummyRegistry:
+    def __init__(self, base_dir: Path) -> None:
+        self.base_dir = Path(base_dir)
+        self.download_requests: list[dict[str, object]] = []
+        self.models_payload = [
+            {
+                "model_id": "alpha",
+                "state": "ready",
+                "local_path": str(self.base_dir / "alpha.bin"),
+                "tags": ["test"],
+            }
+        ]
+
+    async def list_models(self) -> list[dict[str, object]]:
+        return self.models_payload
+
+    async def start_download(
+        self,
+        model_id: str,
+        repo_id: str,
+        filename: str,
+        *,
+        hf_token: str | None = None,
+        checksum: str | None = None,
+        tags: list[str] | None = None,
+    ) -> dict[str, object]:
+        payload = {
+            "model_id": model_id,
+            "repo_id": repo_id,
+            "filename": filename,
+            "hf_token": hf_token,
+            "checksum": checksum,
+            "tags": tags or [],
+        }
+        self.download_requests.append(payload)
+        return {"accepted": True, **payload}
+
+    async def shutdown(self) -> None:  # pragma: no cover - API requirement only
+        return None
+
+
+class DummyLLMManager:
+    def __init__(self) -> None:
+        self.generate_calls: list[dict[str, object]] = []
+        self.raise_error: Exception | None = None
+
+    async def start(self) -> None:  # pragma: no cover - API requirement only
+        return None
+
+    async def shutdown(self) -> None:  # pragma: no cover - API requirement only
+        return None
+
+    async def generate(self, prompt: str, **kwargs) -> GenerationResult:
+        if self.raise_error:
+            error = self.raise_error
+            self.raise_error = None
+            raise error
+        payload = {"prompt": prompt, **kwargs}
+        self.generate_calls.append(payload)
+        return GenerationResult(
+            message="Hola desde Jarvis",
+            actions=[{"id": "open-file", "label": "Abrir", "status": "pending"}],
+        )
+
+    async def unload_model(self) -> None:  # pragma: no cover - not used in tests
+        return None
+
+    async def load_from_metadata(self, metadata):  # pragma: no cover - not used
+        return {"model_id": metadata.get("model_id", "test"), "model_type": "stub", "path": ""}
+
+    def get_status(self) -> dict[str, object]:
+        return {"active_model": "alpha", "model_type": "stub", "memory": {}}
+
+    @property
+    def is_loaded(self) -> bool:
+        return True
+
+
+@pytest.fixture()
+def api_client(monkeypatch, tmp_path):
+    registry = DummyRegistry(tmp_path)
+    llm_manager = DummyLLMManager()
+
+    monkeypatch.setattr("jarvis_core.JarvisCore.ModelRegistry", lambda base_dir: registry)
+    monkeypatch.setattr("jarvis_core.JarvisCore.LLMManager", lambda: llm_manager)
+
+    config = AppConfig(host="127.0.0.1", port=8000, models_dir=tmp_path, token=None, auto_start=False)
+    log_handler = configure_logging()
+    app = create_app(config, log_handler)
+
+    with TestClient(app) as client:
+        yield SimpleNamespace(client=client, registry=registry, llm=llm_manager, models_dir=tmp_path)
+
+
+def test_chat_completions_returns_message_and_actions(api_client):
+    response = api_client.client.post("/chat/completions", json={"prompt": "Hola"})
+
+    assert response.status_code == 200
+    data = response.json()
+    assert data["message"] == "Hola desde Jarvis"
+    assert data["actions"][0]["id"] == "open-file"
+    assert api_client.llm.generate_calls[0]["stream"] is False
+
+
+def test_chat_completions_returns_503_when_model_missing(api_client):
+    api_client.llm.raise_error = ModelNotLoadedError("Model not ready")
+
+    response = api_client.client.post("/chat/completions", json={"prompt": "Hola"})
+
+    assert response.status_code == 503
+    assert response.json()["detail"] == "Model not ready"
+
+
+def test_model_download_records_request(api_client):
+    payload = {"repo_id": "org/model", "filename": "model.bin", "tags": ["gguf"]}
+
+    response = api_client.client.post("/models/alpha/download", json=payload)
+
+    assert response.status_code == 202
+    assert api_client.registry.download_requests == [
+        {
+            "model_id": "alpha",
+            "repo_id": "org/model",
+            "filename": "model.bin",
+            "hf_token": None,
+            "checksum": None,
+            "tags": ["gguf"],
+        }
+    ]
+
+
+def test_actions_open_and_read_use_allowed_paths(api_client):
+    target_dir = api_client.models_dir / "workspace"
+    target_dir.mkdir()
+    target_file = target_dir / "notes.txt"
+    target_file.write_text("Contenido de prueba", encoding="utf-8")
+
+    open_response = api_client.client.post("/actions/open", json={"path": str(target_dir)})
+    assert open_response.status_code == 200
+    listing = open_response.json()
+    assert listing["type"] == "directory"
+    assert any(child["name"] == "notes.txt" for child in listing["children"])
+
+    read_response = api_client.client.post(
+        "/actions/read",
+        json={"path": str(target_file), "encoding": "utf-8", "offset": 0, "length": 10},
+    )
+    assert read_response.status_code == 200
+    body = read_response.json()
+    assert body["content"].startswith("Contenido")
+    assert body["encoding"] == "utf-8"


### PR DESCRIPTION
## Summary
- add pytest coverage for Jarvis Core chat, models and actions endpoints
- exercise Jarvis UI behaviour with new vitest suites
- document how to run Jarvis Core locally and expose npm script plus CI workflow

## Testing
- npm test
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68cff0a3bda083339cadb3de337b7d80