### PR TITLE
feat: add markdown composer and enhanced code display

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
   "dependencies": {
     "@tauri-apps/api": "^1.5.0",
     "@types/three": "^0.179.0",
+    "highlight.js": "^11.9.0",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
     "simple-git": "^3.27.0",

--- a/src/components/chat/ChatInterface.css
+++ b/src/components/chat/ChatInterface.css
@@ -690,23 +690,79 @@
 }
 
 .message-code-block {
-  position: relative;
-  padding: 40px 14px 14px;
-  border-radius: 10px;
-  background: radial-gradient(circle at top, rgba(29, 35, 60, 0.75), rgba(14, 16, 30, 0.85));
-  border: 1px solid rgba(142, 141, 255, 0.2);
-  box-shadow: inset 0 0 0 1px rgba(142, 141, 255, 0.08);
-  color: rgba(233, 236, 255, 0.92);
+  border-radius: 12px;
+  border: 1px solid rgba(142, 141, 255, 0.22);
+  background: radial-gradient(circle at top, rgba(18, 22, 45, 0.82), rgba(10, 12, 25, 0.92));
+  box-shadow: inset 0 0 0 1px rgba(142, 141, 255, 0.1);
   overflow: hidden;
+  color: rgba(233, 236, 255, 0.94);
+}
+
+.message-code-toolbar {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+  padding: 10px 14px;
+  background: linear-gradient(120deg, rgba(22, 26, 54, 0.95), rgba(12, 16, 30, 0.85));
+  border-bottom: 1px solid rgba(142, 141, 255, 0.25);
+}
+
+.message-code-meta {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  font-size: 12px;
+  color: rgba(178, 182, 255, 0.85);
+}
+
+.message-code-language {
+  font-size: 11px;
+  letter-spacing: 0.8px;
+  text-transform: uppercase;
+  padding: 4px 10px;
+  border-radius: 999px;
+  border: 1px solid rgba(178, 182, 255, 0.35);
+  background: rgba(178, 182, 255, 0.12);
+}
+
+.message-code-lines {
+  font-size: 11px;
+  color: rgba(196, 198, 255, 0.75);
+}
+
+.message-code-actions {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+}
+
+.message-code-copy {
+  border: 1px solid rgba(255, 255, 255, 0.14);
+  border-radius: 999px;
+  padding: 4px 12px;
+  font-size: 12px;
+  color: rgba(255, 255, 255, 0.9);
+  background: rgba(255, 255, 255, 0.08);
+  cursor: pointer;
+  transition: background 0.2s ease, transform 0.15s ease, border 0.2s ease;
+}
+
+.message-code-copy:hover,
+.message-code-copy:focus-visible {
+  transform: translateY(-1px);
+  border-color: rgba(255, 183, 77, 0.6);
+  background: rgba(255, 183, 77, 0.15);
 }
 
 .message-code-block pre {
   margin: 0;
+  padding: 18px 16px 20px;
   font-family: 'JetBrains Mono', 'Fira Code', 'SFMono-Regular', Menlo, Monaco, Consolas, 'Liberation Mono', 'Courier New',
     monospace;
   font-size: 13px;
-  line-height: 1.7;
-  background: transparent;
+  line-height: 1.65;
+  background: rgba(10, 12, 25, 0.65);
   color: inherit;
   white-space: pre;
   overflow-x: auto;
@@ -717,81 +773,221 @@
   white-space: inherit;
 }
 
