### PR TITLE
feat: add collaborative code canvas with autocomplete

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,9 +14,11 @@
     "jarvis:dev": "python jarvis_core/JarvisCore.py --models-dir ./models"
   },
   "dependencies": {
+    "@monaco-editor/react": "^4.6.0",
     "@tauri-apps/api": "^1.5.0",
     "@types/three": "^0.179.0",
     "highlight.js": "^11.9.0",
+    "monaco-editor": "^0.52.0",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
     "simple-git": "^3.27.0",

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -7,6 +7,7 @@ import { ChatWorkspace } from './components/chat/ChatWorkspace';
 import { SidePanel } from './components/chat/SidePanel';
 import { ConversationStatsModal } from './components/chat/ConversationStatsModal';
 import { RepoStudio } from './components/repo/RepoStudio';
+import { CodeCanvas } from './components/code/CodeCanvas';
 import { AgentProvider, useAgents } from './core/agents/AgentContext';
 import { useAgentPresence } from './core/agents/presence';
 import { MessageProvider, useMessages } from './core/messages/MessageContext';
@@ -45,7 +46,7 @@ const AppContent: React.FC<AppContentProps> = ({
   const { pendingResponses } = useMessages();
   const { presenceMap, summary: presenceSummary, refresh } = useAgentPresence(agents, apiKeys);
   const [actorFilter, setActorFilter] = useState<ChatActorFilter>('all');
-  const [activeView, setActiveView] = useState<'chat' | 'repo'>('chat');
+  const [activeView, setActiveView] = useState<'chat' | 'repo' | 'canvas'>('chat');
   const [isSettingsOpen, setSettingsOpen] = useState(false);
   const [isPluginsOpen, setPluginsOpen] = useState(false);
   const [isMcpOpen, setMcpOpen] = useState(false);
@@ -87,7 +88,7 @@ const AppContent: React.FC<AppContentProps> = ({
         onChangeView={setActiveView}
       />
 
-      {activeView === 'chat' ? (
+      {activeView === 'chat' && (
         <div className={`app-body sidebar-${sidePanelPosition}`}>
           {sidePanelPosition === 'left' && (
             <aside className="app-sidebar">
@@ -116,10 +117,20 @@ const AppContent: React.FC<AppContentProps> = ({
             </aside>
           )}
         </div>
-      ) : (
+      )}
+
+      {activeView === 'repo' && (
         <div className="app-body">
           <div className="repo-main">
             <RepoStudio />
+          </div>
+        </div>
+      )}
+
+      {activeView === 'canvas' && (
+        <div className="app-body">
+          <div className="canvas-main">
+            <CodeCanvas />
           </div>
         </div>
       )}

--- a/src/AppLayout.css
+++ b/src/AppLayout.css
@@ -261,6 +261,15 @@
   padding: 32px;
 }
 
+.canvas-main {
+  flex: 1 1 auto;
+  min-width: 0;
+  display: flex;
+  flex-direction: column;
+  padding: 0;
+  overflow: hidden;
+}
+
 @media (max-width: 1440px) {
   .app-sidebar {
     min-width: 240px;

--- a/src/components/chat/ChatTopBar.tsx
+++ b/src/components/chat/ChatTopBar.tsx
@@ -20,8 +20,8 @@ interface ChatTopBarProps {
   onOpenPlugins: () => void;
   onOpenMcp: () => void;
   onOpenModelManager: () => void;
-  activeView: 'chat' | 'repo';
-  onChangeView: (view: 'chat' | 'repo') => void;
+  activeView: 'chat' | 'repo' | 'canvas';
+  onChangeView: (view: 'chat' | 'repo' | 'canvas') => void;
 }
 
 const STATUS_LABELS: Record<AgentPresenceStatus, string> = {
@@ -226,6 +226,16 @@ export const ChatTopBar: React.FC<ChatTopBarProps> = ({
             aria-selected={activeView === 'repo'}
           >
             🗂️
+          </button>
+          <button
+            type="button"
+            className={activeView === 'canvas' ? 'is-active' : ''}
+            onClick={() => onChangeView('canvas')}
+            role="tab"
+            aria-selected={activeView === 'canvas'}
+            aria-label="Abrir canvas de código"
+          >
+            🧪
           </button>
         </div>
       </div>

--- a/src/components/code/CodeCanvas.css
+++ b/src/components/code/CodeCanvas.css
@@ -1,0 +1,223 @@
+.code-canvas {
+  display: flex;
+  flex-direction: column;
+  height: 100%;
+  width: 100%;
+  background: #0f1216;
+  color: #f2f5f9;
+}
+
+.canvas-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  padding: 0.5rem 1rem;
+  background: #171c22;
+  border-bottom: 1px solid rgba(255, 255, 255, 0.06);
+  gap: 1rem;
+}
+
+.file-tabs {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+}
+
+.file-tab {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.4rem;
+  background: rgba(255, 255, 255, 0.06);
+  color: inherit;
+  border: none;
+  border-radius: 0.5rem;
+  padding: 0.35rem 0.75rem;
+  cursor: pointer;
+  font-size: 0.85rem;
+  transition: background 0.2s ease;
+}
+
+.file-tab .file-name {
+  font-weight: 600;
+}
+
+.file-tab .file-meta {
+  opacity: 0.6;
+  font-size: 0.75rem;
+}
+
+.file-tab .file-remove {
+  opacity: 0.4;
+  transition: opacity 0.2s ease;
+}
+
+.file-tab .file-remove:hover {
+  opacity: 0.9;
+}
+
+.file-tab.is-active {
+  background: #2d89ef;
+  color: #fff;
+}
+
+.file-tab.add {
+  font-weight: 700;
+  background: rgba(255, 255, 255, 0.12);
+}
+
+.canvas-controls {
+  display: flex;
+  align-items: center;
+  gap: 1rem;
+}
+
+.canvas-controls label {
+  display: flex;
+  flex-direction: column;
+  font-size: 0.75rem;
+  gap: 0.25rem;
+  color: rgba(255, 255, 255, 0.75);
+}
+
+.canvas-controls select {
+  background: #0f1216;
+  color: inherit;
+  border-radius: 0.4rem;
+  border: 1px solid rgba(255, 255, 255, 0.12);
+  padding: 0.35rem 0.5rem;
+}
+
+.canvas-controls .primary {
+  background: linear-gradient(120deg, #2d89ef, #5f2ded);
+  color: #fff;
+  border: none;
+  border-radius: 0.5rem;
+  padding: 0.45rem 0.9rem;
+  font-weight: 600;
+  cursor: pointer;
+}
+
+.canvas-controls .primary:disabled {
+  opacity: 0.5;
+  cursor: not-allowed;
+}
+
+.canvas-body {
+  flex: 1;
+  display: grid;
+  grid-template-columns: minmax(240px, 320px) 1fr;
+  overflow: hidden;
+}
+
+.canvas-sidebar {
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+  padding: 1rem;
+  background: #14181f;
+  border-right: 1px solid rgba(255, 255, 255, 0.06);
+  overflow-y: auto;
+}
+
+.canvas-sidebar h3 {
+  margin: 0 0 0.5rem;
+  font-size: 0.85rem;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  color: rgba(255, 255, 255, 0.6);
+}
+
+.canvas-sidebar label {
+  display: flex;
+  flex-direction: column;
+  gap: 0.25rem;
+  font-size: 0.75rem;
+  color: rgba(255, 255, 255, 0.75);
+}
+
+.canvas-sidebar select {
+  background: #0f1216;
+  color: inherit;
+  border-radius: 0.4rem;
+  border: 1px solid rgba(255, 255, 255, 0.12);
+  padding: 0.35rem 0.5rem;
+}
+
+.canvas-sidebar button {
+  background: rgba(255, 255, 255, 0.08);
+  color: inherit;
+  border: 1px solid rgba(255, 255, 255, 0.12);
+  border-radius: 0.5rem;
+  padding: 0.35rem 0.75rem;
+  font-size: 0.8rem;
+  cursor: pointer;
+  transition: background 0.2s ease;
+}
+
+.canvas-sidebar button:hover:not(:disabled) {
+  background: rgba(45, 137, 239, 0.35);
+}
+
+.canvas-sidebar button:disabled {
+  opacity: 0.5;
+  cursor: not-allowed;
+}
+
+.canvas-sidebar ul {
+  list-style: none;
+  padding: 0;
+  margin: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+}
+
+.canvas-sidebar li {
+  display: flex;
+  flex-direction: column;
+  gap: 0.35rem;
+}
+
+.canvas-sidebar pre {
+  max-height: 120px;
+  overflow: auto;
+  background: rgba(15, 18, 22, 0.8);
+  border-radius: 0.35rem;
+  padding: 0.5rem;
+  font-size: 0.75rem;
+  line-height: 1.3;
+  white-space: pre-wrap;
+  word-break: break-word;
+}
+
+.canvas-editor {
+  position: relative;
+  height: 100%;
+}
+
+.empty-state {
+  padding: 2rem;
+  text-align: center;
+  color: rgba(255, 255, 255, 0.6);
+}
+
+.sidebar-section {
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+  padding-bottom: 0.75rem;
+  border-bottom: 1px solid rgba(255, 255, 255, 0.06);
+}
+
+.sidebar-section:last-of-type {
+  border-bottom: none;
+}
+
+.sidebar-error {
+  background: rgba(255, 93, 99, 0.15);
+  border: 1px solid rgba(255, 93, 99, 0.35);
+  border-radius: 0.5rem;
+  padding: 0.65rem;
+  font-size: 0.8rem;
+  color: #ff5d63;
+}

--- a/src/components/code/CodeCanvas.tsx
+++ b/src/components/code/CodeCanvas.tsx
@@ -1,0 +1,587 @@
+import React, { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import Editor, { type Monaco } from '@monaco-editor/react';
+import type { editor as MonacoEditor } from 'monaco-editor';
+import './CodeCanvas.css';
+import { useMessages } from '../../core/messages/MessageContext';
+import { useRepoWorkflow } from '../../core/codex';
+import { useAgents } from '../../core/agents/AgentContext';
+import { useJarvisCore } from '../../core/jarvis/JarvisCoreContext';
+import useCodeAutocomplete, {
+  type AutocompleteSuggestion,
+  type CanvasFileReference,
+  type CodeAutocompleteProvider,
+} from '../../hooks/useCodeAutocomplete';
+
+interface CanvasFile extends CanvasFileReference {
+  language: string;
+  createdAt: string;
+  updatedAt: string;
+}
+
+type CanvasProviderOption = {
+  id: CodeAutocompleteProvider;
+  label: string;
+};
+
+const STORAGE_KEY = 'junglemonk.code-canvas.v1';
+
+const DEFAULT_LANGUAGES = [
+  { id: 'typescript', label: 'TypeScript' },
+  { id: 'javascript', label: 'JavaScript' },
+  { id: 'python', label: 'Python' },
+  { id: 'markdown', label: 'Markdown' },
+  { id: 'json', label: 'JSON' },
+  { id: 'shell', label: 'Shell' },
+];
+
+const DEFAULT_FILE_NAME = 'boceto.ts';
+
+interface PersistedCanvasState {
+  files: CanvasFile[];
+  activeFileId: string | null;
+}
+
+const createCanvasFile = (name: string, language: string): CanvasFile => ({
+  id: `canvas-${Date.now().toString(36)}-${Math.random().toString(36).slice(2, 8)}`,
+  name,
+  language,
+  content: '',
+  createdAt: new Date().toISOString(),
+  updatedAt: new Date().toISOString(),
+});
+
+const mapMessagesToOptions = (messages: ReturnType<typeof useMessages>['messages'], toPlain: ReturnType<typeof useMessages>['toPlainText']) => {
+  return messages
+    .slice(-10)
+    .reverse()
+    .map(message => {
+      const labelParts = [
+        message.author === 'user'
+          ? 'Usuario'
+          : message.author === 'agent'
+            ? `Agente${message.agentId ? ` ${message.agentId}` : ''}`
+            : 'Sistema',
+        new Date(message.timestamp).toLocaleTimeString([], { hour: '2-digit', minute: '2-digit' }),
+      ];
+      const preview = message.canonicalCode?.trim() || toPlain(message.content).slice(0, 80);
+      return {
+        id: message.id,
+        label: `${labelParts.join(' · ')} · ${preview}`,
+        content: message.canonicalCode?.trim() || toPlain(message.content),
+      };
+    })
+    .filter(option => option.content.trim());
+};
+
+const getSelectionOrFullText = (editorInstance: MonacoEditor.IStandaloneCodeEditor | null, fallback: string) => {
+  if (!editorInstance) {
+    return fallback;
+  }
+  const selection = editorInstance.getSelection();
+  if (!selection || selection.isEmpty()) {
+    return fallback;
+  }
+  const model = editorInstance.getModel();
+  if (!model) {
+    return fallback;
+  }
+  return model.getValueInRange(selection) || fallback;
+};
+
+const applySuggestionToEditor = (
+  editorInstance: MonacoEditor.IStandaloneCodeEditor | null,
+  monacoInstance: Monaco | null,
+  suggestion: AutocompleteSuggestion,
+): string | null => {
+  const editorModel = editorInstance?.getModel();
+  if (!editorInstance || !editorModel) {
+    return suggestion.text;
+  }
+  const selection = editorInstance.getSelection();
+  const position = editorInstance.getPosition();
+  const range =
+    selection && !selection.isEmpty()
+      ? selection
+      : monacoInstance
+      ? new monacoInstance.Range(
+          position?.lineNumber ?? 1,
+          position?.column ?? 1,
+          position?.lineNumber ?? 1,
+          position?.column ?? 1,
+        )
+      : {
+          startLineNumber: position?.lineNumber ?? 1,
+          startColumn: position?.column ?? 1,
+          endLineNumber: position?.lineNumber ?? 1,
+          endColumn: position?.column ?? 1,
+        };
+
+  editorInstance.executeEdits('code-canvas-autocomplete', [
+    {
+      range,
+      text: suggestion.text,
+      forceMoveMarkers: true,
+    },
+  ]);
+
+  editorInstance.focus();
+  return editorModel.getValue();
+};
+
+const loadPersistedState = (): PersistedCanvasState | null => {
+  if (typeof window === 'undefined') {
+    return null;
+  }
+  try {
+    const raw = window.localStorage.getItem(STORAGE_KEY);
+    if (!raw) {
+      return null;
+    }
+    const parsed = JSON.parse(raw) as PersistedCanvasState;
+    if (!parsed || !Array.isArray(parsed.files)) {
+      return null;
+    }
+    return {
+      files: parsed.files.map(file => ({
+        ...file,
+        createdAt: file.createdAt ?? new Date().toISOString(),
+        updatedAt: file.updatedAt ?? new Date().toISOString(),
+      })),
+      activeFileId: parsed.activeFileId ?? parsed.files[0]?.id ?? null,
+    };
+  } catch (error) {
+    console.warn('No se pudo restaurar el estado del canvas de código:', error);
+    return null;
+  }
+};
+
+const persistState = (state: PersistedCanvasState) => {
+  if (typeof window === 'undefined') {
+    return;
+  }
+  try {
+    window.localStorage.setItem(STORAGE_KEY, JSON.stringify(state));
+  } catch (error) {
+    console.warn('No se pudo persistir el estado del canvas de código:', error);
+  }
+};
+
+export const CodeCanvas: React.FC = () => {
+  const { messages, toPlainText, appendToDraft } = useMessages();
+  const { queueRequest, pendingRequest } = useRepoWorkflow();
+  const { agents } = useAgents();
+  const { runtimeStatus } = useJarvisCore();
+  const editorRef = useRef<MonacoEditor.IStandaloneCodeEditor | null>(null);
+  const monacoRef = useRef<Monaco | null>(null);
+
+  const persisted = useMemo(() => loadPersistedState(), []);
+  const [files, setFiles] = useState<CanvasFile[]>(() => {
+    if (persisted?.files?.length) {
+      return persisted.files;
+    }
+    return [createCanvasFile(DEFAULT_FILE_NAME, 'typescript')];
+  });
+  const [activeFileId, setActiveFileId] = useState<string | null>(() => persisted?.activeFileId ?? persisted?.files?.[0]?.id ?? files[0]?.id ?? null);
+  const [provider, setProvider] = useState<CodeAutocompleteProvider>('openai');
+  const [model, setModel] = useState<string | undefined>(undefined);
+
+  const activeFile = useMemo(() => files.find(file => file.id === activeFileId) ?? files[0] ?? null, [files, activeFileId]);
+
+  const fileReferences: CanvasFileReference[] = useMemo(
+    () => files.map(({ id, name, language, content }) => ({ id, name, language, content })),
+    [files],
+  );
+
+  const messageOptions = useMemo(() => mapMessagesToOptions(messages, toPlainText), [messages, toPlainText]);
+
+  const providerOptions: CanvasProviderOption[] = useMemo(() => {
+    const base: CanvasProviderOption[] = [
+      { id: 'openai', label: 'OpenAI' },
+      { id: 'anthropic', label: 'Claude' },
+      { id: 'groq', label: 'Groq' },
+    ];
+    if (runtimeStatus === 'ready' || runtimeStatus === 'starting') {
+      base.push({ id: 'jarvis', label: 'Jarvis Core' });
+    }
+    return base;
+  }, [runtimeStatus]);
+
+  const providerAgents = useMemo(() => {
+    const normalized = provider.toLowerCase();
+    if (provider === 'jarvis') {
+      return [];
+    }
+    return agents
+      .filter(agent => agent.provider.toLowerCase() === normalized && agent.active)
+      .map(agent => ({ id: agent.model, label: agent.model }));
+  }, [agents, provider]);
+
+  const {
+    requestAutocomplete,
+    isLoading: isCompleting,
+    error: completionError,
+    suggestions,
+    providerReady,
+  } = useCodeAutocomplete({ provider, model });
+
+  useEffect(() => {
+    persistState({ files, activeFileId });
+  }, [files, activeFileId]);
+
+  const handleEditorMount = useCallback(
+    (editorInstance: MonacoEditor.IStandaloneCodeEditor | undefined, monacoInstance: Monaco | undefined) => {
+      editorRef.current = editorInstance ?? null;
+      monacoRef.current = monacoInstance ?? null;
+    },
+    [],
+  );
+
+  const updateFile = useCallback(
+    (fileId: string, updater: (previous: CanvasFile) => CanvasFile) => {
+      setFiles(prev =>
+        prev.map(file => (file.id === fileId ? updater({ ...file }) : file)),
+      );
+    },
+    [],
+  );
+
+  const handleContentChange = useCallback(
+    (value?: string) => {
+      if (!activeFile) {
+        return;
+      }
+      const nextValue = value ?? '';
+      updateFile(activeFile.id, previous => ({
+        ...previous,
+        content: nextValue,
+        updatedAt: new Date().toISOString(),
+      }));
+    },
+    [activeFile, updateFile],
+  );
+
+  const handleLanguageChange = useCallback(
+    (event: React.ChangeEvent<HTMLSelectElement>) => {
+      if (!activeFile) {
+        return;
+      }
+      const nextLanguage = event.target.value;
+      updateFile(activeFile.id, previous => ({
+        ...previous,
+        language: nextLanguage,
+        updatedAt: new Date().toISOString(),
+      }));
+    },
+    [activeFile, updateFile],
+  );
+
+  const handleRename = useCallback(() => {
+    if (!activeFile) {
+      return;
+    }
+    const nextName = window.prompt('Nuevo nombre del archivo', activeFile.name)?.trim();
+    if (!nextName) {
+      return;
+    }
+    updateFile(activeFile.id, previous => ({
+      ...previous,
+      name: nextName,
+      updatedAt: new Date().toISOString(),
+    }));
+  }, [activeFile, updateFile]);
+
+  const handleAddFile = useCallback(() => {
+    const baseName = `boceto-${files.length + 1}.ts`;
+    const file = createCanvasFile(baseName, 'typescript');
+    setFiles(prev => [...prev, file]);
+    setActiveFileId(file.id);
+  }, [files.length]);
+
+  const handleRemoveFile = useCallback(
+    (fileId: string) => {
+      setFiles(prev => prev.filter(file => file.id !== fileId));
+      setActiveFileId(prevId => {
+        if (prevId === fileId) {
+          const remaining = files.filter(file => file.id !== fileId);
+          return remaining[0]?.id ?? null;
+        }
+        return prevId;
+      });
+    },
+    [files],
+  );
+
+  const handleSendToChat = useCallback(() => {
+    if (!activeFile) {
+      return;
+    }
+    const snippet = getSelectionOrFullText(editorRef.current, activeFile.content).trim();
+    if (!snippet) {
+      return;
+    }
+    appendToDraft(snippet);
+  }, [activeFile, appendToDraft]);
+
+  const handleSendToRepo = useCallback(() => {
+    if (!activeFile) {
+      return;
+    }
+    const snippet = getSelectionOrFullText(editorRef.current, activeFile.content).trim();
+    if (!snippet) {
+      return;
+    }
+    queueRequest({
+      messageId: activeFile.id,
+      canonicalCode: snippet,
+    });
+  }, [activeFile, queueRequest]);
+
+  const handleImportMessage = useCallback(
+    (event: React.ChangeEvent<HTMLSelectElement>) => {
+      const targetId = event.target.value;
+      if (!activeFile || !targetId) {
+        return;
+      }
+      const selected = messageOptions.find(option => option.id === targetId);
+      if (!selected) {
+        return;
+      }
+      const text = selected.content.trim();
+      if (!text) {
+        return;
+      }
+      const editor = editorRef.current;
+      if (editor) {
+        editor.setValue(text);
+      }
+      updateFile(activeFile.id, previous => ({
+        ...previous,
+        content: text,
+        updatedAt: new Date().toISOString(),
+      }));
+    },
+    [activeFile, messageOptions, updateFile],
+  );
+
+  const handleImportRepo = useCallback(() => {
+    if (!activeFile || !pendingRequest) {
+      return;
+    }
+    const snippet = pendingRequest.canonicalCode?.trim() || pendingRequest.originalResponse?.trim();
+    if (!snippet) {
+      return;
+    }
+    if (editorRef.current) {
+      editorRef.current.setValue(snippet);
+    }
+    updateFile(activeFile.id, previous => ({
+      ...previous,
+      content: snippet,
+      updatedAt: new Date().toISOString(),
+    }));
+  }, [activeFile, pendingRequest, updateFile]);
+
+  const handleAutocomplete = useCallback(async () => {
+    if (!activeFile) {
+      return;
+    }
+    const editorInstance = editorRef.current;
+    const cursor = editorInstance
+      ? {
+          lineNumber: editorInstance.getPosition()?.lineNumber ?? 1,
+          column: editorInstance.getPosition()?.column ?? 1,
+        }
+      : undefined;
+
+    const result = await requestAutocomplete({
+      file: { id: activeFile.id, name: activeFile.name, language: activeFile.language, content: activeFile.content },
+      cursor,
+      files: fileReferences,
+    });
+
+    if (!result?.length) {
+      return;
+    }
+
+    const applied = applySuggestionToEditor(editorInstance, monacoRef.current, result[0]);
+    if (typeof applied === 'string') {
+      updateFile(activeFile.id, previous => ({
+        ...previous,
+        content: applied,
+        updatedAt: new Date().toISOString(),
+      }));
+    }
+  }, [activeFile, fileReferences, requestAutocomplete, updateFile]);
+
+  return (
+    <div className="code-canvas">
+      <div className="canvas-header">
+        <div className="file-tabs" role="tablist" aria-label="Archivos en el canvas">
+          {files.map(file => (
+            <button
+              key={file.id}
+              type="button"
+              role="tab"
+              className={`file-tab ${file.id === activeFile?.id ? 'is-active' : ''}`}
+              aria-selected={file.id === activeFile?.id}
+              onClick={() => setActiveFileId(file.id)}
+            >
+              <span className="file-name">{file.name}</span>
+              <span className="file-meta">{file.language}</span>
+              <span
+                role="button"
+                className="file-remove"
+                onClick={event => {
+                  event.stopPropagation();
+                  handleRemoveFile(file.id);
+                }}
+                aria-label={`Cerrar ${file.name}`}
+              >
+                ×
+              </span>
+            </button>
+          ))}
+          <button type="button" className="file-tab add" onClick={handleAddFile} aria-label="Nuevo archivo">
+            ＋
+          </button>
+        </div>
+
+        <div className="canvas-controls">
+          <label>
+            Proveedor
+            <select value={provider} onChange={event => setProvider(event.target.value as CodeAutocompleteProvider)}>
+              {providerOptions.map(option => (
+                <option key={option.id} value={option.id}>
+                  {option.label}
+                </option>
+              ))}
+            </select>
+          </label>
+          {providerAgents.length > 0 && (
+            <label>
+              Modelo
+              <select value={model ?? ''} onChange={event => setModel(event.target.value || undefined)}>
+                <option value="">Automático</option>
+                {providerAgents.map(option => (
+                  <option key={option.id} value={option.id}>
+                    {option.label}
+                  </option>
+                ))}
+              </select>
+            </label>
+          )}
+          <button
+            type="button"
+            className="primary"
+            onClick={handleAutocomplete}
+            disabled={!activeFile || isCompleting || !providerReady}
+          >
+            {isCompleting ? 'Completando…' : 'Autocompletar'}
+          </button>
+        </div>
+      </div>
+
+      <div className="canvas-body">
+        <aside className="canvas-sidebar">
+          <div className="sidebar-section">
+            <h3>Archivo</h3>
+            <label>
+              Lenguaje
+              <select value={activeFile?.language ?? 'typescript'} onChange={handleLanguageChange}>
+                {DEFAULT_LANGUAGES.map(option => (
+                  <option key={option.id} value={option.id}>
+                    {option.label}
+                  </option>
+                ))}
+              </select>
+            </label>
+            <button type="button" onClick={handleRename} disabled={!activeFile}>
+              Renombrar
+            </button>
+          </div>
+
+          <div className="sidebar-section">
+            <h3>Chat</h3>
+            <button type="button" onClick={handleSendToChat} disabled={!activeFile}>
+              Enviar fragmento
+            </button>
+            <label>
+              Cargar mensaje
+              <select defaultValue="" onChange={handleImportMessage}>
+                <option value="">Selecciona…</option>
+                {messageOptions.map(option => (
+                  <option key={option.id} value={option.id}>
+                    {option.label}
+                  </option>
+                ))}
+              </select>
+            </label>
+          </div>
+
+          <div className="sidebar-section">
+            <h3>Repo Studio</h3>
+            <button type="button" onClick={handleSendToRepo} disabled={!activeFile}>
+              Lanzar análisis
+            </button>
+            <button type="button" onClick={handleImportRepo} disabled={!activeFile || !pendingRequest}>
+              Cargar último plan
+            </button>
+          </div>
+
+          {completionError && <div className="sidebar-error">{completionError}</div>}
+          {!!suggestions.length && (
+            <div className="sidebar-section">
+              <h3>Sugerencias</h3>
+              <ul>
+                {suggestions.map(suggestion => (
+                  <li key={suggestion.id}>
+                    <button
+                      type="button"
+                      onClick={() => {
+                        const applied = applySuggestionToEditor(editorRef.current, monacoRef.current, suggestion);
+                        if (typeof applied === 'string' && activeFile) {
+                          updateFile(activeFile.id, previous => ({
+                            ...previous,
+                            content: applied,
+                            updatedAt: new Date().toISOString(),
+                          }));
+                        }
+                      }}
+                    >
+                      Insertar ({suggestion.provider})
+                    </button>
+                    <pre>{suggestion.text}</pre>
+                  </li>
+                ))}
+              </ul>
+            </div>
+          )}
+        </aside>
+
+        <div className="canvas-editor">
+          {activeFile ? (
+            <Editor
+              height="100%"
+              defaultLanguage={activeFile.language}
+              language={activeFile.language}
+              value={activeFile.content}
+              onChange={handleContentChange}
+              theme="vs-dark"
+              onMount={handleEditorMount}
+              options={{
+                fontSize: 14,
+                minimap: { enabled: false },
+                wordWrap: 'on',
+                automaticLayout: true,
+              }}
+            />
+          ) : (
+            <div className="empty-state">No hay archivos activos. Crea uno nuevo para empezar.</div>
+          )}
+        </div>
+      </div>
+    </div>
+  );
+};
+
+export default CodeCanvas;

--- a/src/hooks/useCodeAutocomplete.ts
+++ b/src/hooks/useCodeAutocomplete.ts
@@ -1,0 +1,301 @@
+import { useCallback, useMemo, useRef, useState } from 'react';
+import { useAgents } from '../core/agents/AgentContext';
+import { useJarvisCore } from '../core/jarvis/JarvisCoreContext';
+import {
+  callAnthropicChat,
+  callGroqChat,
+  callOpenAIChat,
+  type ProviderContent,
+} from '../utils/aiProviders';
+import type { JarvisChatResult } from '../services/jarvisCoreClient';
+
+type CloudAutocompleteProvider = 'openai' | 'anthropic' | 'groq';
+
+export type CodeAutocompleteProvider = CloudAutocompleteProvider | 'jarvis';
+
+export interface CanvasFileReference {
+  id: string;
+  name: string;
+  language: string;
+  content: string;
+}
+
+export interface AutocompleteCursorPosition {
+  lineNumber: number;
+  column: number;
+}
+
+export interface AutocompleteRequest {
+  file: CanvasFileReference;
+  cursor?: AutocompleteCursorPosition;
+  files?: CanvasFileReference[];
+}
+
+export interface AutocompleteSuggestion {
+  id: string;
+  text: string;
+  provider: CodeAutocompleteProvider;
+  model?: string;
+  reason?: string;
+}
+
+export interface UseCodeAutocompleteOptions {
+  provider: CodeAutocompleteProvider;
+  model?: string;
+  temperature?: number;
+  maxTokens?: number;
+}
+
+export interface UseCodeAutocompleteValue {
+  isLoading: boolean;
+  error: string | null;
+  suggestions: AutocompleteSuggestion[];
+  providerReady: boolean;
+  requestAutocomplete: (request: AutocompleteRequest) => Promise<AutocompleteSuggestion[]>;
+  cancel: () => void;
+}
+
+const SYSTEM_PROMPT =
+  'Eres un asistente de autocompletado. Devuelve código válido y conciso para continuar el fragmento indicado.';
+
+const sanitizeContent = (content: ProviderContent): string => {
+  if (typeof content === 'string') {
+    return content;
+  }
+
+  return content
+    .map(part => {
+      if (!part) {
+        return '';
+      }
+      if (typeof part === 'string') {
+        return part;
+      }
+      if (part.type === 'text') {
+        return part.text;
+      }
+      if (part.type === 'image') {
+        return part.alt ?? '';
+      }
+      if (part.type === 'audio') {
+        return part.transcript ?? '';
+      }
+      if (part.type === 'file') {
+        return part.name ?? '';
+      }
+      return '';
+    })
+    .join('\n');
+};
+
+const buildContextPrompt = (
+  { file, cursor, files }: AutocompleteRequest,
+  provider: CodeAutocompleteProvider,
+): string => {
+  const cursorLabel = cursor
+    ? `La solicitud se realiza en la línea ${cursor.lineNumber}, columna ${cursor.column}.`
+    : 'La solicitud se realiza al final del archivo.';
+
+  const header = [`Archivo activo: ${file.name} (${file.language}).`, cursorLabel].join(' ');
+
+  const otherFiles = files
+    ?.filter(entry => entry.id !== file.id && entry.content.trim())
+    .map(entry => `Archivo ${entry.name} (${entry.language}):\n${entry.content}`);
+
+  const contextSections = [header, 'Contenido actual:\n```\n' + file.content + '\n```'];
+
+  if (otherFiles?.length) {
+    contextSections.push(`Contexto adicional:\n${otherFiles.join('\n\n')}`);
+  }
+
+  if (provider !== 'jarvis') {
+    contextSections.push('Responde únicamente con la continuación sugerida del código.');
+  }
+
+  return contextSections.join('\n\n');
+};
+
+const buildSuggestion = (
+  provider: CodeAutocompleteProvider,
+  model: string | undefined,
+  text: string,
+): AutocompleteSuggestion => ({
+  id: `${provider}-${Date.now().toString(36)}-${Math.random().toString(36).slice(2, 8)}`,
+  text: text.trim(),
+  provider,
+  model,
+});
+
+const extractJarvisMessage = async (payload: JarvisChatResult): Promise<string> => {
+  if (!payload) {
+    return '';
+  }
+
+  if (typeof (payload as { message?: string }).message === 'string') {
+    return (payload as { message: string }).message;
+  }
+
+  if (typeof payload === 'object' && payload !== null && Symbol.asyncIterator in payload) {
+    let buffer = '';
+    for await (const event of payload as AsyncIterable<Record<string, unknown>>) {
+      if (!event || typeof event !== 'object') {
+        continue;
+      }
+      if (typeof (event as { message?: string }).message === 'string') {
+        buffer += (event as { message: string }).message;
+      } else if (typeof (event as { delta?: string }).delta === 'string') {
+        buffer += (event as { delta: string }).delta;
+      }
+    }
+    return buffer;
+  }
+
+  return '';
+};
+
+export const useCodeAutocomplete = (options: UseCodeAutocompleteOptions): UseCodeAutocompleteValue => {
+  const { agents } = useAgents();
+  const { invokeChat } = useJarvisCore();
+  const [isLoading, setLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [suggestions, setSuggestions] = useState<AutocompleteSuggestion[]>([]);
+  const runIdRef = useRef(0);
+
+  const normalizedProvider = options.provider;
+
+  const providerAgent = useMemo(() => {
+    if (normalizedProvider === 'jarvis') {
+      return null;
+    }
+
+    const normalized = normalizedProvider.toLowerCase();
+    const selectedModel = options.model?.trim().toLowerCase();
+
+    return (
+      agents
+        .filter(agent => agent.kind === 'cloud' && agent.apiKey && agent.provider.toLowerCase() === normalized)
+        .find(agent => (selectedModel ? agent.model.toLowerCase() === selectedModel : true)) ??
+      agents
+        .filter(agent => agent.kind === 'cloud' && agent.apiKey && agent.provider.toLowerCase() === normalized)
+        .find(() => true) ??
+      null
+    );
+  }, [agents, normalizedProvider, options.model]);
+
+  const providerReady = useMemo(() => {
+    if (normalizedProvider === 'jarvis') {
+      return true;
+    }
+    return Boolean(providerAgent?.apiKey);
+  }, [normalizedProvider, providerAgent]);
+
+  const cancel = useCallback(() => {
+    runIdRef.current += 1;
+    setLoading(false);
+  }, []);
+
+  const requestAutocomplete = useCallback<UseCodeAutocompleteValue['requestAutocomplete']>(
+    async request => {
+      const currentRun = runIdRef.current + 1;
+      runIdRef.current = currentRun;
+
+      if (!request?.file) {
+        setError('No se proporcionó un archivo para autocompletar.');
+        setSuggestions([]);
+        return [];
+      }
+
+      if (normalizedProvider !== 'jarvis' && !providerAgent?.apiKey) {
+        setError('No hay credenciales disponibles para el proveedor seleccionado.');
+        setSuggestions([]);
+        return [];
+      }
+
+      setLoading(true);
+      setError(null);
+
+      const prompt = buildContextPrompt(request, normalizedProvider);
+      const activeModel = options.model ?? providerAgent?.model;
+
+      try {
+        let completion = '';
+
+        if (normalizedProvider === 'openai') {
+          const response = await callOpenAIChat({
+            apiKey: providerAgent?.apiKey ?? '',
+            model: activeModel ?? 'gpt-4o-mini',
+            prompt,
+            systemPrompt: SYSTEM_PROMPT,
+            maxTokens: options.maxTokens,
+            temperature: options.temperature,
+          });
+          completion = sanitizeContent(response.content);
+        } else if (normalizedProvider === 'anthropic') {
+          const response = await callAnthropicChat({
+            apiKey: providerAgent?.apiKey ?? '',
+            model: activeModel ?? 'claude-3-5-sonnet-20241022',
+            prompt,
+            systemPrompt: SYSTEM_PROMPT,
+            maxTokens: options.maxTokens,
+            temperature: options.temperature,
+          });
+          completion = sanitizeContent(response.content);
+        } else if (normalizedProvider === 'groq') {
+          const response = await callGroqChat({
+            apiKey: providerAgent?.apiKey ?? '',
+            model: activeModel ?? providerAgent?.model ?? 'llama-3.2-90b-text',
+            prompt,
+            systemPrompt: SYSTEM_PROMPT,
+            maxTokens: options.maxTokens,
+            temperature: options.temperature,
+          });
+          completion = sanitizeContent(response.content);
+        } else {
+          const result = await invokeChat({
+            prompt,
+            systemPrompt: SYSTEM_PROMPT,
+          });
+          completion = await extractJarvisMessage(result);
+        }
+
+        if (runIdRef.current !== currentRun) {
+          return [];
+        }
+
+        const cleaned = completion.trim();
+        if (!cleaned) {
+          setSuggestions([]);
+          return [];
+        }
+
+        const suggestion = buildSuggestion(normalizedProvider, activeModel, cleaned);
+        setSuggestions([suggestion]);
+        return [suggestion];
+      } catch (caughtError) {
+        if (runIdRef.current !== currentRun) {
+          return [];
+        }
+        const message = caughtError instanceof Error ? caughtError.message : String(caughtError ?? '');
+        setError(message);
+        setSuggestions([]);
+        return [];
+      } finally {
+        if (runIdRef.current === currentRun) {
+          setLoading(false);
+        }
+      }
+    },
+    [invokeChat, normalizedProvider, options.maxTokens, options.model, options.temperature, providerAgent],
+  );
+
+  return {
+    isLoading,
+    error,
+    suggestions,
+    providerReady,
+    requestAutocomplete,
+    cancel,
+  };
+};
+
+export default useCodeAutocomplete;

--- a/tests/useCodeAutocomplete.test.ts
+++ b/tests/useCodeAutocomplete.test.ts
@@ -1,0 +1,105 @@
+import { describe, expect, it, beforeEach, afterEach, vi } from 'vitest';
+import { renderHook, act } from '@testing-library/react';
+import { useCodeAutocomplete } from '../src/hooks/useCodeAutocomplete';
+
+const agentsMock = vi.fn();
+const invokeChatMock = vi.fn();
+
+vi.mock('../src/core/agents/AgentContext', () => ({
+  useAgents: () => agentsMock(),
+}));
+
+vi.mock('../src/core/jarvis/JarvisCoreContext', () => ({
+  useJarvisCore: () => ({ runtimeStatus: 'ready', invokeChat: invokeChatMock }),
+}));
+
+const providerMocks = vi.hoisted(() => ({
+  callOpenAIChatMock: vi.fn(),
+  callAnthropicChatMock: vi.fn(),
+  callGroqChatMock: vi.fn(),
+}));
+
+vi.mock('../src/utils/aiProviders', async importOriginal => {
+  const actual = await importOriginal<typeof import('../src/utils/aiProviders')>();
+  return {
+    ...actual,
+    callOpenAIChat: providerMocks.callOpenAIChatMock,
+    callAnthropicChat: providerMocks.callAnthropicChatMock,
+    callGroqChat: providerMocks.callGroqChatMock,
+  };
+});
+
+const baseAgent = {
+  id: 'openai-gpt-4o-mini',
+  model: 'gpt-4o-mini',
+  name: 'GPT',
+  provider: 'OpenAI',
+  description: 'test',
+  kind: 'cloud',
+  accent: '#fff',
+  active: true,
+  status: 'Disponible',
+};
+
+describe('useCodeAutocomplete', () => {
+  beforeEach(() => {
+    agentsMock.mockReturnValue({ agents: [{ ...baseAgent, apiKey: 'key-123' }] });
+    providerMocks.callOpenAIChatMock.mockResolvedValue({ content: 'resultado', modalities: [] });
+    providerMocks.callAnthropicChatMock.mockResolvedValue({ content: 'anthropic', modalities: [] });
+    providerMocks.callGroqChatMock.mockResolvedValue({ content: 'groq', modalities: [] });
+    invokeChatMock.mockResolvedValue({ message: 'jarvis' });
+  });
+
+  afterEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('solicita autocompletado con OpenAI', async () => {
+    const { result } = renderHook(() =>
+      useCodeAutocomplete({ provider: 'openai', model: 'gpt-4o-mini' }),
+    );
+
+    await act(async () => {
+      await result.current.requestAutocomplete({
+        file: { id: 'f1', name: 'index.ts', language: 'typescript', content: 'const a = 1;' },
+        cursor: { lineNumber: 1, column: 10 },
+        files: [],
+      });
+    });
+
+    expect(providerMocks.callOpenAIChatMock).toHaveBeenCalledOnce();
+    expect(result.current.suggestions).toHaveLength(1);
+    expect(result.current.suggestions[0].text).toBe('resultado');
+  });
+
+  it('usa Jarvis Core cuando se selecciona el proveedor local', async () => {
+    const { result } = renderHook(() => useCodeAutocomplete({ provider: 'jarvis' }));
+
+    await act(async () => {
+      await result.current.requestAutocomplete({
+        file: { id: 'f2', name: 'script.py', language: 'python', content: 'print("hola")' },
+        files: [],
+      });
+    });
+
+    expect(invokeChatMock).toHaveBeenCalledOnce();
+    expect(result.current.suggestions[0].text).toBe('jarvis');
+  });
+
+  it('notifica error cuando falta la clave del proveedor', async () => {
+    agentsMock.mockReturnValue({ agents: [{ ...baseAgent, apiKey: '' }] });
+    const { result } = renderHook(() =>
+      useCodeAutocomplete({ provider: 'openai', model: 'gpt-4o-mini' }),
+    );
+
+    await act(async () => {
+      await result.current.requestAutocomplete({
+        file: { id: 'f3', name: 'app.tsx', language: 'typescript', content: 'export {};' },
+        files: [],
+      });
+    });
+
+    expect(result.current.error).toMatch(/No hay credenciales/);
+    expect(result.current.suggestions).toHaveLength(0);
+  });
+});


### PR DESCRIPTION
## Summary
- add a Monaco-powered CodeCanvas workspace with multi-file persistence, provider selection, and chat/repo sharing actions
- expose the new canvas view in the main app header alongside chat and repo studio tabs
- implement a provider-aware `useCodeAutocomplete` hook with accompanying unit coverage for remote and Jarvis completions

## Testing
- npm test -- --run

------
https://chatgpt.com/codex/tasks/task_e_68d028921d388333985f3b55a4e06d18