### PR TITLE
Support OpenAI provider across runtimes

### DIFF
--- a/index.html
+++ b/index.html
@@ -4,7 +4,7 @@
     <meta charset="UTF-8" />
     <meta
       http-equiv="Content-Security-Policy"
-      content="default-src 'self'; connect-src 'self' http://127.0.0.1:9888 ws://127.0.0.1:9888 ws://localhost:9888 https://api.pexels.com https://videos.pexels.com https://pixabay.com https://archive.org https://*.archive.org https://api.groq.com https://api.anthropic.com; script-src 'self'; style-src 'self' 'unsafe-inline'; img-src 'self' data: https://images.pexels.com https://cdn.pixabay.com https://i.vimeocdn.com https://archive.org https://*.archive.org; media-src 'self' blob: data: https://player.vimeo.com https://vod-progressive.akamaized.net https://videos.pexels.com https://pixabay.com https://cdn.pixabay.com https://archive.org https://*.archive.org https://*.vimeocdn.com;"
+      content="default-src 'self'; connect-src 'self' http://127.0.0.1:9888 ws://127.0.0.1:9888 ws://localhost:9888 https://api.pexels.com https://videos.pexels.com https://pixabay.com https://archive.org https://*.archive.org https://api.groq.com https://api.anthropic.com https://api.openai.com https://*.openai.azure.com; script-src 'self'; style-src 'self' 'unsafe-inline'; img-src 'self' data: https://images.pexels.com https://cdn.pixabay.com https://i.vimeocdn.com https://archive.org https://*.archive.org; media-src 'self' blob: data: https://player.vimeo.com https://vod-progressive.akamaized.net https://videos.pexels.com https://pixabay.com https://cdn.pixabay.com https://archive.org https://*.archive.org https://*.vimeocdn.com;"
     />
     <title>Jungle Lab Studio</title>
   </head>

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -11,7 +11,7 @@ custom-protocol = ["tauri/custom-protocol"]
 tauri = { version = "1.5", features = [] }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
-tokio = { version = "1", features = ["rt-multi-thread", "macros", "fs", "io-util", "net", "sync"] }
+tokio = { version = "1", features = ["rt-multi-thread", "macros", "fs", "io-util", "net", "sync", "time"] }
 midir = "0.9"
 cpal = "0.15"
 rustfft = "6.1"

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -14,6 +14,9 @@
     "bundle": {
       "identifier": "com.junglelabstudio.app",
       "resources": ["../jarvis_core"]
+    },
+    "security": {
+      "csp": "default-src 'self'; connect-src 'self' http://127.0.0.1:9888 ws://127.0.0.1:9888 ws://localhost:9888 https://api.pexels.com https://videos.pexels.com https://pixabay.com https://archive.org https://*.archive.org https://api.groq.com https://api.anthropic.com https://api.openai.com https://*.openai.azure.com; script-src 'self'; style-src 'self' 'unsafe-inline'; img-src 'self' data: https://images.pexels.com https://cdn.pixabay.com https://i.vimeocdn.com https://archive.org https://*.archive.org; media-src 'self' blob: data: https://player.vimeo.com https://vod-progressive.akamaized.net https://videos.pexels.com https://pixabay.com https://cdn.pixabay.com https://archive.org https://*.archive.org https://*.vimeocdn.com;"
     }
   }
 }

