### PR TITLE
Integrate Codex orchestrator into repo workflow

### DIFF
--- a/src/components/repo/RepoStudio.tsx
+++ b/src/components/repo/RepoStudio.tsx
@@ -308,7 +308,7 @@ export const RepoStudio: React.FC = () => {
   }, [repoPath, loadRepositoryStatus]);
 
   useEffect(() => {
-    if (!pendingRequest) {
+    if (!pendingRequest || pendingRequest.status === 'analyzing') {
       return;
     }
 
@@ -360,6 +360,25 @@ export const RepoStudio: React.FC = () => {
 
       if (cancelled) {
         return;
+      }
+
+      if (pendingRequest.status === 'fallback') {
+        syncMessages.push({
+          message: 'El orquestador devolvió un análisis parcial; se completará el flujo con el plan disponible.',
+        });
+      } else if (pendingRequest.status === 'error') {
+        syncMessages.push({
+          message: 'No se pudo completar el análisis remoto. Se utilizará el plan generado localmente.',
+        });
+      }
+
+      if (pendingRequest.analysisErrors.length) {
+        pendingRequest.analysisErrors.forEach(errorMessage => {
+          const detail = errorMessage.trim();
+          if (detail) {
+            syncMessages.push({ message: `⚠️ ${detail}` });
+          }
+        });
       }
 
       syncMessages.push({

--- a/src/components/repo/__tests__/RepoWorkflow.integration.test.tsx
+++ b/src/components/repo/__tests__/RepoWorkflow.integration.test.tsx
@@ -10,6 +10,30 @@ import type { ChatMessage } from '../../../core/messages/messageTypes';
 import { PluginHostProvider } from '../../../core/plugins/PluginHostProvider';
 import { DEFAULT_GLOBAL_SETTINGS } from '../../../utils/globalSettings';
 import { ProjectProvider } from '../../../core/projects/ProjectContext';
+import type { JarvisCoreContextValue } from '../../../core/jarvis/JarvisCoreContext';
+
+const mockJarvisCore: JarvisCoreContextValue = {
+  connected: false,
+  lastError: null,
+  activeModel: null,
+  downloads: {},
+  models: [],
+  runtimeStatus: 'offline',
+  uptimeMs: null,
+  config: DEFAULT_GLOBAL_SETTINGS.jarvisCore,
+  baseUrl: '',
+  lastHealthMessage: null,
+  ensureOnline: vi.fn().mockResolvedValue(undefined),
+  refreshModels: vi.fn().mockResolvedValue([]),
+  downloadModel: vi.fn().mockResolvedValue({} as unknown),
+  activateModel: vi.fn().mockResolvedValue({} as unknown),
+  invokeChat: vi.fn().mockResolvedValue({} as unknown),
+  launchAction: vi.fn().mockResolvedValue({} as unknown),
+};
+
+vi.mock('../../../core/jarvis/JarvisCoreContext', () => ({
+  useJarvisCore: () => mockJarvisCore,
+}));
 
 const gitInvokeMock = vi.hoisted(() => vi.fn());
 const runtimeMode = vi.hoisted(() => ({ current: 'tauri' as 'tauri' | 'electron' }));

--- a/src/core/codex/RepoWorkflowContext.tsx
+++ b/src/core/codex/RepoWorkflowContext.tsx
@@ -7,13 +7,30 @@ import React, {
   useRef,
   useState,
 } from 'react';
-import type { CodexRequest } from './types';
+import type {
+  CodexAnalysisResult,
+  CodexCommitSuggestion,
+  CodexOrchestratorTrace,
+  CodexPlanWithAnalysis,
+  CodexProviderMetadata,
+  CodexPullRequestSummary,
+  CodexRepositorySnapshot,
+  CodexRequest,
+  CodexSuggestedPatch,
+} from './types';
 import type { ChatMessage } from '../messages/messageTypes';
 import { useMessages } from '../messages/MessageContext';
 import { CodexEngine } from './CodexEngine';
+import { CodexOrchestrator } from './CodexOrchestrator';
 import { buildRepoWorkflowSubmission, type RepoWorkflowSubmission } from './bridge';
 import { useProjects } from '../projects/ProjectContext';
 import { canUseDesktopGit, gitInvoke, isGitBackendUnavailableError } from '../../utils/runtimeBridge';
+import { useAgents } from '../agents/AgentContext';
+import type { AgentDefinition } from '../agents/agentRegistry';
+import type { ApiKeySettings } from '../../types/globalSettings';
+import { useJarvisCore } from '../jarvis/JarvisCoreContext';
+
+export type RepoWorkflowExecutionStatus = 'analyzing' | 'ready' | 'fallback' | 'error';
 
 export interface RepoWorkflowRequest {
   id: string;
@@ -29,6 +46,17 @@ export interface RepoWorkflowRequest {
   originalResponse: string;
   canonicalCode?: string;
   remoteName?: string;
+  status: RepoWorkflowExecutionStatus;
+  analysisStatus: RepoWorkflowSubmission['analysisStatus'];
+  analysis?: CodexAnalysisResult;
+  enrichedPlan?: CodexPlanWithAnalysis;
+  suggestedPatches: CodexSuggestedPatch[];
+  suggestedCommits: CodexCommitSuggestion[];
+  suggestedPullRequest?: CodexPullRequestSummary;
+  providerMetadata?: CodexProviderMetadata;
+  providerTraces: CodexOrchestratorTrace[];
+  analysisErrors: string[];
+  repositorySnapshot?: CodexRepositorySnapshot;
 }
 
 interface QueuePayload {
@@ -91,11 +119,152 @@ const buildFallbackMessage = (messageId: string, canonicalCode?: string): ChatMe
   timestamp: new Date().toISOString(),
 });
 
+const normalizePreference = (value?: string | null): string => {
+  if (typeof value !== 'string') {
+    return '';
+  }
+  return value.trim().toLowerCase();
+};
+
+const mergeCandidateList = (target: AgentDefinition[], additions: AgentDefinition[]): void => {
+  additions.forEach(candidate => {
+    if (!target.includes(candidate)) {
+      target.push(candidate);
+    }
+  });
+};
+
+const hasValidCredentials = (agent: AgentDefinition): boolean => {
+  if (agent.kind === 'cloud') {
+    return Boolean(agent.apiKey?.trim());
+  }
+  return true;
+};
+
+const buildApiKeySettingsFromAgents = (agents: AgentDefinition[]): ApiKeySettings => {
+  return agents.reduce<ApiKeySettings>((acc, agent) => {
+    const key = agent.apiKey?.trim();
+    if (key) {
+      acc[agent.provider.toLowerCase()] = key;
+    }
+    return acc;
+  }, {});
+};
+
+const computeApiKeySignature = (apiKeys: ApiKeySettings): string => {
+  return Object.entries(apiKeys)
+    .map(([provider, key]) => `${provider}:${key}`)
+    .sort()
+    .join('|');
+};
+
+const createErrorTrace = (stage: string, error: Error): CodexOrchestratorTrace => ({
+  level: 'error',
+  stage,
+  message: error.message,
+  timestamp: new Date().toISOString(),
+  payload: { stack: error.stack },
+});
+
 export const RepoWorkflowProvider: React.FC<{ children: React.ReactNode }> = ({ children }) => {
   const { messages } = useMessages();
   const engineRef = useRef(new CodexEngine({ defaultDryRun: true }));
+  const orchestratorRef = useRef<{ instance: CodexOrchestrator | null; signature: string | null }>({
+    instance: null,
+    signature: null,
+  });
+  const analysisAbortRef = useRef<AbortController | null>(null);
+  const traceBufferRef = useRef<CodexOrchestratorTrace[]>([]);
   const [pendingRequest, setPendingRequest] = useState<RepoWorkflowRequest | null>(null);
   const { activeProject } = useProjects();
+  const { agents } = useAgents();
+  const { invokeChat } = useJarvisCore();
+
+  const apiKeys = useMemo<ApiKeySettings>(() => buildApiKeySettingsFromAgents(agents), [agents]);
+  const apiKeySignature = useMemo(() => computeApiKeySignature(apiKeys), [apiKeys]);
+
+  const resolvePreferredAgent = useCallback((): AgentDefinition | null => {
+    if (!agents.length) {
+      return null;
+    }
+
+    const preferredModel = activeProject?.preferredModel?.trim();
+    const preferredProvider = normalizePreference(activeProject?.preferredProvider);
+    const prioritized: AgentDefinition[] = [];
+
+    if (preferredModel) {
+      const modelMatches = agents.filter(agent => agent.model === preferredModel);
+      if (modelMatches.length) {
+        mergeCandidateList(prioritized, modelMatches.filter(agent => agent.active));
+        mergeCandidateList(prioritized, modelMatches);
+      }
+    }
+
+    if (preferredProvider) {
+      const providerMatches = agents.filter(
+        agent => normalizePreference(agent.provider) === preferredProvider,
+      );
+      if (providerMatches.length) {
+        mergeCandidateList(prioritized, providerMatches.filter(agent => agent.active));
+        mergeCandidateList(prioritized, providerMatches);
+      }
+    }
+
+    mergeCandidateList(prioritized, agents.filter(agent => agent.active));
+    mergeCandidateList(prioritized, agents);
+
+    for (const candidate of prioritized) {
+      if (hasValidCredentials(candidate)) {
+        return candidate;
+      }
+    }
+
+    return null;
+  }, [agents, activeProject?.preferredModel, activeProject?.preferredProvider]);
+
+  const ensureOrchestrator = useCallback((): CodexOrchestrator | null => {
+    const agent = resolvePreferredAgent();
+    if (!agent) {
+      return null;
+    }
+
+    const signature = [
+      agent.id,
+      activeProject?.id ?? '',
+      apiKeySignature,
+      activeProject?.instructions ?? '',
+      agent.model,
+    ].join('|');
+
+    const existing = orchestratorRef.current;
+    if (existing.instance && existing.signature === signature) {
+      return existing.instance;
+    }
+
+    const orchestrator = new CodexOrchestrator({
+      agent,
+      apiKeys,
+      engine: engineRef.current,
+      jarvisInvoker: agent.kind === 'local' ? invokeChat : null,
+      projectInstructions: activeProject?.instructions,
+      onTrace: trace => {
+        traceBufferRef.current = [...traceBufferRef.current, trace];
+      },
+      onError: (error, stage) => {
+        traceBufferRef.current = [...traceBufferRef.current, createErrorTrace(stage, error)];
+      },
+    });
+
+    orchestratorRef.current = { instance: orchestrator, signature };
+    return orchestrator;
+  }, [
+    resolvePreferredAgent,
+    activeProject?.id,
+    activeProject?.instructions,
+    apiKeys,
+    apiKeySignature,
+    invokeChat,
+  ]);
 
   const syncRepository = useCallback(async (options: RepoSyncOptions) => {
     const { repositoryPath, remote, branch } = options;
@@ -125,8 +294,10 @@ export const RepoWorkflowProvider: React.FC<{ children: React.ReactNode }> = ({ 
   const queueRequest = useCallback(
     (payload: QueuePayload) => {
       const { messageId, canonicalCode, repositoryPath, branch, riskLevel } = payload;
-      const originalMessage = findMessageById(messages, messageId) ?? buildFallbackMessage(messageId, canonicalCode);
+      const originalMessage =
+        findMessageById(messages, messageId) ?? buildFallbackMessage(messageId, canonicalCode);
 
+      const orchestrator = ensureOrchestrator();
       const defaultRepositoryPath = repositoryPath ?? activeProject?.repositoryPath;
       const defaultBranch = branch ?? activeProject?.defaultBranch;
       const remoteName = activeProject?.defaultRemote ?? 'origin';
@@ -136,47 +307,206 @@ export const RepoWorkflowProvider: React.FC<{ children: React.ReactNode }> = ({ 
             .join(':') || activeProject.name
         : undefined;
 
-      const submission = buildRepoWorkflowSubmission({
+      const additionalErrors: string[] = [];
+      if (!orchestrator) {
+        additionalErrors.push(
+          'No hay credenciales activas para ejecutar el análisis remoto. Se utilizará el plan local.',
+        );
+      }
+
+      const baseSubmission = buildRepoWorkflowSubmission({
         message: originalMessage,
         canonicalCode,
         engine: engineRef.current,
         options: {
-          repositoryPath: repositoryPath,
+          repositoryPath,
           branch: defaultBranch,
           actor: defaultActor,
           riskLevel,
         },
         defaultRepositoryPath,
+        additionalErrors,
       });
 
-      if (!submission.analysisPrompt.trim()) {
+      if (!baseSubmission.analysisPrompt.trim()) {
         console.warn('La solicitud a Repo Studio carece de contenido analizable.');
         return;
       }
 
-      const request: RepoWorkflowRequest = {
-        id: generateRequestId(),
+      const requestId = generateRequestId();
+      const baseRequest: RepoWorkflowRequest = {
+        id: requestId,
         sourceMessageId: originalMessage.id,
         sourceAgentId: originalMessage.agentId ?? originalMessage.originAgentId,
-        request: submission.request,
-        plan: submission.plan,
-        analysisPrompt: submission.analysisPrompt,
-        commitMessage: submission.commitMessage,
-        prTitle: submission.prTitle,
-        prBody: submission.prBody,
-        tags: submission.tags,
-        originalResponse: submission.originalResponse,
-        canonicalCode: submission.canonicalCode ?? canonicalCode,
+        request: baseSubmission.request,
+        plan: baseSubmission.plan,
+        analysisPrompt: baseSubmission.analysisPrompt,
+        commitMessage: baseSubmission.commitMessage,
+        prTitle: baseSubmission.prTitle,
+        prBody: baseSubmission.prBody,
+        tags: baseSubmission.tags,
+        originalResponse: baseSubmission.originalResponse,
+        canonicalCode: baseSubmission.canonicalCode ?? canonicalCode,
         remoteName,
+        status: orchestrator ? 'analyzing' : 'error',
+        analysisStatus: baseSubmission.analysisStatus,
+        analysis: baseSubmission.analysis,
+        enrichedPlan: baseSubmission.enrichedPlan,
+        suggestedPatches: baseSubmission.suggestedPatches,
+        suggestedCommits: baseSubmission.suggestedCommits,
+        suggestedPullRequest: baseSubmission.suggestedPullRequest,
+        providerMetadata: baseSubmission.providerMetadata,
+        providerTraces: baseSubmission.providerTraces,
+        analysisErrors: baseSubmission.analysisErrors,
+        repositorySnapshot: baseSubmission.repositorySnapshot,
       };
 
-      setPendingRequest(request);
+      analysisAbortRef.current?.abort();
+      analysisAbortRef.current = null;
+
+      if (!orchestrator) {
+        setPendingRequest(baseRequest);
+        return;
+      }
+
+      traceBufferRef.current = [];
+      const controller = new AbortController();
+      analysisAbortRef.current = controller;
+      setPendingRequest(baseRequest);
+
+      void orchestrator
+        .analyze(baseSubmission.request, {
+          projectInstructions: activeProject?.instructions,
+          signal: controller.signal,
+        })
+        .then(result => {
+          if (controller.signal.aborted) {
+            return;
+          }
+
+          const traces = traceBufferRef.current.slice();
+          const submission = buildRepoWorkflowSubmission({
+            message: originalMessage,
+            canonicalCode,
+            engine: engineRef.current,
+            options: {
+              repositoryPath,
+              branch: defaultBranch,
+              actor: defaultActor,
+              riskLevel,
+            },
+            defaultRepositoryPath,
+            analysis: result,
+            traces,
+          });
+
+          setPendingRequest(previous => {
+            if (!previous || previous.id !== requestId) {
+              return previous;
+            }
+            return {
+              ...previous,
+              request: submission.request,
+              plan: submission.plan,
+              commitMessage: submission.commitMessage,
+              prTitle: submission.prTitle,
+              prBody: submission.prBody,
+              tags: submission.tags,
+              originalResponse: submission.originalResponse,
+              analysis: submission.analysis,
+              enrichedPlan: submission.enrichedPlan,
+              suggestedPatches: submission.suggestedPatches,
+              suggestedCommits: submission.suggestedCommits,
+              suggestedPullRequest: submission.suggestedPullRequest,
+              providerMetadata: submission.providerMetadata,
+              providerTraces: submission.providerTraces,
+              analysisErrors: submission.analysisErrors,
+              repositorySnapshot: submission.repositorySnapshot,
+              analysisStatus: submission.analysisStatus,
+              status: result.status === 'success' ? 'ready' : 'fallback',
+            } satisfies RepoWorkflowRequest;
+          });
+        })
+        .catch(error => {
+          if (controller.signal.aborted) {
+            return;
+          }
+
+          const traces = traceBufferRef.current.slice();
+          const message =
+            (error as Error)?.message ??
+            'Error desconocido al ejecutar el orquestador. Se utilizará el plan local.';
+          const submission = buildRepoWorkflowSubmission({
+            message: originalMessage,
+            canonicalCode,
+            engine: engineRef.current,
+            options: {
+              repositoryPath,
+              branch: defaultBranch,
+              actor: defaultActor,
+              riskLevel,
+            },
+            defaultRepositoryPath,
+            traces,
+            additionalErrors: [message],
+          });
+
+          setPendingRequest(previous => {
+            if (!previous || previous.id !== requestId) {
+              return previous;
+            }
+            return {
+              ...previous,
+              request: submission.request,
+              plan: submission.plan,
+              commitMessage: submission.commitMessage,
+              prTitle: submission.prTitle,
+              prBody: submission.prBody,
+              tags: submission.tags,
+              originalResponse: submission.originalResponse,
+              analysis: submission.analysis,
+              enrichedPlan: submission.enrichedPlan,
+              suggestedPatches: submission.suggestedPatches,
+              suggestedCommits: submission.suggestedCommits,
+              suggestedPullRequest: submission.suggestedPullRequest,
+              providerMetadata: submission.providerMetadata,
+              providerTraces: submission.providerTraces,
+              analysisErrors: submission.analysisErrors,
+              repositorySnapshot: submission.repositorySnapshot,
+              analysisStatus: submission.analysisStatus,
+              status: 'error',
+            } satisfies RepoWorkflowRequest;
+          });
+        })
+        .finally(() => {
+          if (analysisAbortRef.current === controller) {
+            analysisAbortRef.current = null;
+          }
+          traceBufferRef.current = [];
+        });
     },
-    [messages, activeProject],
+    [
+      messages,
+      activeProject?.instructions,
+      activeProject?.defaultBranch,
+      activeProject?.defaultRemote,
+      activeProject?.preferredModel,
+      activeProject?.preferredProvider,
+      activeProject?.repositoryPath,
+      activeProject?.name,
+      ensureOrchestrator,
+    ],
   );
 
   const clearPendingRequest = useCallback(() => {
     setPendingRequest(null);
+  }, []);
+
+  useEffect(() => {
+    return () => {
+      analysisAbortRef.current?.abort();
+      analysisAbortRef.current = null;
+    };
   }, []);
 
   useEffect(() => {

--- a/src/core/codex/__tests__/RepoWorkflowContext.test.tsx
+++ b/src/core/codex/__tests__/RepoWorkflowContext.test.tsx
@@ -4,6 +4,41 @@ import { renderHook, act } from '@testing-library/react';
 import { RepoWorkflowProvider, useRepoWorkflow } from '../RepoWorkflowContext';
 import { ProjectProvider } from '../../projects/ProjectContext';
 import { DEFAULT_GLOBAL_SETTINGS } from '../../../utils/globalSettings';
+import type { JarvisCoreContextValue } from '../../jarvis/JarvisCoreContext';
+
+vi.mock('../../agents/AgentContext', () => ({
+  useAgents: () => ({
+    agents: [],
+    activeAgents: [],
+    agentMap: new Map(),
+    toggleAgent: vi.fn(),
+    updateLocalAgentState: vi.fn(),
+    assignAgentRole: vi.fn(),
+  }),
+}));
+
+const mockJarvisCore: JarvisCoreContextValue = {
+  connected: false,
+  lastError: null,
+  activeModel: null,
+  downloads: {},
+  models: [],
+  runtimeStatus: 'offline',
+  uptimeMs: null,
+  config: DEFAULT_GLOBAL_SETTINGS.jarvisCore,
+  baseUrl: '',
+  lastHealthMessage: null,
+  ensureOnline: vi.fn().mockResolvedValue(undefined),
+  refreshModels: vi.fn().mockResolvedValue([]),
+  downloadModel: vi.fn().mockResolvedValue({} as unknown),
+  activateModel: vi.fn().mockResolvedValue({} as unknown),
+  invokeChat: vi.fn().mockResolvedValue({} as unknown),
+  launchAction: vi.fn().mockResolvedValue({} as unknown),
+};
+
+vi.mock('../../jarvis/JarvisCoreContext', () => ({
+  useJarvisCore: () => mockJarvisCore,
+}));
 
 const messageTimestamp = new Date().toISOString();
 
@@ -65,5 +100,7 @@ describe('RepoWorkflowContext', () => {
     expect(pending?.request.context.branch).toBe('develop');
     expect(pending?.request.context.actor).toBe('openai:gpt-4');
     expect(pending?.remoteName).toBe('origin');
+    expect(pending?.status).toBe('error');
+    expect(pending?.analysisErrors.length).toBeGreaterThan(0);
   });
 });


### PR DESCRIPTION
## Summary
- switch the repo workflow provider to bootstrap a Codex orchestrator with active project preferences and api keys while keeping CodexEngine as the fallback
- extend the repo workflow submission payload with orchestration metadata (enriched plan, suggested patches/commits/PR, traces, status) and propagate new status/error handling into Repo Studio
- update repository workflow tests to stub Jarvis Core and agent contexts and cover the new execution states

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68d0154e5d6083338d187cb86424101c