### PR TITLE
feat: expose orchestrator preferences in project settings

### DIFF
--- a/src/types/globalSettings.ts
+++ b/src/types/globalSettings.ts
@@ -87,6 +87,21 @@ export interface WorkspacePreferences {
 
 export type GitHostingProvider = 'github' | 'gitlab' | (string & {});
 
+export type OrchestratorExecutionMode = 'auto' | 'cloud' | 'local';
+
+export type OrchestratorDegradationPolicy = 'none' | 'on-error';
+
+export interface ProjectOrchestratorPreferences {
+  mode: OrchestratorExecutionMode;
+  primaryProvider?: string;
+  primaryModel?: string;
+  fallbackProvider?: string;
+  fallbackModel?: string;
+  retryLimit: number;
+  retryDelayMs: number;
+  degradationPolicy: OrchestratorDegradationPolicy;
+}
+
 export interface ProjectProfile {
   id: string;
   name: string;
@@ -99,6 +114,7 @@ export interface ProjectProfile {
   instructions?: string;
   preferredProvider?: string;
   preferredModel?: string;
+  orchestrator?: ProjectOrchestratorPreferences;
 }
 
 export interface DataLocationSettings {

--- a/src/utils/__tests__/globalSettings.test.ts
+++ b/src/utils/__tests__/globalSettings.test.ts
@@ -81,6 +81,9 @@ describe('globalSettings schema validation', () => {
     expect(project.defaultBranch).toBe('develop');
     expect(project.preferredProvider).toBe('OpenAI');
     expect(project.preferredModel).toBe('gpt-4');
+    expect(project.orchestrator?.primaryProvider).toBe('OpenAI');
+    expect(project.orchestrator?.primaryModel).toBe('gpt-4');
+    expect(project.orchestrator?.mode).toBe('cloud');
     expect(project.instructions).toBe('Revisar CI antes de desplegar.');
     expect(migrated.activeProjectId).toBe('demo');
   });


### PR DESCRIPTION
## Summary
- extend global settings schema with orchestrator preferences, normalization helpers, and defaults
- add project binding controls for orchestrator mode, fallback provider/model, and retry limits while registering custom providers
- honor orchestrator preferences inside repo workflow and Codex orchestrator with fallback agent support

## Testing
- npm run test

------
https://chatgpt.com/codex/tasks/task_e_68d01f6b55988333ad05f46add5741ef