### PR TITLE
feat: migrate workspace chrome to proxmox layout

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -14,7 +14,6 @@
   border-inline-end: 1px solid var(--color-border-strong);
   display: flex;
   flex-direction: column;
-  gap: var(--space-lg);
   padding: var(--space-lg) var(--space-md);
   box-shadow: inset -1px 0 0 rgba(0, 0, 0, 0.25);
 }
@@ -37,6 +36,36 @@
   font-size: 12px;
   text-transform: uppercase;
   letter-spacing: 1px;
+}
+
+.proxmox-sider__content {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-md);
+  flex: 1;
+  overflow: hidden;
+  padding-top: var(--space-md);
+}
+
+.proxmox-sider__content--compact {
+  gap: var(--space-sm);
+  padding-top: var(--space-sm);
+}
+
+.proxmox-sider__tree {
+  flex: 1;
+  min-height: 0;
+  overflow: hidden;
+}
+
+.proxmox-sider__tree .resource-tree {
+  height: 100%;
+  padding-block: 0;
+}
+
+.proxmox-sider__tree .ant-tree {
+  overflow: auto;
+  max-height: 100%;
 }
 
 .proxmox-main {
@@ -113,14 +142,22 @@
 }
 
 .proxmox-footer {
-  background: rgba(12, 14, 28, 0.85);
+  background: rgba(12, 14, 28, 0.92);
   border-top: 1px solid var(--color-border-strong);
-  padding: var(--space-md) var(--space-xl);
+  display: flex;
+  flex-direction: column;
+  gap: 0;
+  padding: 0;
+}
+
+.proxmox-footer__meta {
+  width: 100%;
+  padding: var(--space-sm) var(--space-xl);
   color: var(--color-text-muted);
   font-size: 12px;
   letter-spacing: 0.8px;
-  display: flex;
-  align-items: center;
+  border-top: 1px solid rgba(255, 255, 255, 0.08);
+  background: rgba(10, 11, 24, 0.88);
 }
 
 .proxmox-nav-drawer .ant-drawer-body {
@@ -150,6 +187,10 @@
   .proxmox-info-panel {
     width: 100%;
   }
+
+  .proxmox-footer__meta {
+    padding: var(--space-sm) var(--space-lg);
+  }
 }
 
 @media (max-width: 1024px) {
@@ -172,10 +213,7 @@
     padding: var(--space-md) var(--space-sm) var(--space-md);
   }
 
-  .proxmox-footer {
+  .proxmox-footer__meta {
     padding: var(--space-sm) var(--space-md);
-    flex-direction: column;
-    gap: var(--space-xs);
-    align-items: flex-start;
   }
 }

--- a/src/components/layout/ProviderStatus.css
+++ b/src/components/layout/ProviderStatus.css
@@ -1,0 +1,57 @@
+.provider-status {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-sm);
+  padding: var(--space-sm) var(--space-xs);
+  background: rgba(19, 22, 40, 0.72);
+  border: 1px solid rgba(255, 255, 255, 0.06);
+  border-radius: var(--radius-md);
+  box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.04);
+}
+
+.provider-status__header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  color: var(--color-text-base);
+}
+
+.provider-status__runtime {
+  display: flex;
+  flex-wrap: wrap;
+  gap: var(--space-xs);
+}
+
+.provider-status__grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(120px, 1fr));
+  gap: var(--space-sm);
+  margin-top: var(--space-xs);
+}
+
+.provider-status__metric {
+  padding: var(--space-sm);
+  border-radius: var(--radius-sm);
+  background: rgba(255, 255, 255, 0.02);
+  border: 1px solid rgba(255, 255, 255, 0.04);
+  min-height: 88px;
+}
+
+.provider-status__metric .ant-typography,
+.provider-status__header .ant-typography {
+  color: inherit;
+}
+
+.provider-status__metric .ant-typography-secondary {
+  font-size: 12px;
+  letter-spacing: 0.6px;
+}
+
+.provider-status__metric .ant-typography.ant-typography-secondary {
+  color: rgba(255, 255, 255, 0.55);
+}
+
+.provider-status__metric .ant-typography.ant-typography-paragraph {
+  margin-bottom: 0;
+  font-size: 12px;
+}