-.message-code-toolbar {
-  position: absolute;
-  top: 12px;
-  left: 14px;
-  right: 14px;
-  display: flex;
-  align-items: center;
-  justify-content: space-between;
-  gap: 8px;
-  padding: 6px 10px;
-  border-radius: 10px;
-  background: linear-gradient(120deg, rgba(20, 24, 44, 0.95), rgba(35, 41, 72, 0.75));
-  border: 1px solid rgba(142, 141, 255, 0.18);
-  box-shadow: 0 10px 20px rgba(12, 14, 28, 0.5);
-  pointer-events: none;
+.message-code-block .hljs {
+  color: #e5e8ff;
 }
 
-.message-code-language {
-  font-size: 11px;
-  letter-spacing: 0.8px;
-  text-transform: uppercase;
-  color: rgba(178, 182, 255, 0.9);
-  padding: 4px 10px;
-  border-radius: 999px;
-  border: 1px solid rgba(178, 182, 255, 0.3);
-  background: rgba(178, 182, 255, 0.08);
+.message-code-block .hljs-keyword,
+.message-code-block .hljs-selector-tag,
+.message-code-block .hljs-built_in,
+.message-code-block .hljs-literal {
+  color: #c792ea;
+}
+
+.message-code-block .hljs-string,
+.message-code-block .hljs-attr,
+.message-code-block .hljs-template-variable,
+.message-code-block .hljs-name {
+  color: #9effa9;
+}
+
+.message-code-block .hljs-number,
+.message-code-block .hljs-meta,
+.message-code-block .hljs-params,
+.message-code-block .hljs-title {
+  color: #ffe082;
+}
+
+.message-code-block .hljs-comment {
+  color: rgba(199, 200, 230, 0.6);
+  font-style: italic;
 }
 
 .message-actions {
-  display: flex;
-  gap: 8px;
-  margin-left: auto;
-  pointer-events: auto;
   position: relative;
 }
 
-.message-action {
+.message-action-trigger {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 32px;
+  height: 32px;
+  border-radius: 10px;
+  border: 1px solid rgba(255, 255, 255, 0.16);
   background: rgba(255, 255, 255, 0.08);
-  color: #fff;
-  border: 1px solid rgba(255, 255, 255, 0.14);
-  border-radius: 999px;
-  font-size: 11px;
-  padding: 6px 12px;
-  letter-spacing: 0.6px;
-  text-transform: uppercase;
+  color: rgba(255, 255, 255, 0.9);
   cursor: pointer;
-  transition: transform 0.2s ease, background 0.2s ease, border-color 0.2s ease, box-shadow 0.2s ease;
+  transition: background 0.2s ease, transform 0.15s ease, border 0.2s ease;
 }
 
-.message-action:hover {
+.message-action-trigger:hover,
+.message-action-trigger:focus-visible {
   transform: translateY(-1px);
-  background: rgba(255, 183, 77, 0.16);
-  border-color: rgba(255, 183, 77, 0.4);
-  box-shadow: 0 10px 20px rgba(255, 183, 77, 0.18);
+  border-color: rgba(142, 141, 255, 0.6);
+  background: rgba(142, 141, 255, 0.2);
 }
 
 .message-action-popover {
   position: absolute;
-  top: 36px;
+  top: calc(100% + 8px);
   right: 0;
-  width: 320px;
-  max-height: 260px;
-  overflow-y: auto;
+  width: 260px;
   padding: 12px;
   border-radius: 12px;
-  background: rgba(14, 16, 32, 0.96);
-  border: 1px solid rgba(142, 141, 255, 0.24);
-  box-shadow: 0 18px 34px rgba(12, 14, 28, 0.55);
-  z-index: 10;
+  border: 1px solid rgba(142, 141, 255, 0.2);
+  background: rgba(12, 14, 28, 0.92);
+  box-shadow: 0 12px 32px rgba(0, 0, 0, 0.45);
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+  z-index: 5;
+}
+
+.message-action-item {
+  width: 100%;
+  border: 1px solid rgba(255, 255, 255, 0.12);
+  border-radius: 8px;
+  background: rgba(255, 255, 255, 0.05);
+  color: rgba(255, 255, 255, 0.85);
+  padding: 6px 10px;
+  font-size: 13px;
+  text-align: left;
+  cursor: pointer;
+  transition: background 0.2s ease, border 0.2s ease;
+}
+
+.message-action-item:hover,
+.message-action-item:focus-visible {
+  border-color: rgba(255, 183, 77, 0.55);
+  background: rgba(255, 183, 77, 0.18);
+}
+
+.message-action-item.is-active {
+  border-color: rgba(142, 141, 255, 0.6);
+  background: rgba(142, 141, 255, 0.18);
+}
+
+.message-action-submenu {
+  border-top: 1px solid rgba(255, 255, 255, 0.08);
+  margin-top: 6px;
+  padding-top: 6px;
+  max-height: 220px;
+  overflow-y: auto;
 }
 
 .message-action-empty {
-  margin: 0;
+  margin: 4px 0;
   font-size: 12px;
   color: rgba(255, 255, 255, 0.7);
+}
+
+@media (prefers-color-scheme: light) {
+  .message-code-block {
+    border: 1px solid rgba(30, 34, 68, 0.15);
+    background: radial-gradient(circle at top, rgba(244, 246, 255, 0.95), rgba(220, 224, 255, 0.92));
+    color: rgba(24, 26, 48, 0.95);
+  }
+
+  .message-code-toolbar {
+    background: linear-gradient(120deg, rgba(235, 238, 255, 0.9), rgba(214, 220, 255, 0.85));
+    border-bottom: 1px solid rgba(30, 34, 68, 0.12);
+  }
+
+  .message-code-language {
+    border: 1px solid rgba(30, 34, 68, 0.16);
+    background: rgba(86, 108, 255, 0.12);
+    color: rgba(30, 34, 68, 0.8);
+  }
+
+  .message-code-lines {
+    color: rgba(30, 34, 68, 0.7);
+  }
+
+  .message-code-copy {
+    border: 1px solid rgba(30, 34, 68, 0.16);
+    background: rgba(30, 34, 68, 0.08);
+    color: rgba(30, 34, 68, 0.8);
+  }
+
+  .message-code-copy:hover,
+  .message-code-copy:focus-visible {
+    border-color: rgba(86, 108, 255, 0.55);
+    background: rgba(86, 108, 255, 0.18);
+  }
+
+  .message-code-block pre {
+    background: rgba(246, 248, 255, 0.85);
+    color: inherit;
+  }
+
+  .message-code-block .hljs {
+    color: rgba(26, 28, 52, 0.95);
+  }
+
+  .message-code-block .hljs-keyword,
+  .message-code-block .hljs-selector-tag,
+  .message-code-block .hljs-built_in,
+  .message-code-block .hljs-literal {
+    color: #4d5ad1;
+  }
+
+  .message-code-block .hljs-string,
+  .message-code-block .hljs-attr,
+  .message-code-block .hljs-template-variable,
+  .message-code-block .hljs-name {
+    color: #1f7a5c;
+  }
+
+  .message-code-block .hljs-number,
+  .message-code-block .hljs-meta,
+  .message-code-block .hljs-params,
+  .message-code-block .hljs-title {
+    color: #a66b00;
+  }
+
+  .message-code-block .hljs-comment {
+    color: rgba(30, 34, 68, 0.55);
+  }
+
+  .message-action-trigger {
+    border: 1px solid rgba(30, 34, 68, 0.16);
+    background: rgba(30, 34, 68, 0.08);
+    color: rgba(30, 34, 68, 0.8);
+  }
+
+  .message-action-trigger:hover,
+  .message-action-trigger:focus-visible {
+    border-color: rgba(86, 108, 255, 0.55);
+    background: rgba(86, 108, 255, 0.18);
+  }
+
+  .message-action-popover {
+    border: 1px solid rgba(30, 34, 68, 0.16);
+    background: rgba(248, 249, 255, 0.95);
+    box-shadow: 0 12px 32px rgba(28, 32, 68, 0.15);
+  }
+
+  .message-action-item {
+    border: 1px solid rgba(30, 34, 68, 0.14);
+    background: rgba(30, 34, 68, 0.06);
+    color: rgba(30, 34, 68, 0.85);
+  }
+
+  .message-action-empty {
+    color: rgba(30, 34, 68, 0.65);
+  }
+
+  .message-action-item:hover,
+  .message-action-item:focus-visible {
+    border-color: rgba(86, 108, 255, 0.55);
+    background: rgba(86, 108, 255, 0.18);
+  }
+
+  .message-action-item.is-active {
+    border-color: rgba(86, 108, 255, 0.6);
+    background: rgba(86, 108, 255, 0.22);
+  }
 }
 
 .message-card-action {
@@ -925,7 +1121,64 @@
   gap: var(--chat-vertical-gap);
 }
 
-.chat-input {
+.chat-code-composer {
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+  padding: 12px;
+  border-radius: 16px;
+  background: rgba(15, 18, 32, 0.7);
+  border: 1px solid rgba(255, 255, 255, 0.08);
+  box-shadow: inset 0 0 0 1px rgba(255, 255, 255, 0.03);
+  backdrop-filter: blur(18px);
+}
+
+.chat-code-toolbar {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  padding: 6px 10px;
+  border-radius: 12px;
+  border: 1px solid rgba(255, 255, 255, 0.08);
+  background: linear-gradient(120deg, rgba(25, 28, 48, 0.9), rgba(20, 22, 38, 0.7));
+}
+
+.composer-toolbar-button {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 32px;
+  height: 32px;
+  border-radius: 8px;
+  border: 1px solid rgba(255, 255, 255, 0.1);
+  background: rgba(255, 255, 255, 0.05);
+  color: rgba(255, 255, 255, 0.85);
+  cursor: pointer;
+  transition: transform 0.15s ease, border 0.2s ease, background 0.2s ease;
+}
+
+.composer-toolbar-button:hover,
+.composer-toolbar-button:focus-visible {
+  transform: translateY(-1px);
+  border-color: rgba(255, 183, 77, 0.6);
+  background: rgba(255, 183, 77, 0.15);
+}
+
+.composer-toolbar-button.is-active {
+  border-color: rgba(142, 141, 255, 0.8);
+  background: rgba(142, 141, 255, 0.15);
+}
+
+.chat-code-toolbar-spacer {
+  flex: 1;
+}
+
+.chat-code-token-count {
+  font-size: 12px;
+  color: rgba(255, 255, 255, 0.65);
+}
+
+.chat-code-textarea {
   width: 100%;
   resize: vertical;
   min-height: 90px;
@@ -942,9 +1195,48 @@
   transition: border 0.2s ease, box-shadow 0.2s ease;
 }
 
-.chat-input:focus {
+.chat-code-textarea:focus {
   border-color: rgba(255, 183, 77, 0.7);
   box-shadow: 0 0 0 2px rgba(255, 183, 77, 0.15);
+}
+
+@media (prefers-color-scheme: light) {
+  .chat-code-composer {
+    background: rgba(255, 255, 255, 0.85);
+    border: 1px solid rgba(20, 24, 44, 0.08);
+    box-shadow: inset 0 0 0 1px rgba(20, 24, 44, 0.05);
+  }
+
+  .chat-code-toolbar {
+    border: 1px solid rgba(20, 24, 44, 0.12);
+    background: linear-gradient(120deg, rgba(245, 246, 255, 0.95), rgba(225, 229, 255, 0.8));
+  }
+
+  .composer-toolbar-button {
+    border: 1px solid rgba(20, 24, 44, 0.12);
+    background: rgba(20, 24, 44, 0.06);
+    color: rgba(20, 24, 44, 0.85);
+  }
+
+  .composer-toolbar-button.is-active {
+    border-color: rgba(86, 108, 255, 0.6);
+    background: rgba(86, 108, 255, 0.12);
+  }
+
+  .chat-code-token-count {
+    color: rgba(20, 24, 44, 0.65);
+  }
+
+  .chat-code-textarea {
+    background: rgba(255, 255, 255, 0.9);
+    color: rgba(20, 24, 44, 0.9);
+    border: 1px solid rgba(20, 24, 44, 0.12);
+  }
+
+  .chat-code-textarea:focus {
+    border-color: rgba(86, 108, 255, 0.65);
+    box-shadow: 0 0 0 2px rgba(86, 108, 255, 0.15);
+  }
 }
 
 .composer-toolbar {
@@ -2601,7 +2893,7 @@
   gap: 8px;
 }
 
-.chat-input {
+.chat-code-textarea {
   width: 100%;
   border: 1px solid rgba(255, 255, 255, 0.1);
   border-radius: 12px;

--- a/src/components/chat/ChatWorkspace.tsx
+++ b/src/components/chat/ChatWorkspace.tsx
@@ -10,6 +10,7 @@ import { AgentKind } from '../../core/agents/agentRegistry';
 import type { AgentDefinition } from '../../core/agents/agentRegistry';
 import { getAgentDisplayName, getAgentVersionLabel } from '../../utils/agentDisplay';
 import { MessageCard } from './messages/MessageCard';
+import { ChatCodeComposer } from './composer/ChatCodeComposer';
 import type { GlobalSettings, CommandPreset } from '../../types/globalSettings';
 import type { AgentPresenceEntry } from '../../core/agents/presence';
 interface ChatWorkspaceProps {
@@ -688,12 +689,12 @@ export const ChatWorkspace: React.FC<ChatWorkspaceProps> = ({
             <AudioRecorder onRecordingComplete={handleRecordingComplete} />
           </div>
 
-          <textarea
+          <ChatCodeComposer
             value={draft}
-            onChange={event => setDraft(event.target.value)}
+            setDraft={setDraft}
+            appendToDraft={appendToDraft}
+            onSend={sendMessage}
             placeholder="Habla con varios agentes a la vez: por ejemplo “gpt, genera un esquema de estilos”"
-            className="chat-input"
-            rows={3}
           />
 
           <div className="composer-toolbar">

--- a/src/components/chat/composer/ChatCodeComposer.tsx
+++ b/src/components/chat/composer/ChatCodeComposer.tsx
@@ -1,0 +1,194 @@
+import React, { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import { estimateTokenCount } from '../../../utils/tokens';
+import { copyToClipboard } from '../../../utils/clipboard';
+
+interface ChatCodeComposerProps {
+  value: string;
+  placeholder?: string;
+  appendToDraft: (value: string) => void;
+  setDraft: (value: string) => void;
+  onSend?: () => void;
+  disabled?: boolean;
+}
+
+interface ToolbarAction {
+  id: string;
+  icon: string;
+  label: string;
+  shortcut?: string;
+  onAction: () => void;
+}
+
+const CODE_BLOCK_TEMPLATE = '```\n\n```';
+
+export const ChatCodeComposer: React.FC<ChatCodeComposerProps> = ({
+  value,
+  placeholder,
+  appendToDraft,
+  setDraft,
+  onSend,
+  disabled,
+}) => {
+  const textareaRef = useRef<HTMLTextAreaElement | null>(null);
+  const [lastCopied, setLastCopied] = useState<number | null>(null);
+
+  const tokenCount = useMemo(() => estimateTokenCount(value), [value]);
+
+  const wrapSelectionWithCodeBlock = useCallback(
+    (language?: string) => {
+      const textarea = textareaRef.current;
+      if (!textarea) {
+        return;
+      }
+      const { selectionStart, selectionEnd } = textarea;
+      const currentValue = textarea.value;
+      const selectedText = currentValue.slice(selectionStart, selectionEnd);
+      const normalizedLanguage = language?.trim() ?? '';
+      const fenceHeader = `\`\`\`${normalizedLanguage}\n`;
+      const fenceFooter = '\n```\n';
+      const before = currentValue.slice(0, selectionStart);
+      const after = currentValue.slice(selectionEnd);
+      const needsLeadingNewline = before.length > 0 && !before.endsWith('\n');
+      const headerPrefix = needsLeadingNewline ? `\n${fenceHeader}` : fenceHeader;
+      const newValue = `${before}${headerPrefix}${selectedText}${fenceFooter}${after}`;
+      setDraft(newValue);
+
+      window.requestAnimationFrame(() => {
+        const caretPosition = selectionStart + headerPrefix.length + selectedText.length;
+        textarea.selectionStart = caretPosition;
+        textarea.selectionEnd = caretPosition;
+        textarea.focus();
+      });
+    },
+    [setDraft],
+  );
+
+  const insertCodeBlockTemplate = useCallback(() => {
+    const textarea = textareaRef.current;
+    if (!textarea) {
+      appendToDraft(`\n${CODE_BLOCK_TEMPLATE}`);
+      return;
+    }
+    const { selectionStart, selectionEnd } = textarea;
+    if (selectionStart !== selectionEnd) {
+      wrapSelectionWithCodeBlock();
+      return;
+    }
+    const currentValue = textarea.value;
+    const before = currentValue.slice(0, selectionStart);
+    const after = currentValue.slice(selectionEnd);
+    const needsLeadingNewline = before.length > 0 && !before.endsWith('\n');
+    const insertion = `${needsLeadingNewline ? '\n' : ''}\`\`\`\n\n\`\`\``;
+    const newValue = `${before}${insertion}${after}`;
+    setDraft(newValue);
+
+    window.requestAnimationFrame(() => {
+      const caretPosition = selectionStart + (needsLeadingNewline ? 5 : 4);
+      textarea.selectionStart = caretPosition;
+      textarea.selectionEnd = caretPosition;
+      textarea.focus();
+    });
+  }, [appendToDraft, setDraft, wrapSelectionWithCodeBlock]);
+
+  const handleKeyboardShortcuts = useCallback(
+    (event: React.KeyboardEvent<HTMLTextAreaElement>) => {
+      if (event.key === 'Enter' && (event.metaKey || event.ctrlKey)) {
+        event.preventDefault();
+        onSend?.();
+        return;
+      }
+
+      if (event.key.toLowerCase() === 'c' && event.shiftKey && (event.metaKey || event.ctrlKey)) {
+        event.preventDefault();
+        wrapSelectionWithCodeBlock();
+        return;
+      }
+
+      if (event.key === '`' && event.shiftKey && (event.metaKey || event.ctrlKey)) {
+        event.preventDefault();
+        insertCodeBlockTemplate();
+      }
+    },
+    [insertCodeBlockTemplate, onSend, wrapSelectionWithCodeBlock],
+  );
+
+  const handleCopyAll = useCallback(() => {
+    copyToClipboard(value)
+      .then(() => {
+        setLastCopied(Date.now());
+      })
+      .catch(() => {
+        setLastCopied(null);
+      });
+  }, [value]);
+
+  useEffect(() => {
+    if (lastCopied === null) {
+      return;
+    }
+    const timeout = window.setTimeout(() => setLastCopied(null), 2000);
+    return () => window.clearTimeout(timeout);
+  }, [lastCopied]);
+
+  const toolbarActions: ToolbarAction[] = useMemo(
+    () => [
+      {
+        id: 'code-block',
+        icon: '🧱',
+        label: 'Bloque de código',
+        shortcut: 'Ctrl+Shift+`',
+        onAction: insertCodeBlockTemplate,
+      },
+      {
+        id: 'wrap-selection',
+        icon: '🪄',
+        label: 'Envolver selección',
+        shortcut: 'Ctrl+Shift+C',
+        onAction: () => wrapSelectionWithCodeBlock(),
+      },
+      {
+        id: 'copy',
+        icon: '📋',
+        label: lastCopied ? 'Copiado!' : 'Copiar todo',
+        onAction: handleCopyAll,
+      },
+    ],
+    [handleCopyAll, insertCodeBlockTemplate, lastCopied, wrapSelectionWithCodeBlock],
+  );
+
+  return (
+    <div className="chat-code-composer">
+      <div className="chat-code-toolbar" role="toolbar" aria-label="Acciones del compositor">
+        {toolbarActions.map(action => (
+          <button
+            key={action.id}
+            type="button"
+            className={`composer-toolbar-button${action.id === 'copy' && lastCopied ? ' is-active' : ''}`}
+            onClick={action.onAction}
+            disabled={disabled}
+            title={action.shortcut ? `${action.label} (${action.shortcut})` : action.label}
+            aria-label={action.label}
+          >
+            <span aria-hidden="true">{action.icon}</span>
+          </button>
+        ))}
+        <div className="chat-code-toolbar-spacer" />
+        <span className="chat-code-token-count" aria-live="polite">
+          {tokenCount} tokens estimados
+        </span>
+      </div>
+      <textarea
+        ref={textareaRef}
+        value={value}
+        onChange={event => setDraft(event.target.value)}
+        onKeyDown={handleKeyboardShortcuts}
+        placeholder={placeholder}
+        className="chat-code-textarea"
+        rows={4}
+        disabled={disabled}
+      />
+    </div>
+  );
+};
+
+export default ChatCodeComposer;

--- a/src/components/chat/composer/__tests__/ChatCodeComposer.test.tsx
+++ b/src/components/chat/composer/__tests__/ChatCodeComposer.test.tsx
@@ -1,0 +1,43 @@
+import React from 'react';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { cleanup, fireEvent, render, screen } from '@testing-library/react';
+import { ChatCodeComposer } from '../ChatCodeComposer';
+
+vi.mock('../../../../utils/clipboard', () => ({
+  copyToClipboard: vi.fn().mockResolvedValue(undefined),
+}));
+
+afterEach(() => {
+  cleanup();
+  vi.clearAllMocks();
+});
+
+describe('ChatCodeComposer', () => {
+  it('renders composer with toolbar and textarea', () => {
+    const { container } = render(
+      <ChatCodeComposer
+        value="Hola agentes"
+        appendToDraft={vi.fn()}
+        setDraft={vi.fn()}
+      />,
+    );
+    expect(container).toMatchSnapshot();
+  });
+
+  it('wraps selected text with code fences using shortcut', () => {
+    const setDraft = vi.fn();
+    const appendToDraft = vi.fn();
+    render(
+      <ChatCodeComposer
+        value="Seleccion"
+        appendToDraft={appendToDraft}
+        setDraft={setDraft}
+      />,
+    );
+    const textarea = screen.getByRole('textbox') as HTMLTextAreaElement;
+    textarea.setSelectionRange(0, textarea.value.length);
+    fireEvent.keyDown(textarea, { key: 'c', ctrlKey: true, shiftKey: true });
+    expect(setDraft).toHaveBeenCalledWith('```\nSeleccion\n```\n');
+    expect(appendToDraft).not.toHaveBeenCalled();
+  });
+});

--- a/src/components/chat/composer/__tests__/__snapshots__/ChatCodeComposer.test.tsx.snap
+++ b/src/components/chat/composer/__tests__/__snapshots__/ChatCodeComposer.test.tsx.snap
@@ -1,0 +1,68 @@
+// Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
+
+exports[`ChatCodeComposer > renders composer with toolbar and textarea 1`] = `
+<div>
+  <div
+    class="chat-code-composer"
+  >
+    <div
+      aria-label="Acciones del compositor"
+      class="chat-code-toolbar"
+      role="toolbar"
+    >
+      <button
+        aria-label="Bloque de código"
+        class="composer-toolbar-button"
+        title="Bloque de código (Ctrl+Shift+\`)"
+        type="button"
+      >
+        <span
+          aria-hidden="true"
+        >
+          🧱
+        </span>
+      </button>
+      <button
+        aria-label="Envolver selección"
+        class="composer-toolbar-button"
+        title="Envolver selección (Ctrl+Shift+C)"
+        type="button"
+      >
+        <span
+          aria-hidden="true"
+        >
+          🪄
+        </span>
+      </button>
+      <button
+        aria-label="Copiar todo"
+        class="composer-toolbar-button"
+        title="Copiar todo"
+        type="button"
+      >
+        <span
+          aria-hidden="true"
+        >
+          📋
+        </span>
+      </button>
+      <div
+        class="chat-code-toolbar-spacer"
+      />
+      <span
+        aria-live="polite"
+        class="chat-code-token-count"
+      >
+        3
+         tokens estimados
+      </span>
+    </div>
+    <textarea
+      class="chat-code-textarea"
+      rows="4"
+    >
+      Hola agentes
+    </textarea>
+  </div>
+</div>
+`;

--- a/src/components/chat/messages/MessageContent.tsx
+++ b/src/components/chat/messages/MessageContent.tsx
@@ -1,4 +1,14 @@
 import React from 'react';
+import hljs from 'highlight.js/lib/core';
+import javascript from 'highlight.js/lib/languages/javascript';
+import typescript from 'highlight.js/lib/languages/typescript';
+import python from 'highlight.js/lib/languages/python';
+import bash from 'highlight.js/lib/languages/bash';
+import json from 'highlight.js/lib/languages/json';
+import xml from 'highlight.js/lib/languages/xml';
+import yaml from 'highlight.js/lib/languages/yaml';
+import markdown from 'highlight.js/lib/languages/markdown';
+import { copyToClipboard } from '../../../utils/clipboard';
 import {
   ChatContentPart,
   ChatTranscription,
@@ -9,6 +19,40 @@ import {
 } from '../../../core/messages/format';
 import { AudioPlayer } from './AudioPlayer';
 import { MessageActions } from './MessageActions';
+
+hljs.registerLanguage('javascript', javascript);
+hljs.registerLanguage('typescript', typescript);
+hljs.registerLanguage('python', python);
+hljs.registerLanguage('bash', bash);
+hljs.registerLanguage('json', json);
+hljs.registerLanguage('xml', xml);
+hljs.registerLanguage('yaml', yaml);
+hljs.registerLanguage('yml', yaml);
+hljs.registerLanguage('markdown', markdown);
+
+const escapeHtml = (code: string): string =>
+  code.replace(/[&<>]/g, char => ({ '&': '&amp;', '<': '&lt;', '>': '&gt;' }[char] ?? char));
+
+const highlightCode = (code: string, language?: string): string => {
+  const normalized = language?.toLowerCase();
+  if (normalized && hljs.getLanguage(normalized)) {
+    return hljs.highlight(code, { language: normalized }).value;
+  }
+
+  try {
+    return hljs.highlightAuto(code).value;
+  } catch (error) {
+    if (process.env.NODE_ENV !== 'production') {
+      console.warn('Fallo al resaltar código', error);
+    }
+    return escapeHtml(code);
+  }
+};
+
+const formatLineCount = (code: string): string => {
+  const lines = code.split(/\n/).length;
+  return `${lines} ${lines === 1 ? 'línea' : 'líneas'}`;
+};
 
 interface MessageContentProps {
   messageId: string;
@@ -38,21 +82,45 @@ export const MessageContent: React.FC<MessageContentProps> = ({
 
           return segments.map((segment, segmentIndex) => {
             if (segment.kind === 'code') {
+              const highlighted = highlightCode(segment.code, segment.language);
+              const lineLabel = formatLineCount(segment.code);
+              const languageClass = segment.language
+                ? `language-${segment.language.trim().toLowerCase()}`
+                : undefined;
+
               return (
                 <div className="message-code-block" key={`code-${index}-${segmentIndex}`}>
                   <div className="message-code-toolbar">
-                    {segment.language ? (
-                      <span className="message-code-language">{segment.language}</span>
-                    ) : null}
-                    <MessageActions
-                      messageId={messageId}
-                      value={segment.code}
-                      onAppend={onAppendToComposer}
-                      onShare={onShare}
-                    />
+                    <div className="message-code-meta">
+                      {segment.language ? (
+                        <span className="message-code-language">{segment.language}</span>
+                      ) : (
+                        <span className="message-code-language">texto</span>
+                      )}
+                      <span className="message-code-lines">{lineLabel}</span>
+                    </div>
+                    <div className="message-code-actions">
+                      <button
+                        type="button"
+                        className="message-code-copy"
+                        onClick={() => {
+                          void copyToClipboard(segment.code);
+                        }}
+                        aria-label="Copiar bloque de código"
+                        title="Copiar bloque de código"
+                      >
+                        Copiar
+                      </button>
+                      <MessageActions
+                        messageId={messageId}
+                        value={segment.code}
+                        onAppend={onAppendToComposer}
+                        onShare={onShare}
+                      />
+                    </div>
                   </div>
                   <pre>
-                    <code>{segment.code}</code>
+                    <code className={languageClass} dangerouslySetInnerHTML={{ __html: highlighted }} />
                   </pre>
                 </div>
               );

--- a/src/components/chat/messages/__tests__/__snapshots__/MessageContent.test.tsx.snap
+++ b/src/components/chat/messages/__tests__/__snapshots__/MessageContent.test.tsx.snap
@@ -15,40 +15,89 @@ exports[`MessageContent > renders fenced code blocks with actions 1`] = `
     <div
       class="message-code-toolbar"
     >
-      <span
-        class="message-code-language"
-      >
-        ts
-      </span>
       <div
-        aria-label="Acciones del bloque de código"
-        class="message-actions"
-        role="group"
+        class="message-code-meta"
+      >
+        <span
+          class="message-code-language"
+        >
+          ts
+        </span>
+        <span
+          class="message-code-lines"
+        >
+          2 líneas
+        </span>
+      </div>
+      <div
+        class="message-code-actions"
       >
         <button
-          class="message-action"
+          aria-label="Copiar bloque de código"
+          class="message-code-copy"
+          title="Copiar bloque de código"
           type="button"
         >
           Copiar
         </button>
-        <button
-          class="message-action"
-          type="button"
+        <div
+          aria-label="Acciones adicionales del bloque de código"
+          class="message-actions"
+          role="group"
         >
-          Añadir al compositor
-        </button>
-        <button
-          class="message-action"
-          type="button"
-        >
-          Enviar a Repo Studio
-        </button>
+          <button
+            aria-expanded="false"
+            aria-haspopup="true"
+            aria-label="Abrir menú de acciones"
+            class="message-action-trigger"
+            type="button"
+          >
+            ⋯
+          </button>
+        </div>
       </div>
     </div>
     <pre>
-      <code>
-        const saludo: string = 'hola';
-console.log(saludo);
+      <code
+        class="language-ts"
+      >
+        <span
+          class="hljs-keyword"
+        >
+          const
+        </span>
+         
+        <span
+          class="hljs-attr"
+        >
+          saludo
+        </span>
+        : 
+        <span
+          class="hljs-built_in"
+        >
+          string
+        </span>
+         = 
+        <span
+          class="hljs-string"
+        >
+          'hola'
+        </span>
+        ;
+
+        <span
+          class="hljs-variable language_"
+        >
+          console
+        </span>
+        .
+        <span
+          class="hljs-title function_"
+        >
+          log
+        </span>
+        (saludo);
       </code>
     </pre>
   </div>

--- a/src/core/messages/__tests__/format.test.ts
+++ b/src/core/messages/__tests__/format.test.ts
@@ -1,0 +1,26 @@
+import { describe, expect, it } from 'vitest';
+import { splitMarkdownContent } from '../format';
+
+describe('splitMarkdownContent', () => {
+  it('splits markdown into text and code segments preserving language', () => {
+    const input = "Hola\n\n```js\nconsole.log('hola');\n```\n\nAdiós";
+    const segments = splitMarkdownContent(input);
+    expect(segments).toHaveLength(3);
+    expect(segments[0].kind).toBe('text');
+    expect(segments[0].text.trim()).toBe('Hola');
+    expect(segments[1]).toEqual({ kind: 'code', code: "console.log('hola');", language: 'js' });
+    expect(segments[2].kind).toBe('text');
+    expect(segments[2].text.trim()).toBe('Adiós');
+  });
+
+  it('returns single text segment when no fences are present', () => {
+    const input = 'Mensaje sin código';
+    expect(splitMarkdownContent(input)).toEqual([{ kind: 'text', text: input }]);
+  });
+
+  it('trims trailing whitespace inside code blocks', () => {
+    const input = '```python\nprint("hola")\n\n\n```';
+    const segments = splitMarkdownContent(input);
+    expect(segments[0]).toEqual({ kind: 'code', code: 'print("hola")', language: 'python' });
+  });
+});

--- a/src/utils/__tests__/clipboard.test.ts
+++ b/src/utils/__tests__/clipboard.test.ts
@@ -1,0 +1,44 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { copyToClipboard } from '../clipboard';
+
+declare global {
+  // eslint-disable-next-line no-var
+  var clipboardData: string | undefined;
+}
+
+const setupFallbackClipboard = () => {
+  Object.defineProperty(document, 'execCommand', {
+    value: vi.fn(command => {
+      if (command === 'copy') {
+        globalThis.clipboardData = (document.activeElement as HTMLTextAreaElement | null)?.value ?? '';
+        return true;
+      }
+      return false;
+    }),
+    configurable: true,
+  });
+};
+
+describe('copyToClipboard', () => {
+  beforeEach(() => {
+    // @ts-expect-error reset test clipboard
+    globalThis.clipboardData = undefined;
+  });
+
+  it('uses navigator.clipboard when available', async () => {
+    const writeText = vi.fn().mockResolvedValue(undefined);
+    Object.assign(navigator, { clipboard: { writeText } });
+
+    await copyToClipboard('hola mundo');
+    expect(writeText).toHaveBeenCalledWith('hola mundo');
+  });
+
+  it('falls back to execCommand when clipboard API is missing', async () => {
+    // @ts-expect-error override clipboard for test
+    navigator.clipboard = undefined;
+    setupFallbackClipboard();
+
+    await copyToClipboard('texto secundario');
+    expect(globalThis.clipboardData).toBe('texto secundario');
+  });
+});

--- a/src/utils/clipboard.ts
+++ b/src/utils/clipboard.ts
@@ -1,0 +1,24 @@
+export const copyToClipboard = async (value: string): Promise<void> => {
+  if (typeof navigator !== 'undefined' && navigator?.clipboard?.writeText) {
+    await navigator.clipboard.writeText(value);
+    return;
+  }
+
+  // Fallback for environments sin API de clipboard (por ejemplo tests)
+  if (typeof document === 'undefined') {
+    return;
+  }
+
+  const textarea = document.createElement('textarea');
+  textarea.value = value;
+  textarea.setAttribute('readonly', 'true');
+  textarea.style.position = 'absolute';
+  textarea.style.left = '-9999px';
+  document.body.appendChild(textarea);
+  textarea.focus();
+  textarea.select();
+  document.execCommand('copy');
+  document.body.removeChild(textarea);
+};
+
+export default copyToClipboard;

--- a/src/utils/tokens.ts
+++ b/src/utils/tokens.ts
@@ -1,0 +1,17 @@
+export const estimateTokenCount = (value: string): number => {
+  if (!value) {
+    return 0;
+  }
+
+  const sanitized = value.trim();
+  if (!sanitized) {
+    return 0;
+  }
+
+  const words = sanitized.split(/\s+/u).length;
+  const punctuation = sanitized.replace(/[\w\d\s]/gu, '').length;
+  const estimated = Math.ceil(words * 1.2 + punctuation * 0.5);
+  return Number.isFinite(estimated) ? estimated : 0;
+};
+
+export default estimateTokenCount;


### PR DESCRIPTION
## Summary
- add a dedicated ChatCodeComposer with code block shortcuts, clipboard support and live token estimate
- highlight code blocks in MessageContent, surface copy/menu actions, and restyle chat UI to support the new composer
- introduce clipboard/tokens utilities with unit tests and refresh repo workflow integration tests for the menu changes

## Testing
- npm test -- --run

------
https://chatgpt.com/codex/tasks/task_e_68d023f55ea483339c610a15e57e5e6e