### PR TITLE
Refactor console message handler params

### DIFF
--- a/console-message-handler.cjs
+++ b/console-message-handler.cjs
@@ -4,23 +4,31 @@
  * Logs a console message emitted by the renderer with defensive fallbacks.
  *
  * @param {{ log: (...args: any[]) => void }} logger
- * @param {number} level
- * @param {string} message
- * @param {number} line
- * @param {string} sourceId
+ * @param {{
+ *   level?: number,
+ *   message?: unknown,
+ *   lineNumber?: number,
+ *   sourceId?: string
+ * }} params
  * @returns {boolean} True if the message was logged, false otherwise.
  */
-function logConsoleMessage(logger, level, message, line, sourceId) {
+function logConsoleMessage(logger, params) {
   if (!logger || typeof logger.log !== 'function') {
     return false;
   }
+
+  if (!params || typeof params !== 'object') {
+    return false;
+  }
+
+  const { level, message, lineNumber, sourceId } = params;
 
   if (typeof message !== 'string' || message.length === 0) {
     return false;
   }
 
   const safeLevel = typeof level === 'number' && Number.isFinite(level) ? level : -1;
-  const safeLine = typeof line === 'number' && Number.isFinite(line) ? line : 0;
+  const safeLine = typeof lineNumber === 'number' && Number.isFinite(lineNumber) ? lineNumber : 0;
   const safeSourceId = typeof sourceId === 'string' && sourceId.length > 0 ? sourceId : '<anonymous>';
 
   logger.log(`Console [${safeLevel}] ${safeSourceId}:${safeLine} -`, message);

--- a/electron.cjs
+++ b/electron.cjs
@@ -567,18 +567,12 @@ function createWindow() {
   // Log console errors from the page
   /**
    * Maneja los mensajes de consola emitidos por el renderer.
-   * @param {Electron.Event} event
-   * @param {number} level
-   * @param {string} message
-   * @param {number} line
-   * @param {string} sourceId
+   * @param {Electron.ConsoleMessageEvent} details
    */
-  mainWindow.webContents.on('console-message', (event, level, message, line, sourceId) => {
-    if (!event) {
-      return;
-    }
+  mainWindow.webContents.on('console-message', details => {
+    const params = details && typeof details === 'object' ? details.params : undefined;
 
-    logConsoleMessage(console, level, message, line, sourceId);
+    logConsoleMessage(console, params);
   });
 
   // Si el usuario sale del modo fullscreen manualmente, cerrar las ventanas

--- a/tests/console-message-handler.test.ts
+++ b/tests/console-message-handler.test.ts
@@ -4,10 +4,19 @@ import handler from '../console-message-handler.cjs';
 const { logConsoleMessage } = handler as { logConsoleMessage: (...args: any[]) => boolean };
 
 describe('logConsoleMessage', () => {
+  it('ignores events without params', () => {
+    const logger = { log: vi.fn() };
+
+    const result = logConsoleMessage(logger as any, undefined as any);
+
+    expect(result).toBe(false);
+    expect(logger.log).not.toHaveBeenCalled();
+  });
+
   it('ignores events without a valid message payload', () => {
     const logger = { log: vi.fn() };
 
-    const result = logConsoleMessage(logger as any, undefined as any, undefined as any, undefined as any, undefined as any);
+    const result = logConsoleMessage(logger as any, { level: 1, message: undefined } as any);
 
     expect(result).toBe(false);
     expect(logger.log).not.toHaveBeenCalled();
@@ -16,7 +25,12 @@ describe('logConsoleMessage', () => {
   it('logs events with valid payload applying defensive defaults', () => {
     const logger = { log: vi.fn() };
 
-    const result = logConsoleMessage(logger as any, 2, 'Test message', undefined as any, '');
+    const result = logConsoleMessage(logger as any, {
+      level: 2,
+      message: 'Test message',
+      sourceId: '',
+      lineNumber: undefined
+    });
 
     expect(result).toBe(true);
     expect(logger.log).toHaveBeenCalledWith('Console [2] <anonymous>:0 -', 'Test message');


### PR DESCRIPTION
## Summary
- update the console message helper to accept WebContentsConsoleMessageEventParams and keep defensive defaults
- forward console-message event details params from the Electron entry point
- refresh unit tests to cover the new payload structure and logging safeguards

## Testing
- `npm run test -- --run tests/console-message-handler.test.ts`


------
https://chatgpt.com/codex/tasks/task_e_68cfffa590cc8333a3477934aad17c32