### PR TITLE
feat: redesign side panel and resource explorer with Ant Design

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
     "@monaco-editor/react": "^4.6.0",
     "@tauri-apps/api": "^1.5.0",
     "@types/three": "^0.179.0",
+    "@ant-design/icons": "^5.3.7",
     "antd": "^5.21.0",
     "framer-motion": "^11.11.11",
     "highlight.js": "^11.9.0",

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -37,7 +37,7 @@ interface AppContentProps {
   onSettingsChange: (updater: (previous: GlobalSettings) => GlobalSettings) => void;
 }
 
-const { Header, Content, Sider } = Layout;
+const { Header, Content } = Layout;
 
 const AppContent: React.FC<AppContentProps> = ({
   apiKeys,
@@ -105,17 +105,13 @@ const AppContent: React.FC<AppContentProps> = ({
               hasSider={showDesktopSidebar}
             >
               {sidePanelPosition === 'left' && showDesktopSidebar && (
-                <Sider
+                <SidePanel
+                  position="left"
                   width={siderWidth}
-                  className="app-sidebar"
-                  role="complementary"
-                  aria-label="Agent configuration"
-                >
-                  <SidePanel
-                    onOpenGlobalSettings={() => setSettingsOpen(true)}
-                    onOpenModelManager={() => setModelManagerOpen(true)}
-                  />
-                </Sider>
+                  variant="desktop"
+                  onOpenGlobalSettings={() => setSettingsOpen(true)}
+                  onOpenModelManager={() => setModelManagerOpen(true)}
+                />
               )}
 
               <Content className="chat-main-container">
@@ -131,23 +127,22 @@ const AppContent: React.FC<AppContentProps> = ({
               </Content>
 
               {sidePanelPosition === 'right' && showDesktopSidebar && (
-                <Sider
+                <SidePanel
+                  position="right"
                   width={siderWidth}
-                  className="app-sidebar"
-                  role="complementary"
-                  aria-label="Agent configuration"
-                >
-                  <SidePanel
-                    onOpenGlobalSettings={() => setSettingsOpen(true)}
-                    onOpenModelManager={() => setModelManagerOpen(true)}
-                  />
-                </Sider>
+                  variant="desktop"
+                  onOpenGlobalSettings={() => setSettingsOpen(true)}
+                  onOpenModelManager={() => setModelManagerOpen(true)}
+                />
               )}
             </Layout>
 
             {!showDesktopSidebar && (
               <div className="app-sidebar-mobile" role="complementary" aria-label="Agent configuration">
                 <SidePanel
+                  position={sidePanelPosition}
+                  width={siderWidth}
+                  variant="mobile"
                   onOpenGlobalSettings={() => setSettingsOpen(true)}
                   onOpenModelManager={() => setModelManagerOpen(true)}
                 />

--- a/src/components/ResourceExplorer.css
+++ b/src/components/ResourceExplorer.css
@@ -2,160 +2,122 @@
   position: relative;
   display: flex;
   flex-direction: column;
-  background: rgba(10, 10, 10, 0.96);
+  background: rgba(12, 12, 16, 0.95);
   border-right: 1px solid rgba(255, 255, 255, 0.08);
-  transition: min-width 0.25s ease, width 0.25s ease;
-  overflow: visible;
-  z-index: 15;
+  transition: min-width 0.3s ease, width 0.3s ease;
+  overflow: hidden;
+  color: #fff;
 }
 
 .resource-explorer__content {
   flex: 1;
   display: flex;
   flex-direction: column;
-  padding: 18px 18px 12px;
-  gap: 12px;
+  padding: 20px 20px 16px;
+  gap: 16px;
   overflow: hidden;
-  opacity: 1;
-  transition: opacity 0.2s ease;
 }
 
 .resource-explorer__header {
   display: flex;
-  align-items: center;
+  align-items: flex-start;
   justify-content: space-between;
   gap: 12px;
 }
 
-.resource-explorer__header h2 {
-  font-size: 16px;
-  font-weight: 600;
-  color: #fff;
-}
-
-.resource-explorer__actions {
-  display: flex;
-  gap: 8px;
-}
-
-.resource-explorer__action {
-  width: 28px;
-  height: 28px;
-  border-radius: 6px;
-  border: 1px solid rgba(255, 255, 255, 0.15);
-  background: rgba(20, 20, 20, 0.85);
-  color: #fff;
-  cursor: pointer;
+.resource-explorer__search {
   display: flex;
   align-items: center;
-  justify-content: center;
-  transition: background 0.2s ease, transform 0.2s ease;
 }
 
-.resource-explorer__action:disabled {
-  opacity: 0.5;
-  cursor: default;
-}
-
-.resource-explorer__action:not(:disabled):hover {
-  background: rgba(255, 183, 77, 0.25);
-  transform: translateY(-1px);
-}
-
-.resource-explorer__search input {
+.resource-explorer__filters {
   width: 100%;
-  background: rgba(0, 0, 0, 0.75);
-  border: 1px solid rgba(255, 255, 255, 0.15);
-  border-radius: 6px;
-  padding: 6px 10px;
-  color: #fff;
-  font-size: 12px;
 }
 
-.resource-explorer__search input::placeholder {
-  color: rgba(255, 255, 255, 0.4);
-}
-
-.resource-explorer__body {
-  flex: 1;
-  overflow-y: auto;
-  padding-right: 6px;
-}
-
-.resource-explorer__tree,
-.resource-explorer__matches {
+.resource-explorer__results {
   display: flex;
   flex-direction: column;
-  gap: 4px;
+  gap: 8px;
+  padding: 12px;
+  background: rgba(255, 255, 255, 0.04);
+  border-radius: 12px;
+}
+
+.resource-explorer__matches .resource-match {
+  margin: 0;
+  padding: 0;
+  border: none;
+}
+
+.resource-match__item {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  padding: 8px 10px;
+  border-radius: 10px;
+  background: rgba(18, 18, 22, 0.85);
+  transition: transform 0.2s ease, background 0.2s ease;
+}
+
+.resource-match__item:hover,
+.resource-match__item:focus-visible {
+  transform: translateX(2px);
+  background: rgba(255, 255, 255, 0.08);
 }
 
 .resource-node {
   display: flex;
   flex-direction: column;
-  color: #fff;
+  color: inherit;
 }
 
 .resource-node__label {
   display: flex;
   align-items: center;
-  gap: 8px;
-  background: transparent;
-  border: none;
+  justify-content: space-between;
+  width: 100%;
+  font-size: 13px;
   color: inherit;
-  text-align: left;
-  cursor: pointer;
-  font-size: 12px;
-  padding: 4px 6px;
-  border-radius: 6px;
-  transition: background 0.2s ease;
 }
 
-.resource-node__label:hover {
-  background: rgba(255, 255, 255, 0.08);
+.resource-node__badge {
+  margin-inline-start: 8px;
 }
 
 .resource-node__children {
   display: flex;
   flex-direction: column;
-  gap: 4px;
-  margin-top: 2px;
+  gap: 6px;
+  margin-top: 4px;
 }
 
 .resource-node--item {
-  background: rgba(255, 255, 255, 0.04);
-  border-radius: 6px;
-  transition: background 0.2s ease, transform 0.2s ease;
-}
-
-.resource-node--item:hover {
-  background: rgba(255, 183, 77, 0.1);
-  transform: translateX(2px);
-}
-
-.resource-node__item,
-.resource-match {
   display: flex;
   align-items: center;
-  gap: 8px;
-  padding: 6px 8px;
-  font-size: 12px;
-}
-
-.resource-match {
+  justify-content: space-between;
+  padding: 8px 10px;
+  margin-top: 6px;
+  border-radius: 10px;
   background: rgba(255, 255, 255, 0.05);
-  border-radius: 6px;
   transition: background 0.2s ease, transform 0.2s ease;
 }
 
-.resource-match:hover {
-  background: rgba(255, 183, 77, 0.15);
+.resource-node--item:hover,
+.resource-node--item:focus-visible {
+  background: rgba(255, 255, 255, 0.12);
   transform: translateX(2px);
+}
+
+.resource-node__item {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  font-size: 13px;
 }
 
 .resource-node__icon {
-  width: 18px;
+  width: 20px;
   text-align: center;
-  opacity: 0.9;
 }
 
 .resource-node__title {
@@ -165,35 +127,100 @@
   text-overflow: ellipsis;
 }
 
-.resource-explorer__empty {
-  text-align: center;
-  padding: 12px;
-  font-size: 12px;
-  color: rgba(255, 255, 255, 0.5);
+.resource-node__actions {
+  display: flex;
+  gap: 4px;
+}
+
+.resource-tree {
+  background: transparent !important;
+  color: inherit;
+}
+
+.resource-tree .ant-tree-treenode {
+  padding-block: 2px;
+}
+
+.resource-card {
+  background: rgba(18, 18, 22, 0.85);
+  border: 1px solid rgba(255, 255, 255, 0.08);
+  border-radius: 16px;
+  transition: transform 0.25s ease, border-color 0.25s ease;
+}
+
+.resource-card:hover {
+  transform: translateY(-2px);
+  border-color: rgba(255, 255, 255, 0.22);
+}
+
+.resource-card__avatar {
+  font-size: 20px;
+}
+
+.resource-card__tags {
+  margin-top: 12px;
+  display: flex;
+  gap: 6px;
+  flex-wrap: wrap;
+}
+
+.resource-explorer__tabs .ant-tabs-nav {
+  margin: 0;
+}
+
+.resource-highlight {
+  background: rgba(255, 214, 102, 0.35);
+  padding: 0 2px;
+  border-radius: 4px;
+}
+
+.resource-drag-ghost {
+  position: fixed;
+  top: -9999px;
+  left: -9999px;
+  padding: 6px 10px;
+  background: rgba(0, 0, 0, 0.85);
+  color: #fff;
+  border-radius: 10px;
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+  pointer-events: none;
+  box-shadow: 0 12px 24px rgba(0, 0, 0, 0.45);
+  font-size: 13px;
+}
+
+.resource-drag-ghost__icon {
+  font-size: 16px;
+}
+
+.resource-drag-ghost__label {
+  font-weight: 500;
 }
 
 .resource-explorer__hint {
-  font-size: 11px;
-  color: rgba(255, 255, 255, 0.45);
+  font-size: 12px;
+  color: rgba(255, 255, 255, 0.6);
   text-align: center;
-  padding-top: 4px;
+  padding-top: 8px;
   border-top: 1px solid rgba(255, 255, 255, 0.08);
 }
 
-.resource-explorer__body::-webkit-scrollbar {
-  width: 6px;
+@media (max-width: 1024px) {
+  .resource-explorer__content {
+    padding: 16px;
+  }
+
+  .resource-explorer__filters {
+    font-size: 12px;
+  }
 }
 
-.resource-explorer__body::-webkit-scrollbar-track {
-  background: rgba(255, 255, 255, 0.05);
-  border-radius: 3px;
-}
-
-.resource-explorer__body::-webkit-scrollbar-thumb {
-  background: rgba(255, 255, 255, 0.2);
-  border-radius: 3px;
-}
-
-.resource-explorer__body::-webkit-scrollbar-thumb:hover {
-  background: rgba(255, 255, 255, 0.35);
+@media (prefers-reduced-motion: reduce) {
+  .resource-explorer,
+  .resource-node--item,
+  .resource-card,
+  .resource-match__item {
+    transition: none !important;
+  }
 }

--- a/src/components/chat/SidePanel.css
+++ b/src/components/chat/SidePanel.css
@@ -1,221 +1,181 @@
-.sidebar {
+.sidepanel-sider {
+  display: flex;
+  flex-direction: column;
+  background: rgba(9, 9, 11, 0.96);
+  border-inline: 1px solid rgba(255, 255, 255, 0.08);
+  transition: width 0.3s ease;
+}
+
+.sidepanel-sider__inner {
   display: flex;
   flex-direction: column;
   height: 100%;
+  overflow: hidden;
+}
+
+.sidepanel-sider__toolbar {
+  display: flex;
+  justify-content: flex-end;
   padding: 12px;
-  gap: 12px;
-  background: rgba(10, 10, 10, 0.92);
-  border-left: 1px solid rgba(255, 255, 255, 0.08);
+}
+
+.sidepanel-sider__scroll {
+  flex: 1;
   overflow-y: auto;
-  scrollbar-width: thin;
-  scrollbar-color: rgba(255, 255, 255, 0.3) transparent;
+  padding: 0 16px 24px;
+  scroll-behavior: smooth;
 }
 
-.sidebar::-webkit-scrollbar {
-  width: 6px;
+.sidepanel-sider__scroll[data-collapsed='true'] {
+  opacity: 0;
+  pointer-events: none;
 }
 
-.sidebar::-webkit-scrollbar-thumb {
-  background: rgba(255, 255, 255, 0.3);
-  border-radius: 999px;
-}
-
-.sidebar-section {
+.sidepanel-content {
   display: flex;
   flex-direction: column;
+  gap: 18px;
+  min-height: 100%;
+}
+
+.sidepanel-header {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
   gap: 12px;
-  padding: 12px;
-  border-radius: 12px;
-  background: rgba(18, 18, 18, 0.85);
-  border: 1px solid rgba(255, 255, 255, 0.06);
-  box-shadow: 0 8px 18px rgba(0, 0, 0, 0.35);
 }
 
-.sidebar-section header h2 {
-  font-size: 18px;
-  font-weight: 600;
-  letter-spacing: 0.5px;
+.sidepanel-heading {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
 }
 
-.sidebar-section header p {
-  margin-top: 4px;
-  font-size: 13px;
-  color: rgba(255, 255, 255, 0.65);
+.sidepanel-provider-list {
+  background: transparent;
+  padding: 0;
 }
 
-.provider-status-list {
-  list-style: none;
+.sidepanel-provider-item {
   margin: 0;
   padding: 0;
-  display: grid;
-  grid-template-columns: 1fr;
-  gap: 12px;
+  list-style: none;
 }
 
-@media (min-width: 860px) {
-  .provider-status-list {
-    grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
-  }
-}
-
-.provider-card {
+.sidepanel-provider-card {
   display: flex;
   flex-direction: column;
   gap: 10px;
-  padding: 14px;
-  border-radius: 12px;
+  padding: 14px 16px;
   background: rgba(255, 255, 255, 0.04);
-  border: 1px solid rgba(255, 255, 255, 0.07);
-  box-shadow: 0 8px 22px rgba(0, 0, 0, 0.35);
+  border-radius: 16px;
+  border: 1px solid rgba(255, 255, 255, 0.08);
+  box-shadow: 0 8px 22px rgba(0, 0, 0, 0.4);
 }
 
-.provider-card__header {
+.sidepanel-provider-card__header {
   display: flex;
   align-items: center;
   justify-content: space-between;
-  gap: 16px;
+  width: 100%;
 }
 
-.provider-card__identity {
-  display: flex;
-  align-items: center;
-  gap: 12px;
-}
-
-.provider-card__identity-text {
+.sidepanel-provider-card__identity {
+  flex: 1;
   display: flex;
   flex-direction: column;
   gap: 4px;
 }
 
-.provider-card__name {
-  font-size: 15px;
-  font-weight: 600;
-  letter-spacing: 0.3px;
+.sidepanel-provider-card__name {
+  margin: 0;
+  color: #fff;
 }
 
-.provider-card__model {
-  font-size: 12px;
-  color: rgba(255, 255, 255, 0.7);
-}
-
-.provider-led {
-  width: 14px;
-  height: 14px;
-  border-radius: 999px;
-  box-shadow: 0 0 0 0 rgba(0, 0, 0, 0.2);
-  transition: background 0.25s ease, box-shadow 0.25s ease;
-  background: rgba(255, 255, 255, 0.2);
-}
-
-.provider-led.is-online {
-  background: #66ff99;
-  box-shadow: 0 0 14px rgba(102, 255, 153, 0.6);
-}
-
-.provider-led.is-warning {
-  background: #ffd966;
-  box-shadow: 0 0 14px rgba(255, 217, 102, 0.45);
-}
-
-.provider-led.is-error {
-  background: #ff7373;
-  box-shadow: 0 0 14px rgba(255, 115, 115, 0.55);
-}
-
-.provider-card__state {
-  font-size: 11px;
+.sidepanel-provider-card__state {
   text-transform: uppercase;
-  letter-spacing: 0.55px;
-  padding: 4px 10px;
-  border-radius: 999px;
-  border: 1px solid rgba(255, 255, 255, 0.12);
-  background: rgba(255, 255, 255, 0.04);
+  letter-spacing: 0.4px;
+}
+
+.sidepanel-provider-card__description {
+  font-size: 12px;
+  line-height: 1.5;
+}
+
+.sidepanel-provider-card__description.is-success {
+  color: rgba(130, 255, 164, 0.9);
+}
+
+.sidepanel-provider-card__description.is-secondary {
   color: rgba(255, 255, 255, 0.75);
 }
 
-.provider-card__state.is-online {
-  border-color: rgba(102, 255, 153, 0.45);
-  color: rgba(102, 255, 153, 0.9);
+.sidepanel-provider-card__description.is-danger {
+  color: rgba(255, 145, 145, 0.9);
 }
 
-.provider-card__state.is-warning {
-  border-color: rgba(255, 217, 102, 0.35);
-  color: rgba(255, 217, 102, 0.9);
-}
-
-.provider-card__state.is-error {
-  border-color: rgba(255, 115, 115, 0.45);
-  color: rgba(255, 115, 115, 0.95);
-}
-
-.provider-card__description {
-  margin: 0;
-  font-size: 12px;
-  line-height: 1.5;
-  color: rgba(255, 255, 255, 0.72);
-}
-
-.provider-card__actions {
+.sidepanel-provider-card__actions {
   display: flex;
   justify-content: flex-start;
 }
 
-.provider-card__actions button {
-  border: none;
-  border-radius: 8px;
-  padding: 6px 12px;
-  font-size: 12px;
-  letter-spacing: 0.5px;
-  text-transform: uppercase;
-  background: rgba(142, 141, 255, 0.18);
-  color: rgba(255, 255, 255, 0.85);
-  cursor: pointer;
-  transition: background 0.2s ease;
-}
-
-.provider-card__actions button:hover,
-.provider-card__actions button:focus-visible {
-  background: rgba(142, 141, 255, 0.32);
-}
-
-.sidebar-actions {
+.sidepanel-actions {
   display: flex;
-  gap: 8px;
   justify-content: flex-end;
-  flex-wrap: wrap;
+  gap: 12px;
 }
 
-.sidebar-actions button {
-  border: none;
-  border-radius: 10px;
-  padding: 8px 12px;
-  font-size: 12px;
-  letter-spacing: 0.6px;
-  text-transform: uppercase;
-  background: rgba(255, 255, 255, 0.12);
+.sidepanel-mobile-trigger {
+  position: fixed;
+  bottom: 24px;
+  z-index: 1200;
+  box-shadow: 0 12px 28px rgba(0, 0, 0, 0.4);
+}
+
+.sidepanel-mobile-trigger--left {
+  left: 24px;
+}
+
+.sidepanel-mobile-trigger--right {
+  right: 24px;
+}
+
+.sidepanel-drawer .ant-drawer-body {
+  padding: 0;
+  background: rgba(9, 9, 11, 0.96);
+}
+
+.sidepanel-drawer__content {
+  display: flex;
+  flex-direction: column;
+  height: 100%;
+  padding: 16px 20px 24px;
+  gap: 16px;
+}
+
+.sidepanel-drawer__header {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+}
+
+.sidepanel-drawer__title {
+  margin: 0;
   color: #fff;
-  cursor: pointer;
-  transition: background 0.2s ease, opacity 0.2s ease;
 }
 
-.sidebar-actions button:disabled {
-  opacity: 0.55;
-  cursor: default;
+.sidepanel-sider.is-collapsed {
+  border-inline-width: 0;
 }
 
-.sidebar-actions .primary {
-  background: linear-gradient(135deg, rgba(142, 141, 255, 0.7), rgba(255, 183, 77, 0.7));
-  color: #0a0a0a;
-  font-weight: 600;
+.sidepanel-sider.is-expanded {
+  border-inline-width: 1px;
 }
 
-@media (max-width: 1200px) {
-  .sidebar {
-    padding: 16px;
-  }
-
-  .sidebar-section {
-    padding: 16px;
+@media (prefers-reduced-motion: reduce) {
+  .sidepanel-sider,
+  .sidepanel-provider-card,
+  .sidepanel-drawer__content {
+    transition: none !important;
   }
 }

--- a/src/components/chat/__tests__/SidePanel.test.tsx
+++ b/src/components/chat/__tests__/SidePanel.test.tsx
@@ -208,7 +208,13 @@ describe('Resumen de proveedores en SidePanel', () => {
   });
 
   it('muestra los cuatro proveedores principales con su estado resumido', () => {
-    render(<SidePanel onOpenGlobalSettings={vi.fn()} onOpenModelManager={vi.fn()} />);
+    render(
+      <SidePanel
+        variant="desktop"
+        onOpenGlobalSettings={vi.fn()}
+        onOpenModelManager={vi.fn()}
+      />,
+    );
 
     const cards = screen.getAllByTestId(/provider-card-/);
     expect(cards).toHaveLength(4);
@@ -259,12 +265,28 @@ describe('Resumen de proveedores en SidePanel', () => {
       refresh: vi.fn(),
     });
 
-    render(<SidePanel onOpenGlobalSettings={vi.fn()} onOpenModelManager={vi.fn()} />);
+    render(
+      <SidePanel
+        variant="desktop"
+        onOpenGlobalSettings={vi.fn()}
+        onOpenModelManager={vi.fn()}
+      />,
+    );
 
-    expect(screen.getByTestId('provider-led-openai')).toHaveClass('is-online');
-    expect(screen.getByTestId('provider-led-anthropic')).toHaveClass('is-warning');
-    expect(screen.getByTestId('provider-led-groq')).toHaveClass('is-error');
-    expect(screen.getByTestId('provider-led-jarvis')).toHaveClass('is-warning');
+    const openaiCard = screen.getByTestId('provider-card-openai').closest('.sidepanel-provider-item');
+    const anthropicCard = screen.getByTestId('provider-card-anthropic').closest('.sidepanel-provider-item');
+    const groqCard = screen.getByTestId('provider-card-groq').closest('.sidepanel-provider-item');
+    const jarvisCard = screen.getByTestId('provider-card-jarvis').closest('.sidepanel-provider-item');
+
+    expect(openaiCard as HTMLElement | null).not.toBeNull();
+    expect(anthropicCard as HTMLElement | null).not.toBeNull();
+    expect(groqCard as HTMLElement | null).not.toBeNull();
+    expect(jarvisCard as HTMLElement | null).not.toBeNull();
+
+    expect(openaiCard as HTMLElement).toHaveClass('tone-online');
+    expect(anthropicCard as HTMLElement).toHaveClass('tone-warning');
+    expect(groqCard as HTMLElement).toHaveClass('tone-error');
+    expect(jarvisCard as HTMLElement).toHaveClass('tone-warning');
     expect(screen.getByRole('button', { name: 'Gestionar modelos' })).toBeInTheDocument();
   });
 


### PR DESCRIPTION
## Summary
- migrate the chat SidePanel to an Ant Design Sider/Drawer with responsive collapse controls, mobile drawer gestures, and refreshed provider status cards
- overhaul the ResourceExplorer with Ant Design search, filters, tree/list/grid views, tagging, and drag ghost previews for presets and videos
- wire the new panel layout into App.tsx and add @ant-design/icons plus updated unit tests for the provider summary

## Testing
- npm test -- --run
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68d03bff3cc083339a516e1772830317