--- a/src/components/layout/ProviderStatus.tsx
+++ b/src/components/layout/ProviderStatus.tsx
@@ -1,0 +1,145 @@
+import React, { useMemo } from 'react';
+import { Button, Space, Tag, Tooltip, Typography } from 'antd';
+import {
+  CloudServerOutlined,
+  FieldTimeOutlined,
+  ReloadOutlined,
+  ThunderboltOutlined,
+  UsbOutlined,
+} from '@ant-design/icons';
+import type { AgentPresenceSummary } from '../../core/agents/presence';
+import type { AgentPresenceEntry } from '../../core/agents/presence';
+import type { JarvisRuntimeStatus } from '../../core/jarvis/JarvisCoreContext';
+import './ProviderStatus.css';
+
+export interface ProviderStatusProps {
+  summary: AgentPresenceSummary;
+  presenceMap: Map<string, AgentPresenceEntry>;
+  pendingResponses: number;
+  runtimeStatus: JarvisRuntimeStatus;
+  uptimeMs?: number | null;
+  onRefresh: () => void;
+}
+
+const runtimeLabels: Record<JarvisRuntimeStatus, { label: string; tone: 'default' | 'success' | 'warning' | 'error' }> = {
+  offline: { label: 'Desconectado', tone: 'default' },
+  starting: { label: 'Iniciando…', tone: 'warning' },
+  ready: { label: 'Operativo', tone: 'success' },
+  error: { label: 'Con incidencias', tone: 'error' },
+};
+
+const toneColor: Record<'default' | 'success' | 'warning' | 'error', string> = {
+  default: 'default',
+  success: 'success',
+  warning: 'warning',
+  error: 'error',
+};
+
+const formatUptime = (uptimeMs?: number | null): string | null => {
+  if (!uptimeMs || uptimeMs <= 0) {
+    return null;
+  }
+  const totalSeconds = Math.floor(uptimeMs / 1000);
+  const hours = Math.floor(totalSeconds / 3600);
+  const minutes = Math.floor((totalSeconds % 3600) / 60);
+  if (hours > 24) {
+    const days = Math.floor(hours / 24);
+    return `${days}d ${hours % 24}h`;
+  }
+  if (hours > 0) {
+    return `${hours}h ${minutes.toString().padStart(2, '0')}m`;
+  }
+  const seconds = totalSeconds % 60;
+  return `${minutes}m ${seconds.toString().padStart(2, '0')}s`;
+};
+
+const countAverageLatency = (presenceMap: Map<string, AgentPresenceEntry>): number | null => {
+  const values = Array.from(presenceMap.values())
+    .map(entry => entry.latencyMs)
+    .filter((latency): latency is number => typeof latency === 'number');
+  if (!values.length) {
+    return null;
+  }
+  const total = values.reduce((acc, latency) => acc + latency, 0);
+  return Math.round(total / values.length);
+};
+
+export const ProviderStatus: React.FC<ProviderStatusProps> = ({
+  summary,
+  presenceMap,
+  pendingResponses,
+  runtimeStatus,
+  uptimeMs,
+  onRefresh,
+}) => {
+  const runtime = runtimeLabels[runtimeStatus];
+  const uptimeLabel = formatUptime(uptimeMs);
+  const latencyMs = useMemo(() => countAverageLatency(presenceMap), [presenceMap]);
+
+  return (
+    <section className="provider-status" aria-label="Estado de proveedores">
+      <header className="provider-status__header">
+        <Space size="small" align="center">
+          <ThunderboltOutlined />
+          <Typography.Text strong>Orquestación en vivo</Typography.Text>
+        </Space>
+        <Tooltip title="Actualizar presencia de agentes">
+          <Button type="text" icon={<ReloadOutlined />} onClick={onRefresh} aria-label="Actualizar presencia" />
+        </Tooltip>
+      </header>
+
+      <div className="provider-status__runtime">
+        <Tag color={toneColor[runtime.tone]} icon={<ThunderboltOutlined />} bordered={false}>
+          Jarvis Core · {runtime.label}
+        </Tag>
+        {uptimeLabel ? (
+          <Tag icon={<FieldTimeOutlined />} color="geekblue" bordered={false}>
+            Uptime {uptimeLabel}
+          </Tag>
+        ) : null}
+        {typeof latencyMs === 'number' ? (
+          <Tag icon={<ThunderboltOutlined />} color="purple" bordered={false}>
+            Latencia media {latencyMs} ms
+          </Tag>
+        ) : null}
+      </div>
+
+      <div className="provider-status__grid" role="list">
+        <div className="provider-status__metric" role="listitem">
+          <Space size={4} align="center">
+            <CloudServerOutlined />
+            <Typography.Text type="secondary">Cloud</Typography.Text>
+          </Space>
+          <Typography.Title level={4}>
+            {summary.byKind.cloud.online}/{summary.byKind.cloud.total}
+          </Typography.Title>
+          <Typography.Paragraph type="secondary">
+            {summary.byKind.cloud.loading} verificando · {summary.byKind.cloud.error} incidencias
+          </Typography.Paragraph>
+        </div>
+        <div className="provider-status__metric" role="listitem">
+          <Space size={4} align="center">
+            <UsbOutlined />
+            <Typography.Text type="secondary">Local</Typography.Text>
+          </Space>
+          <Typography.Title level={4}>
+            {summary.byKind.local.online}/{summary.byKind.local.total}
+          </Typography.Title>
+          <Typography.Paragraph type="secondary">
+            {summary.byKind.local.loading} preparando · {summary.byKind.local.error} incidencias
+          </Typography.Paragraph>
+        </div>
+        <div className="provider-status__metric" role="listitem">
+          <Space size={4} align="center">
+            <ThunderboltOutlined />
+            <Typography.Text type="secondary">Tareas</Typography.Text>
+          </Space>
+          <Typography.Title level={4}>{pendingResponses}</Typography.Title>
+          <Typography.Paragraph type="secondary">Respuestas pendientes en cola</Typography.Paragraph>
+        </div>
+      </div>
+    </section>
+  );
+};
+
+export default ProviderStatus;

