### PR TITLE
Adjust manual chunk splitting to rely on Rollup for React

### DIFF
--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -12,6 +12,7 @@
       }
     ],
     "bundle": {
+      "identifier": "com.junglelabstudio.app",
       "resources": ["../jarvis_core"]
     }
   }

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -14,9 +14,12 @@ export default defineConfig({
         main: './index.html',
       },
       output: {
-        manualChunks: {
-          react: ['react', 'react-dom'],
-          three: ['three']
+        // Allow Rollup to decide how to split React dependencies while keeping
+        // Three.js in its own chunk to avoid inflating the main bundle.
+        manualChunks(id) {
+          if (id.includes('node_modules/three')) {
+            return 'three';
+          }
         }
       }
     }


### PR DESCRIPTION
## Summary
- replace the manualChunks object in `vite.config.ts` with a function that only isolates Three.js and documents why React is left to Rollup
- add the missing Tauri bundle identifier so production builds complete

## Testing
- `npm run build` *(fails: `tauri build` requires system package glib-2.0 which is unavailable in the container)*
- `npm run electron` *(fails: Electron binary requires libatk-1.0 which is unavailable in the container)*

------
https://chatgpt.com/codex/tasks/task_e_68d0003f1148833382ad3333f9236154