### PR TITLE
Refactor layout to Proxmox-style shell

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -1,42 +1,48 @@
-.app-pro-shell {
+.proxmox-shell {
   min-height: 100vh;
-  display: flex;
-  flex-direction: column;
   background: var(--color-bg-base);
   color: var(--color-text-base);
 }
 
-.app-pro-shell.sidebar-left .ant-pro-layout-sider,
-.app-pro-shell.sidebar-right .ant-pro-layout-sider {
-  background: transparent;
-}
-
-.app-pro-layout {
+.proxmox-layout {
   min-height: inherit;
-}
-
-.app-pro-layout .ant-pro-layout-content {
   background: transparent;
 }
 
-.app-pro-layout .ant-pro-layout-bg-list {
-  display: none;
-}
-
-.app-pro-layout .ant-pro-layout-sider {
-  border-inline-end: 1px solid var(--color-border-strong);
-  backdrop-filter: blur(16px);
+.proxmox-sider {
   background: var(--shell-sider-bg);
-  box-shadow: inset -1px 0 0 rgba(0, 0, 0, 0.2);
+  border-inline-end: 1px solid var(--color-border-strong);
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-lg);
+  padding: var(--space-lg) var(--space-md);
+  box-shadow: inset -1px 0 0 rgba(0, 0, 0, 0.25);
 }
 
-.app-pro-layout .ant-pro-sider-logo,
-.app-pro-layout .ant-pro-sider-links {
-  display: none !important;
+.proxmox-sider__brand {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+  padding: 0 var(--space-xs) var(--space-md);
+  border-bottom: 1px solid var(--shell-divider);
 }
 
-.app-pro-layout .ant-pro-layout .ant-layout-header,
-.app-header-shell {
+.proxmox-sider__brand .ant-typography {
+  margin: 0;
+  color: var(--color-text-base);
+}
+
+.proxmox-sider__brand .ant-typography.ant-typography-secondary {
+  color: var(--color-text-muted);
+  font-size: 12px;
+  text-transform: uppercase;
+  letter-spacing: 1px;
+}
+
+.proxmox-main {
+  min-height: inherit;
+  display: flex;
+  flex-direction: column;
   background: transparent;
 }
 
@@ -56,18 +62,27 @@
   box-shadow: none;
 }
 
-.app-page-container {
-  padding: var(--space-lg) var(--space-xl) var(--space-lg);
+.proxmox-content {
+  flex: 1;
+  padding: var(--space-xl) var(--space-xl) var(--space-lg);
 }
 
-.app-main-content {
+.proxmox-content-inner {
   display: flex;
-  flex-direction: column;
   gap: var(--space-lg);
-  min-height: calc(100vh - 240px);
+  align-items: flex-start;
 }
 
-.app-surface-card {
+.proxmox-workspace {
+  flex: 1;
+  min-width: 0;
+}
+
+.proxmox-info-panel {
+  width: clamp(280px, 22vw, 360px);
+}
+
+.proxmox-surface-card {
   position: relative;
   border-radius: var(--radius-lg);
   padding: var(--space-lg);
@@ -77,7 +92,7 @@
   overflow: hidden;
 }
 
-.app-surface-card::after {
+.proxmox-surface-card::after {
   content: '';
   position: absolute;
   inset: 0;
@@ -92,41 +107,48 @@
   opacity: 0.32;
 }
 
-.app-surface-card > * {
+.proxmox-surface-card > * {
   position: relative;
   z-index: 1;
 }
 
-.app-sider-shell {
-  height: 100%;
+.proxmox-footer {
+  background: rgba(12, 14, 28, 0.85);
+  border-top: 1px solid var(--color-border-strong);
+  padding: var(--space-md) var(--space-xl);
+  color: var(--color-text-muted);
+  font-size: 12px;
+  letter-spacing: 0.8px;
   display: flex;
-  flex-direction: column;
-  background: var(--shell-sider-bg);
+  align-items: center;
 }
 
-.app-sider-shell .sidepanel-sider {
-  background: transparent;
-  border-inline: none;
-  box-shadow: none;
+.proxmox-nav-drawer .ant-drawer-body {
+  padding: var(--space-md) var(--space-sm) var(--space-lg);
 }
 
-.app-sider-shell .sidepanel-sider__toolbar {
-  padding-inline: 12px;
+.proxmox-nav-drawer .ant-drawer-header {
+  border-bottom: 1px solid var(--color-border-strong);
+  background: var(--shell-header-bg);
 }
 
-.app-mobile-sidebar-container {
-  margin-top: var(--space-lg);
-}
-
-.task-panel-wrapper {
-  position: sticky;
-  bottom: 0;
-  z-index: 5;
+.proxmox-nav-drawer .ant-drawer-title {
+  color: var(--color-text-base);
+  letter-spacing: 0.6px;
+  text-transform: uppercase;
 }
 
 @media (max-width: 1280px) {
-  .app-page-container {
-    padding: var(--space-lg);
+  .proxmox-content {
+    padding: var(--space-lg) var(--space-lg) var(--space-md);
+  }
+
+  .proxmox-content-inner {
+    flex-direction: column;
+  }
+
+  .proxmox-info-panel {
+    width: 100%;
   }
 }
 
@@ -135,33 +157,25 @@
     padding: 0 var(--space-md);
   }
 
-  .app-page-container {
+  .proxmox-surface-card {
     padding: var(--space-md);
-  }
-
-  .app-main-content {
-    min-height: auto;
-  }
-
-  .app-surface-card {
-    padding: var(--space-md);
+    border-radius: var(--radius-md);
   }
 }
 
 @media (max-width: 768px) {
-  .app-page-container {
-    padding: var(--space-md) var(--space-sm) var(--space-lg);
-  }
-
   .app-header-shell {
     padding: 0 var(--space-sm);
   }
 
-  .app-surface-card {
-    border-radius: var(--radius-md);
+  .proxmox-content {
+    padding: var(--space-md) var(--space-sm) var(--space-md);
   }
 
-  .app-mobile-sidebar-container {
-    margin-top: var(--space-md);
+  .proxmox-footer {
+    padding: var(--space-sm) var(--space-md);
+    flex-direction: column;
+    gap: var(--space-xs);
+    align-items: flex-start;
   }
 }

--- a/src/components/chat/ChatInterface.css
+++ b/src/components/chat/ChatInterface.css
@@ -2973,3 +2973,110 @@
     text-align: left;
   }
 }
+
+.chat-workspace-shell {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) 320px;
+  gap: var(--space-lg);
+  align-items: start;
+  width: 100%;
+}
+
+.chat-workspace-main {
+  min-width: 0;
+}
+
+.chat-workspace-sideinfo {
+  position: relative;
+  border-radius: var(--radius-lg);
+  background: var(--surface-velvet);
+  border: 1px solid var(--color-border-subtle);
+  padding: var(--space-lg);
+  box-shadow: var(--surface-glow);
+  min-height: 100%;
+}
+
+.chat-workspace-tabs .ant-tabs-nav {
+  margin-bottom: var(--space-lg);
+  padding: 4px;
+  border-radius: var(--radius-pill);
+  background: rgba(255, 255, 255, 0.05);
+}
+
+.chat-workspace-tabs .ant-tabs-tab {
+  padding: 10px 18px;
+  font-weight: 500;
+  letter-spacing: 0.3px;
+}
+
+.chat-workspace-tabs .ant-tabs-tab-active {
+  background: rgba(110, 107, 255, 0.16);
+  border-radius: var(--radius-pill);
+}
+
+.chat-tab-panel,
+.chat-feed-tab,
+.chat-details-tab {
+  width: 100%;
+  min-height: 100%;
+}
+
+.chat-feed-tab,
+.chat-details-tab {
+  padding: var(--space-md) var(--space-lg);
+  background: rgba(0, 0, 0, 0.25);
+  border-radius: var(--radius-lg);
+  border: 1px solid rgba(255, 255, 255, 0.08);
+}
+
+.chat-summary-panel {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-md);
+}
+
+.chat-summary-metrics .ant-statistic {
+  min-width: 120px;
+}
+
+.chat-summary-status .ant-tag {
+  border-radius: var(--radius-pill);
+}
+
+.chat-details-descriptions .ant-descriptions-item-label {
+  color: var(--color-text-muted);
+}
+
+.feed-timeline-entry {
+  padding: var(--space-sm) var(--space-md);
+  border-radius: var(--radius-md);
+  background: rgba(15, 17, 26, 0.6);
+  border: 1px solid rgba(255, 255, 255, 0.06);
+}
+
+@media (max-width: 1200px) {
+  .chat-workspace-shell {
+    grid-template-columns: minmax(0, 1fr);
+  }
+
+  .chat-workspace-sideinfo {
+    order: -1;
+  }
+}
+
+@media (max-width: 768px) {
+  .chat-workspace-tabs .ant-tabs-nav {
+    padding: 2px;
+  }
+
+  .chat-feed-tab,
+  .chat-details-tab {
+    padding: var(--space-md);
+    border-radius: var(--radius-md);
+  }
+
+  .chat-workspace-sideinfo {
+    padding: var(--space-md);
+    border-radius: var(--radius-md);
+  }
+}

--- a/src/components/chat/ChatTopBar.tsx
+++ b/src/components/chat/ChatTopBar.tsx
@@ -13,7 +13,13 @@ import {
   Tag,
 } from 'antd';
 import type { BadgeProps } from 'antd';
-import { DownOutlined, ReloadOutlined, RobotOutlined, SettingOutlined } from '@ant-design/icons';
+import {
+  DownOutlined,
+  MenuUnfoldOutlined,
+  ReloadOutlined,
+  RobotOutlined,
+  SettingOutlined,
+} from '@ant-design/icons';
 import { AnimatePresence, motion } from 'framer-motion';
 import { AgentDefinition, AgentKind } from '../../core/agents/agentRegistry';
 import {
@@ -43,6 +49,8 @@ interface ChatTopBarProps {
   onOpenModelManager: () => void;
   activeView: 'chat' | 'repo' | 'canvas';
   onChangeView: (view: 'chat' | 'repo' | 'canvas') => void;
+  showNavigationToggle?: boolean;
+  onToggleNavigation?: () => void;
 }
 
 const STATUS_LABELS: Record<AgentPresenceStatus, string> = {
@@ -94,6 +102,8 @@ export const ChatTopBar: React.FC<ChatTopBarProps> = ({
   onOpenModelManager,
   activeView,
   onChangeView,
+  showNavigationToggle = false,
+  onToggleNavigation,
 }) => {
   const hasPending = pendingResponses > 0;
   const overallStatus = resolveStatus(presenceSummary);
@@ -340,6 +350,14 @@ export const ChatTopBar: React.FC<ChatTopBarProps> = ({
   return (
     <Layout.Header className="chat-top-bar">
       <Space className="topbar-left" align="center" size="large">
+        {showNavigationToggle && (
+          <Button
+            type="text"
+            icon={<MenuUnfoldOutlined />}
+            aria-label="Abrir navegación"
+            onClick={onToggleNavigation}
+          />
+        )}
         <Space align="center" size="middle">
           <Avatar shape="square" size={40} style={{ backgroundColor: '#2b2b52', color: '#fff' }}>
             🌀

--- a/src/components/layout/ResourceTree.css
+++ b/src/components/layout/ResourceTree.css
@@ -1,0 +1,82 @@
+.resource-tree {
+  display: flex;
+  flex-direction: column;
+  height: 100%;
+  padding: var(--space-md) var(--space-sm) var(--space-lg);
+  color: var(--color-text-base);
+}
+
+.resource-tree--compact {
+  padding-inline: 0;
+}
+
+.resource-tree .ant-tree {
+  background: transparent;
+  color: inherit;
+}
+
+.resource-tree .ant-tree-switcher,
+.resource-tree .ant-tree-indent {
+  color: var(--color-text-muted);
+}
+
+.resource-tree .ant-tree-treenode {
+  padding: 2px 4px;
+  border-radius: var(--radius-sm);
+  margin-bottom: 2px;
+  transition: background 0.2s ease, border 0.2s ease;
+}
+
+.resource-tree .ant-tree-treenode:hover {
+  background: rgba(255, 255, 255, 0.06);
+}
+
+.resource-tree-node--active {
+  background: rgba(110, 107, 255, 0.12);
+  border: 1px solid rgba(110, 107, 255, 0.35);
+}
+
+.resource-tree-item {
+  display: flex;
+  align-items: center;
+  gap: var(--space-sm);
+  font-size: 13px;
+  letter-spacing: 0.2px;
+}
+
+.resource-tree-item__icon {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 20px;
+  color: rgba(255, 255, 255, 0.65);
+}
+
+.resource-tree-item__label {
+  flex: 1;
+  font-weight: 500;
+}
+
+.resource-tree-item__badge {
+  padding: 2px 8px;
+  border-radius: var(--radius-pill);
+  background: rgba(110, 107, 255, 0.15);
+  color: var(--color-primary);
+  font-size: 11px;
+  text-transform: uppercase;
+}
+
+.resource-tree-item.is-active .resource-tree-item__icon {
+  color: var(--color-primary);
+}
+
+.resource-tree__hint {
+  margin-top: auto;
+  font-size: 12px;
+  opacity: 0.7;
+}
+
+.resource-tree__hint::before {
+  content: '⟲ ';
+  opacity: 0.8;
+}

--- a/src/components/layout/ResourceTree.tsx
+++ b/src/components/layout/ResourceTree.tsx
@@ -1,0 +1,282 @@
+import React, { useEffect, useMemo, useState } from 'react';
+import { Dropdown, Tree, Typography } from 'antd';
+import type { DataNode } from 'antd/es/tree';
+import type { MenuProps } from 'antd';
+import {
+  ApiOutlined,
+  AppstoreOutlined,
+  BranchesOutlined,
+  ClusterOutlined,
+  DeploymentUnitOutlined,
+  InboxOutlined,
+  MessageOutlined,
+  RadarChartOutlined,
+  RobotOutlined,
+  SettingOutlined,
+  ShareAltOutlined,
+} from '@ant-design/icons';
+import './ResourceTree.css';
+
+const { DirectoryTree } = Tree;
+
+type WorkspaceTabKey = 'chat' | 'feed' | 'details';
+
+interface ResourceTreeProps {
+  activeView: 'chat' | 'repo' | 'canvas';
+  activeWorkspaceTab: WorkspaceTabKey;
+  onNodeSelect?: (key: string) => void;
+  onNodeAction?: (key: string, action: string) => void;
+  variant?: 'default' | 'compact';
+}
+
+type ResourceTreeMenuKey = 'open' | 'details' | 'refresh';
+
+interface ResourceNode {
+  key: string;
+  title: string;
+  icon: React.ReactNode;
+  badge?: string;
+  menu?: MenuProps['items'];
+  children?: ResourceNode[];
+}
+
+const defaultMenu: MenuProps['items'] = [
+  { key: 'open', label: 'Abrir' },
+  { key: 'details', label: 'Ver detalles' },
+];
+
+const agentMenu: MenuProps['items'] = [
+  { key: 'open', label: 'Ver agentes' },
+  { key: 'refresh', label: 'Actualizar estado' },
+];
+
+const treeSchema: ResourceNode[] = [
+  {
+    key: 'workspace',
+    title: 'Espacios de trabajo',
+    icon: <ClusterOutlined />, 
+    children: [
+      {
+        key: 'workspace-chat',
+        title: 'Chat Operativo',
+        icon: <MessageOutlined />,
+        badge: 'Live',
+      },
+      {
+        key: 'workspace-feed',
+        title: 'Feed de eventos',
+        icon: <RadarChartOutlined />,
+      },
+      {
+        key: 'workspace-details',
+        title: 'Panel de detalles',
+        icon: <ShareAltOutlined />,
+      },
+      {
+        key: 'workspace-repo',
+        title: 'Repositorios',
+        icon: <BranchesOutlined />,
+      },
+      {
+        key: 'workspace-canvas',
+        title: 'Code Canvas',
+        icon: <DeploymentUnitOutlined />,
+      },
+    ],
+  },
+  {
+    key: 'agents',
+    title: 'Agentes orquestados',
+    icon: <RobotOutlined />,
+    menu: agentMenu,
+    children: [
+      {
+        key: 'agents-active',
+        title: 'Activos',
+        icon: <RobotOutlined />,
+        badge: 'Auto',
+        menu: agentMenu,
+      },
+      {
+        key: 'agents-archived',
+        title: 'Archivados',
+        icon: <RobotOutlined />,
+        menu: agentMenu,
+      },
+    ],
+  },
+  {
+    key: 'models',
+    title: 'Modelos',
+    icon: <AppstoreOutlined />,
+    children: [
+      {
+        key: 'models-local',
+        title: 'Modelos locales',
+        icon: <InboxOutlined />,
+      },
+      {
+        key: 'models-cloud',
+        title: 'Modelos en nube',
+        icon: <ApiOutlined />,
+      },
+    ],
+  },
+  {
+    key: 'projects',
+    title: 'Proyectos',
+    icon: <BranchesOutlined />,
+    children: [
+      {
+        key: 'projects-active',
+        title: 'Activos',
+        icon: <BranchesOutlined />,
+      },
+      {
+        key: 'projects-archive',
+        title: 'Histórico',
+        icon: <InboxOutlined />,
+      },
+    ],
+  },
+  {
+    key: 'preferences',
+    title: 'Preferencias',
+    icon: <SettingOutlined />,
+    children: [
+      {
+        key: 'preferences-routing',
+        title: 'Rutas inteligentes',
+        icon: <ShareAltOutlined />,
+      },
+      {
+        key: 'preferences-workspace',
+        title: 'Diseño del workspace',
+        icon: <SettingOutlined />,
+      },
+    ],
+  },
+  {
+    key: 'plugins',
+    title: 'Plugins y extensiones',
+    icon: <DeploymentUnitOutlined />,
+  },
+  {
+    key: 'mcp',
+    title: 'Perfiles MCP',
+    icon: <ShareAltOutlined />,
+  },
+  {
+    key: 'settings',
+    title: 'Ajustes globales',
+    icon: <SettingOutlined />,
+  },
+];
+
+const deriveWorkspaceKey = (
+  activeView: 'chat' | 'repo' | 'canvas',
+  tab: WorkspaceTabKey,
+): string | null => {
+  if (activeView === 'chat') {
+    return `workspace-${tab}`;
+  }
+  if (activeView === 'repo') {
+    return 'workspace-repo';
+  }
+  if (activeView === 'canvas') {
+    return 'workspace-canvas';
+  }
+  return null;
+};
+
+export const ResourceTree: React.FC<ResourceTreeProps> = ({
+  activeView,
+  activeWorkspaceTab,
+  onNodeSelect,
+  onNodeAction,
+  variant = 'default',
+}) => {
+  const [expandedKeys, setExpandedKeys] = useState<React.Key[]>(['workspace', 'agents', 'models']);
+  const [selectedKeys, setSelectedKeys] = useState<React.Key[]>([]);
+
+  useEffect(() => {
+    const workspaceKey = deriveWorkspaceKey(activeView, activeWorkspaceTab);
+    if (!workspaceKey) {
+      return;
+    }
+
+    setSelectedKeys(current => {
+      if (current.length === 0) {
+        return [workspaceKey];
+      }
+
+      const [currentKey] = current;
+      if (typeof currentKey === 'string' && currentKey.startsWith('workspace-') && currentKey !== workspaceKey) {
+        return [workspaceKey];
+      }
+
+      return current;
+    });
+  }, [activeView, activeWorkspaceTab]);
+
+  const decoratedTreeData = useMemo<DataNode[]>(() => {
+    const selectedKeySet = new Set(selectedKeys.map(String));
+
+    const buildNodes = (nodes: ResourceNode[]): DataNode[] =>
+      nodes.map(node => {
+        const menuItems = node.menu ?? defaultMenu;
+        const isActive = selectedKeySet.has(node.key);
+        const titleContent = (
+          <Dropdown
+            trigger={['contextMenu']}
+            menu={{
+              items: menuItems,
+              onClick: ({ key }) => onNodeAction?.(node.key, key as ResourceTreeMenuKey),
+            }}
+          >
+            <span className={`resource-tree-item ${isActive ? 'is-active' : ''}`}>
+              <span className="resource-tree-item__icon">{node.icon}</span>
+              <span className="resource-tree-item__label">{node.title}</span>
+              {node.badge ? <span className="resource-tree-item__badge">{node.badge}</span> : null}
+            </span>
+          </Dropdown>
+        );
+
+        return {
+          key: node.key,
+          title: titleContent,
+          className: `resource-tree-node ${isActive ? 'resource-tree-node--active' : ''}`,
+          children: node.children ? buildNodes(node.children) : undefined,
+        } satisfies DataNode;
+      });
+
+    return buildNodes(treeSchema);
+  }, [onNodeAction, selectedKeys]);
+
+  return (
+    <div className={`resource-tree resource-tree--${variant}`}>
+      <DirectoryTree
+        treeData={decoratedTreeData}
+        expandedKeys={expandedKeys}
+        onExpand={keys => setExpandedKeys(keys)}
+        selectedKeys={selectedKeys}
+        onSelect={(keys, info) => {
+          setSelectedKeys(keys);
+          const targetKey = info.node?.key;
+          if (typeof targetKey === 'string') {
+            onNodeSelect?.(targetKey);
+          }
+        }}
+        multiple={false}
+        showIcon={false}
+        blockNode
+        height={variant === 'compact' ? undefined : 520}
+      />
+      <Typography.Paragraph className="resource-tree__hint" type="secondary">
+        Click izquierdo para navegar · Click derecho para acciones rápidas
+      </Typography.Paragraph>
+    </div>
+  );
+};
+
+export default ResourceTree;


### PR DESCRIPTION
## Summary
- Replaced the legacy ProLayout container with a Proxmox-inspired Layout/Sider/Content shell, featuring a persistent resource tree and mobile drawer navigation.
- Reorganized the chat workspace into Proxmox-style tabs (Chat, Feed, Detalles) with a companion info panel while preserving existing messaging logic.
- Added new styling for the shell, navigation tree, and workspace tabs to match the Proxmox look and feel.

## Testing
- npm run lint
- npm run test

------
https://chatgpt.com/codex/tasks/task_e_68d43c3aaee083339e0a156f8e617ab8