--- a/src/components/layout/QuickActions.css
+++ b/src/components/layout/QuickActions.css
@@ -1,0 +1,35 @@
+.quick-actions {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-sm);
+  padding: var(--space-sm) var(--space-xs);
+  background: rgba(19, 22, 40, 0.68);
+  border-radius: var(--radius-md);
+  border: 1px solid rgba(255, 255, 255, 0.05);
+}
+
+.quick-actions__header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  color: var(--color-text-muted);
+}
+
+.quick-actions__grid {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: var(--space-xs);
+}
+
+.quick-actions__divider {
+  margin: var(--space-xs) 0;
+  border-color: rgba(255, 255, 255, 0.08);
+}
+
+.quick-actions .ant-btn {
+  border-radius: var(--radius-sm);
+}
+
+.quick-actions .ant-btn-primary {
+  box-shadow: 0 8px 16px rgba(89, 125, 255, 0.26);
+}

--- a/src/components/layout/QuickActions.tsx
+++ b/src/components/layout/QuickActions.tsx
@@ -1,0 +1,69 @@
+import React from 'react';
+import { Button, Divider, Tooltip, Typography } from 'antd';
+import {
+  ApiOutlined,
+  AppstoreOutlined,
+  BarChartOutlined,
+  PlusCircleOutlined,
+  SettingOutlined,
+  ThunderboltOutlined,
+} from '@ant-design/icons';
+import './QuickActions.css';
+
+export interface QuickActionsProps {
+  onOpenSettings: () => void;
+  onOpenPlugins: () => void;
+  onOpenMcp: () => void;
+  onOpenModelManager: () => void;
+  onOpenStats: () => void;
+  onRefreshPresence: () => void;
+}
+
+export const QuickActions: React.FC<QuickActionsProps> = ({
+  onOpenSettings,
+  onOpenPlugins,
+  onOpenMcp,
+  onOpenModelManager,
+  onOpenStats,
+  onRefreshPresence,
+}) => {
+  return (
+    <section className="quick-actions" aria-label="Accesos rápidos">
+      <header className="quick-actions__header">
+        <Typography.Text type="secondary">Acciones rápidas</Typography.Text>
+        <Tooltip title="Refrescar estado de agentes">
+          <Button
+            type="text"
+            size="small"
+            icon={<ThunderboltOutlined />}
+            onClick={onRefreshPresence}
+            aria-label="Refrescar estado"
+          />
+        </Tooltip>
+      </header>
+
+      <div className="quick-actions__grid">
+        <Button block icon={<PlusCircleOutlined />} onClick={onOpenStats}>
+          Task history
+        </Button>
+        <Button block icon={<AppstoreOutlined />} onClick={onOpenPlugins}>
+          Plugins
+        </Button>
+        <Button block icon={<ApiOutlined />} onClick={onOpenMcp}>
+          Perfiles MCP
+        </Button>
+        <Button block icon={<BarChartOutlined />} onClick={onOpenModelManager}>
+          Modelos
+        </Button>
+      </div>
+
+      <Divider className="quick-actions__divider" />
+
+      <Button block type="primary" icon={<SettingOutlined />} onClick={onOpenSettings}>
+        Preferencias globales
+      </Button>
+    </section>
+  );
+};
+
+export default QuickActions;