--- a/tests/aiProviders.test.ts
+++ b/tests/aiProviders.test.ts
@@ -1,0 +1,412 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { callAnthropicChat, callGroqChat, callOpenAIChat } from '../src/utils/aiProviders';
+
+type MockFetchResponse = {
+  ok: boolean;
+  status: number;
+  text: () => Promise<string>;
+};
+
+const createMockResponse = (status: number, body: unknown): MockFetchResponse => {
+  const payload = typeof body === 'string' ? body : JSON.stringify(body);
+  return {
+    ok: status >= 200 && status < 300,
+    status,
+    text: vi.fn().mockResolvedValue(payload),
+  };
+};
+
+const installFetchMock = (responses: Array<{ status: number; body: unknown }>) => {
+  const queue = [...responses];
+  const mock = vi.fn(async () => {
+    const entry = queue.shift() ?? responses[responses.length - 1];
+    return createMockResponse(entry.status, entry.body);
+  });
+  // @ts-expect-error: jsdom typings
+  globalThis.fetch = mock;
+  return mock;
+};
+
+const resetRuntime = () => {
+  delete (globalThis as unknown as { window?: unknown }).window;
+};
+
+const setElectronRuntime = (callProviderChat: ReturnType<typeof vi.fn>) => {
+  (globalThis as unknown as { window?: unknown }).window = {
+    electronAPI: {
+      callProviderChat,
+    },
+  };
+};
+
+const sanitizeGlobals = () => {
+  delete (globalThis as { __anthropicLimiter__?: unknown }).__anthropicLimiter__;
+};
+
+let originalFetch: typeof fetch | undefined;
+let originalWindow: typeof window | undefined;
+
+beforeEach(() => {
+  originalFetch = globalThis.fetch;
+  // @ts-expect-error: jsdom typings
+  originalWindow = globalThis.window;
+  vi.restoreAllMocks();
+  vi.clearAllMocks();
+  sanitizeGlobals();
+});
+
+afterEach(() => {
+  if (originalFetch) {
+    globalThis.fetch = originalFetch;
+  } else {
+    delete (globalThis as { fetch?: typeof fetch }).fetch;
+  }
+
+  if (typeof originalWindow === 'undefined') {
+    resetRuntime();
+  } else {
+    (globalThis as unknown as { window?: typeof window }).window = originalWindow;
+  }
+
+  sanitizeGlobals();
+});
+
+describe('callOpenAIChat', () => {
+  describe('browser runtime', () => {
+    it('resuelve contenido cuando la API responde con éxito', async () => {
+      resetRuntime();
+      installFetchMock([
+        {
+          status: 200,
+          body: {
+            choices: [
+              {
+                message: {
+                  content: [
+                    {
+                      type: 'text',
+                      text: 'Hola desde OpenAI',
+                    },
+                  ],
+                },
+              },
+            ],
+          },
+        },
+      ]);
+
+      const response = await callOpenAIChat({
+        apiKey: 'sk-browser-key',
+        model: 'gpt-test',
+        prompt: 'Hola',
+      });
+
+      expect(response.content).toBe('Hola desde OpenAI');
+      expect(response.modalities).toEqual(['text']);
+    });
+
+    it('propaga el mensaje de error y registra la API key enmascarada', async () => {
+      resetRuntime();
+      const fetchMock = installFetchMock([
+        {
+          status: 500,
+          body: { error: { message: 'OpenAI se rompió' } },
+        },
+        {
+          status: 500,
+          body: { error: { message: 'OpenAI se rompió' } },
+        },
+      ]);
+      const consoleErrorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+
+      await expect(
+        callOpenAIChat({
+          apiKey: 'sk-openai-secret-key',
+          model: 'gpt-test',
+          prompt: 'Hola',
+        }),
+      ).rejects.toThrow('OpenAI se rompió');
+
+      expect(fetchMock).toHaveBeenCalledTimes(2);
+      expect(consoleErrorSpy).toHaveBeenCalled();
+      const [, context] = consoleErrorSpy.mock.calls.at(-1) ?? [];
+      expect(context).toMatchObject({ apiKey: expect.stringContaining('…') });
+    });
+  });
+
+  describe('bridge runtime', () => {
+    it('utiliza el bridge de Electron y devuelve el contenido', async () => {
+      const callProviderChat = vi.fn().mockResolvedValue({
+        choices: [
+          {
+            message: {
+              content: [
+                {
+                  type: 'text',
+                  text: 'Respuesta bridged',
+                },
+              ],
+            },
+          },
+        ],
+      });
+
+      setElectronRuntime(callProviderChat);
+
+      const response = await callOpenAIChat({
+        apiKey: '  sk-bridge-openai  ',
+        model: 'gpt-test',
+        prompt: 'Hola',
+      });
+
+      expect(callProviderChat).toHaveBeenCalledWith(
+        'openai',
+        expect.objectContaining({
+          apiKey: 'sk-bridge-openai',
+        }),
+      );
+      expect(response.content).toBe('Respuesta bridged');
+      expect(response.modalities).toEqual(['text']);
+    });
+
+    it('registra errores en el bridge con la API key enmascarada', async () => {
+      const callProviderChat = vi.fn().mockRejectedValue(new Error('Bridge caído'));
+      const consoleErrorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+
+      setElectronRuntime(callProviderChat);
+
+      await expect(
+        callOpenAIChat({
+          apiKey: 'sk-bridge-error-openai',
+          model: 'gpt-test',
+          prompt: 'Hola',
+        }),
+      ).rejects.toThrow('Bridge caído');
+
+      expect(consoleErrorSpy).toHaveBeenCalled();
+      const [, context] = consoleErrorSpy.mock.calls.at(-1) ?? [];
+      expect(context).toMatchObject({ apiKey: expect.stringContaining('…') });
+    });
+  });
+});
+
+describe('callGroqChat', () => {
+  describe('browser runtime', () => {
+    it('retorna contenido en una respuesta exitosa', async () => {
+      resetRuntime();
+      installFetchMock([
+        {
+          status: 200,
+          body: {
+            choices: [
+              {
+                message: {
+                  content: [
+                    {
+                      type: 'text',
+                      text: 'Hola desde Groq',
+                    },
+                  ],
+                },
+              },
+            ],
+          },
+        },
+      ]);
+
+      const response = await callGroqChat({
+        apiKey: 'sk-groq-browser',
+        model: 'llama',
+        prompt: 'Hola',
+      });
+
+      expect(response.content).toBe('Hola desde Groq');
+      expect(response.modalities).toEqual(['text']);
+    });
+
+    it('lanza el mensaje de error devuelto por Groq', async () => {
+      resetRuntime();
+      const fetchMock = installFetchMock([
+        {
+          status: 500,
+          body: { error: { message: 'Groq en mantenimiento' } },
+        },
+        {
+          status: 500,
+          body: { error: { message: 'Groq en mantenimiento' } },
+        },
+      ]);
+      const consoleErrorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+
+      await expect(
+        callGroqChat({
+          apiKey: 'sk-groq-secret',
+          model: 'llama',
+          prompt: 'Hola',
+        }),
+      ).rejects.toThrow('Groq en mantenimiento');
+
+      expect(fetchMock).toHaveBeenCalledTimes(2);
+      expect(consoleErrorSpy).toHaveBeenCalled();
+      const [, context] = consoleErrorSpy.mock.calls.at(-1) ?? [];
+      expect(context).toMatchObject({ apiKey: expect.stringContaining('…') });
+    });
+  });
+
+  describe('bridge runtime', () => {
+    it('envía la solicitud mediante el bridge de Electron', async () => {
+      const callProviderChat = vi.fn().mockResolvedValue({
+        choices: [
+          {
+            message: {
+              content: [
+                {
+                  type: 'text',
+                  text: 'Groq vía bridge',
+                },
+              ],
+            },
+          },
+        ],
+      });
+
+      setElectronRuntime(callProviderChat);
+
+      const response = await callGroqChat({
+        apiKey: 'sk-groq-bridge',
+        model: 'llama',
+        prompt: 'Hola',
+      });
+
+      expect(callProviderChat).toHaveBeenCalledWith(
+        'groq',
+        expect.objectContaining({ apiKey: 'sk-groq-bridge' }),
+      );
+      expect(response.content).toBe('Groq vía bridge');
+    });
+
+    it('registra los errores del bridge y los propaga', async () => {
+      const callProviderChat = vi.fn().mockRejectedValue(new Error('Bridge Groq error'));
+      const consoleErrorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+
+      setElectronRuntime(callProviderChat);
+
+      await expect(
+        callGroqChat({
+          apiKey: 'sk-groq-bridge-error',
+          model: 'llama',
+          prompt: 'Hola',
+        }),
+      ).rejects.toThrow('Bridge Groq error');
+
+      expect(consoleErrorSpy).toHaveBeenCalled();
+      const [, context] = consoleErrorSpy.mock.calls.at(-1) ?? [];
+      expect(context).toMatchObject({ apiKey: expect.stringContaining('…') });
+    });
+  });
+});
+
+describe('callAnthropicChat', () => {
+  describe('browser runtime', () => {
+    it('devuelve contenido textual cuando la respuesta es válida', async () => {
+      resetRuntime();
+      installFetchMock([
+        {
+          status: 200,
+          body: {
+            content: [
+              {
+                type: 'text',
+                text: 'Hola desde Anthropic',
+              },
+            ],
+          },
+        },
+      ]);
+
+      const response = await callAnthropicChat({
+        apiKey: 'sk-anthropic-browser',
+        model: 'claude',
+        prompt: 'Hola',
+      });
+
+      expect(response.content).toBe('Hola desde Anthropic');
+      expect(response.modalities).toEqual(['text']);
+    });
+
+    it('propaga los errores de la API y reintenta la solicitud', async () => {
+      resetRuntime();
+      const fetchMock = installFetchMock([
+        {
+          status: 503,
+          body: { error: { message: 'Anthropic saturado' } },
+        },
+        {
+          status: 503,
+          body: { error: { message: 'Anthropic saturado' } },
+        },
+      ]);
+      const consoleErrorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+
+      await expect(
+        callAnthropicChat({
+          apiKey: 'sk-anthropic-error',
+          model: 'claude',
+          prompt: 'Hola',
+        }),
+      ).rejects.toThrow('Anthropic saturado');
+
+      expect(fetchMock).toHaveBeenCalledTimes(2);
+      expect(consoleErrorSpy).toHaveBeenCalled();
+      const [, context] = consoleErrorSpy.mock.calls.at(-1) ?? [];
+      expect(context).toMatchObject({ apiKey: expect.stringContaining('…') });
+    });
+  });
+
+  describe('bridge runtime', () => {
+    it('usa el bridge y devuelve el contenido en éxito', async () => {
+      const callProviderChat = vi.fn().mockResolvedValue({
+        content: [
+          {
+            type: 'text',
+            text: 'Anthropic bridge',
+          },
+        ],
+      });
+
+      setElectronRuntime(callProviderChat);
+
+      const response = await callAnthropicChat({
+        apiKey: 'sk-anthropic-bridge',
+        model: 'claude',
+        prompt: 'Hola',
+      });
+
+      expect(callProviderChat).toHaveBeenCalledWith(
+        'anthropic',
+        expect.objectContaining({ apiKey: 'sk-anthropic-bridge' }),
+      );
+      expect(response.content).toBe('Anthropic bridge');
+    });
+
+    it('registra los errores del bridge y lanza la excepción resultante', async () => {
+      const callProviderChat = vi.fn().mockRejectedValue(new Error('Anthropic bridge caído'));
+      const consoleErrorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+
+      setElectronRuntime(callProviderChat);
+
+      await expect(
+        callAnthropicChat({
+          apiKey: 'sk-anthropic-error',
+          model: 'claude',
+          prompt: 'Hola',
+        }),
+      ).rejects.toThrow('Anthropic bridge caído');
+
+      expect(consoleErrorSpy).toHaveBeenCalled();
+      const [, context] = consoleErrorSpy.mock.calls.at(-1) ?? [];
+      expect(context).toMatchObject({ apiKey: expect.stringContaining('…') });
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- allow the web and Tauri CSPs to talk to the OpenAI endpoints required for the new provider
- extend the Electron/Tauri bridges with OpenAI support, retries, and masked-key logging alongside the existing providers
- share the new retry helper inside the frontend provider utilities and cover browser/bridge flows with unit tests

## Testing
- npm run test
- cargo check *(fails: missing system library `glib-2.0` required by glib-sys)*

------
https://chatgpt.com/codex/tasks/task_e_68d000edefe08333b347dcd880f39d30