--- a/src/components/layout/ResourceTree.css
+++ b/src/components/layout/ResourceTree.css
@@ -66,6 +66,26 @@
   text-transform: uppercase;
 }
 
+.resource-tree-item__badge--success {
+  background: rgba(82, 196, 26, 0.2);
+  color: #52c41a;
+}
+
+.resource-tree-item__badge--warning {
+  background: rgba(250, 140, 22, 0.18);
+  color: #fa8c16;
+}
+
+.resource-tree-item__badge--processing {
+  background: rgba(47, 84, 235, 0.22);
+  color: #2f54eb;
+}
+
+.resource-tree-item__badge--error {
+  background: rgba(255, 77, 79, 0.2);
+  color: #ff4d4f;
+}
+
 .resource-tree-item.is-active .resource-tree-item__icon {
   color: var(--color-primary);
 }

--- a/src/components/layout/TaskDock.css
+++ b/src/components/layout/TaskDock.css
@@ -1,0 +1,82 @@
+.task-dock {
+  position: relative;
+  width: 100%;
+  background: rgba(10, 11, 24, 0.94);
+  border-top: 1px solid rgba(255, 255, 255, 0.08);
+  box-shadow: 0 -12px 32px rgba(0, 0, 0, 0.35);
+  display: flex;
+  flex-direction: column;
+  overflow: hidden;
+  transition: height 0.2s ease;
+}
+
+.task-dock--collapsed {
+  min-height: 56px;
+}
+
+.task-dock__resize {
+  height: 6px;
+  cursor: row-resize;
+  background: linear-gradient(90deg, transparent 0%, rgba(255, 255, 255, 0.18) 50%, transparent 100%);
+}
+
+.task-dock__header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: var(--space-xs) var(--space-lg);
+  border-bottom: 1px solid rgba(255, 255, 255, 0.05);
+  color: var(--color-text-base);
+}
+
+.task-dock__header .ant-typography {
+  color: inherit;
+}
+
+.task-dock__presence {
+  flex-wrap: wrap;
+}
+
+.task-dock__tabs {
+  flex: 1;
+  display: flex;
+  flex-direction: column;
+  padding: var(--space-sm) var(--space-lg) var(--space-md);
+  overflow: hidden;
+}
+
+.task-dock__tabs .ant-tabs-content-holder {
+  flex: 1;
+  overflow: auto;
+}
+
+.task-dock__tabs .ant-list {
+  background: transparent;
+  color: var(--color-text-base);
+}
+
+.task-dock__tabs .ant-list-item {
+  border-color: rgba(255, 255, 255, 0.06);
+  padding: var(--space-xs) 0;
+}
+
+.task-dock__list-item {
+  width: 100%;
+}
+
+.task-dock__tabs .ant-empty-description {
+  color: var(--color-text-muted);
+}
+
+@media (max-width: 768px) {
+  .task-dock__header {
+    padding-inline: var(--space-md);
+    flex-direction: column;
+    align-items: flex-start;
+    gap: var(--space-xs);
+  }
+
+  .task-dock__tabs {
+    padding-inline: var(--space-md);
+  }
+}

--- a/src/components/layout/TaskDock.tsx
+++ b/src/components/layout/TaskDock.tsx
@@ -1,0 +1,291 @@
+import React, { useMemo, useRef, useState } from 'react';
+import { Badge, Button, Empty, List, Space, Tabs, Tag, Tooltip, Typography } from 'antd';
+import {
+  AlertOutlined,
+  AreaChartOutlined,
+  ClockCircleOutlined,
+  HistoryOutlined,
+  PicCenterOutlined,
+  SwapOutlined,
+} from '@ant-design/icons';
+import type { AgentDefinition } from '../../core/agents/agentRegistry';
+import type { AgentPresenceSummary } from '../../core/agents/presence';
+import type { OrchestrationTraceEntry } from '../../core/orchestration/types';
+import type { ChatMessageAction } from '../../core/messages/messageTypes';
+import type { SharedMessageLogEntry } from '../../core/messages/MessageContext';
+import { getAgentDisplayName } from '../../utils/agentDisplay';
+import './TaskDock.css';
+
+export interface TaskDockProps {
+  pendingResponses: number;
+  pendingActions: ChatMessageAction[];
+  sharedMessageLog: SharedMessageLogEntry[];
+  orchestrationTraces: OrchestrationTraceEntry[];
+  presenceSummary: AgentPresenceSummary;
+  agents: AgentDefinition[];
+}
+
+const STATUS_COLOR: Record<ChatMessageAction['status'], string> = {
+  pending: 'default',
+  accepted: 'processing',
+  executing: 'blue',
+  completed: 'success',
+  rejected: 'default',
+  failed: 'error',
+};
+
+const statusLabel: Record<ChatMessageAction['status'], string> = {
+  pending: 'Pendiente',
+  accepted: 'Aceptada',
+  executing: 'Ejecutando',
+  completed: 'Completada',
+  rejected: 'Rechazada',
+  failed: 'Fallida',
+};
+
+const formatTimestamp = (iso: string): string => {
+  try {
+    return new Date(iso).toLocaleTimeString('es-ES', { hour: '2-digit', minute: '2-digit', second: '2-digit' });
+  } catch {
+    return iso;
+  }
+};
+
+const presenceOrder: Array<keyof AgentPresenceSummary['totals']> = ['online', 'loading', 'offline', 'error'];
+
+export const TaskDock: React.FC<TaskDockProps> = ({
+  pendingResponses,
+  pendingActions,
+  sharedMessageLog,
+  orchestrationTraces,
+  presenceSummary,
+  agents,
+}) => {
+  const [activeKey, setActiveKey] = useState('queue');
+  const [isCollapsed, setCollapsed] = useState(false);
+  const [height, setHeight] = useState(260);
+  const dockRef = useRef<HTMLDivElement | null>(null);
+
+  const sortedActions = useMemo(
+    () =>
+      [...pendingActions]
+        .sort((a, b) => new Date(b.updatedAt).getTime() - new Date(a.updatedAt).getTime())
+        .slice(0, 20),
+    [pendingActions],
+  );
+
+  const recentLogs = useMemo(
+    () =>
+      [...sharedMessageLog]
+        .sort((a, b) => new Date(b.sharedAt).getTime() - new Date(a.sharedAt).getTime())
+        .slice(0, 20),
+    [sharedMessageLog],
+  );
+
+  const recentEvents = useMemo(
+    () =>
+      [...orchestrationTraces]
+        .sort((a, b) => new Date(b.timestamp).getTime() - new Date(a.timestamp).getTime())
+        .slice(0, 20),
+    [orchestrationTraces],
+  );
+
+  const agentLookup = useMemo(() => {
+    return new Map(agents.map(agent => [agent.id, getAgentDisplayName(agent)]));
+  }, [agents]);
+
+  const handleResizeStart = (event: React.MouseEvent<HTMLDivElement>) => {
+    if (isCollapsed) {
+      return;
+    }
+    event.preventDefault();
+    const startY = event.clientY;
+    const startHeight = dockRef.current?.offsetHeight ?? height;
+
+    const handleMove = (moveEvent: MouseEvent) => {
+      const delta = startY - moveEvent.clientY;
+      const next = Math.min(480, Math.max(160, startHeight + delta));
+      setHeight(next);
+    };
+
+    const handleStop = () => {
+      window.removeEventListener('mousemove', handleMove);
+      window.removeEventListener('mouseup', handleStop);
+    };
+
+    window.addEventListener('mousemove', handleMove);
+    window.addEventListener('mouseup', handleStop);
+  };
+
+  const presenceSummaryItems = presenceOrder.map(key => ({
+    key,
+    value: presenceSummary.totals[key],
+  }));
+
+  const presenceMeta: Record<keyof AgentPresenceSummary['totals'], { label: string; color: string }> = {
+    online: { label: 'Online', color: 'success' },
+    loading: { label: 'Verificando', color: 'warning' },
+    offline: { label: 'En espera', color: 'default' },
+    error: { label: 'Incidencias', color: 'error' },
+  };
+
+  const tabItems = [
+    {
+      key: 'queue',
+      label: (
+        <Space size={4} align="center">
+          <PicCenterOutlined />
+          Cola ({pendingResponses + pendingActions.length})
+        </Space>
+      ),
+      children: sortedActions.length === 0 && pendingResponses === 0 ? (
+        <Empty description="Sin tareas pendientes" image={Empty.PRESENTED_IMAGE_SIMPLE} />
+      ) : (
+        <List
+          size="small"
+          dataSource={sortedActions}
+          renderItem={item => (
+            <List.Item key={item.id}>
+              <Space direction="vertical" size={0} className="task-dock__list-item">
+                <Space size="small" align="center">
+                  <Tag color={STATUS_COLOR[item.status]}>{statusLabel[item.status]}</Tag>
+                  <Typography.Text>{item.label ?? item.kind}</Typography.Text>
+                  <Typography.Text type="secondary">{formatTimestamp(item.updatedAt)}</Typography.Text>
+                </Space>
+                {item.description ? (
+                  <Typography.Paragraph type="secondary" ellipsis={{ rows: 2 }}>
+                    {item.description}
+                  </Typography.Paragraph>
+                ) : null}
+              </Space>
+            </List.Item>
+          )}
+          footer={
+            pendingResponses > 0 ? (
+              <Typography.Text type="secondary">
+                {pendingResponses} respuestas en cola de agentes.
+              </Typography.Text>
+            ) : null
+          }
+        />
+      ),
+    },
+    {
+      key: 'logs',
+      label: (
+        <Space size={4} align="center">
+          <HistoryOutlined />
+          Logs ({recentLogs.length})
+        </Space>
+      ),
+      children: recentLogs.length === 0 ? (
+        <Empty description="Sin actividad compartida" image={Empty.PRESENTED_IMAGE_SIMPLE} />
+      ) : (
+        <List
+          size="small"
+          dataSource={recentLogs}
+          renderItem={log => (
+            <List.Item key={log.id}>
+              <Space direction="vertical" size={0} className="task-dock__list-item">
+                <Space size={4} align="center">
+                  <Badge color="geekblue" />
+                  <Typography.Text strong>
+                    {agentLookup.get(log.agentId ?? '') ?? 'Agente desconocido'}
+                  </Typography.Text>
+                  <Typography.Text type="secondary">{formatTimestamp(log.sharedAt)}</Typography.Text>
+                </Space>
+                {log.canonicalCode ? (
+                  <Typography.Text type="secondary" ellipsis>
+                    {log.canonicalCode}
+                  </Typography.Text>
+                ) : null}
+              </Space>
+            </List.Item>
+          )}
+        />
+      ),
+    },
+    {
+      key: 'events',
+      label: (
+        <Space size={4} align="center">
+          <AreaChartOutlined />
+          Eventos ({recentEvents.length})
+        </Space>
+      ),
+      children: recentEvents.length === 0 ? (
+        <Empty description="Sin eventos recientes" image={Empty.PRESENTED_IMAGE_SIMPLE} />
+      ) : (
+        <List
+          size="small"
+          dataSource={recentEvents}
+          renderItem={event => (
+            <List.Item key={event.id}>
+              <Space direction="vertical" size={0} className="task-dock__list-item">
+                <Space size={4} align="center">
+                  <Tag color="blue">{event.strategyId}</Tag>
+                  <Typography.Text>{event.description}</Typography.Text>
+                </Space>
+                <Typography.Text type="secondary">
+                  {event.agentId ? `${agentLookup.get(event.agentId) ?? event.agentId} · ` : ''}
+                  {formatTimestamp(event.timestamp)}
+                </Typography.Text>
+                {event.details ? (
+                  <Typography.Paragraph type="secondary" ellipsis={{ rows: 2 }}>
+                    {event.details}
+                  </Typography.Paragraph>
+                ) : null}
+              </Space>
+            </List.Item>
+          )}
+        />
+      ),
+    },
+  ];
+
+  return (
+    <aside
+      className={`task-dock ${isCollapsed ? 'task-dock--collapsed' : ''}`}
+      style={{ height: isCollapsed ? 56 : height }}
+      ref={dockRef}
+    >
+      <div className="task-dock__resize" onMouseDown={handleResizeStart} role="separator" aria-orientation="horizontal" />
+      <header className="task-dock__header">
+        <Space size="large" align="center">
+          <Space size={6} align="center">
+            <SwapOutlined />
+            <Typography.Text strong>Task Log</Typography.Text>
+          </Space>
+          <Space size={4} align="center" className="task-dock__presence">
+            {presenceSummaryItems.map(item => (
+              <Tag
+                key={item.key}
+                icon={<AlertOutlined />}
+                color={presenceMeta[item.key].color}
+                bordered={false}
+              >
+                {presenceMeta[item.key].label}: {item.value}
+              </Tag>
+            ))}
+          </Space>
+        </Space>
+        <Space align="center" size="small">
+          <Tooltip title={isCollapsed ? 'Expandir panel' : 'Minimizar panel'}>
+            <Button
+              type="text"
+              size="small"
+              icon={isCollapsed ? <ClockCircleOutlined /> : <PicCenterOutlined />}
+              onClick={() => setCollapsed(prev => !prev)}
+              aria-label={isCollapsed ? 'Expandir panel' : 'Minimizar panel'}
+            />
+          </Tooltip>
+        </Space>
+      </header>
+      {!isCollapsed ? (
+        <Tabs activeKey={activeKey} onChange={setActiveKey} items={tabItems} className="task-dock__tabs" />
+      ) : null}
+    </aside>
+  );
+};
+
+export default TaskDock;


### PR DESCRIPTION
## Summary
- restructure the navigation sidebar into provider metrics, quick actions, and a resource tree with live presence badges
- add a resizable task dock that surfaces queues, shared logs, and orchestration events alongside new layout chrome
- expand the top bar with connection KPIs, data center selection, and session controls to mirror the Proxmox-style UI

## Testing
- npm run test

------
https://chatgpt.com/codex/tasks/task_e_68d440c0cb488333a561234df5bfaaef