### PR TITLE
feat: responsive layout with quick configuration drawers

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,26 @@
 # JungleMonkAI
 
+## Arquitectura de layout responsivo
+
+- El shell principal replica la experiencia de Proxmox con un `Sider` plegable para escritorio y un **Drawer** automático en tablet/móvil. El colapso se sincroniza con `workspacePreferences.sidePanel` para mantener la preferencia por usuario.
+- El área de contenido adapta la distribución mediante breakpoints `xl` y `lg`. En pantallas amplias se muestran simultáneamente el workspace, el monitor de actividad y la barra inferior; en resoluciones reducidas se apilan para priorizar el flujo conversacional.
+- La cabecera incorpora **breadcrumbs dinámicos** y un *context switcher* (workspace/cluster/insights) que guía la navegación según el ámbito activo.
+- Se añadieron paneles flotantes (`Drawer`) para configurar agentes y modelos sin abandonar el contexto principal. Desde escritorio los accesos aparecen en el Sider colapsable; en móvil se integran en el Drawer lateral.
+
+## Biblioteca de componentes reutilizables
+
+- `ProSectionCard`: envoltorio de `ProCard` con estilos consistentes para superficies principales, información complementaria y paneles secundarios.
+- `ProDataTable`: tabla con paginación compacta, controles desactivados por defecto y `rowKey="id"` para simplificar listados operativos.
+- `ProListPanel`: combina `ProCard` + `ProList` para configuraciones rápidas (por ejemplo, agentes). Acepta `metas` personalizados y mantiene estilo Ant Design Pro.
+- Los componentes anteriores se ubican en `src/components/pro` y deben reutilizarse en nuevos módulos para garantizar consistencia visual.
+
+## Atajos, drawers y feedback visual
+
+- Atajos soportados (Ctrl/Cmd + Shift): `A` abre la configuración rápida de agentes, `M` la de modelos, `S` los ajustes globales, `P` el gestor de plugins y `B` alterna el menú lateral.
+- Cada atajo genera una notificación (Ant Design) en la esquina inferior derecha para confirmar la acción y orientar al usuario.
+- El Drawer de agentes (`AgentQuickConfigDrawer`) permite activar/desactivar instancias al instante; el Drawer de modelos (`ModelQuickConfigDrawer`) habilita cambios básicos de almacenamiento y Hugging Face.
+- `QuickActions` adopta la librería pro-component para mostrar accesos coherentes y destacar las rutas de configuración rápida.
+
 ## Flujo de compartición entre agentes
 
 El panel de conversación ahora permite reenviar respuestas entre agentes para acelerar revisiones y hand-offs técnicos.
@@ -61,3 +82,7 @@ Los tests de la API de Jarvis Core se ejecutan con `pytest`:
 ```bash
 pytest
 ```
+
+## Checklist para nuevos módulos
+
+Consulta [docs/extension-checklist.md](docs/extension-checklist.md) antes de añadir pantallas o paneles. Resume los pasos mínimos para mantener la coherencia visual, UX y las validaciones automáticas.

--- a/docs/extension-checklist.md
+++ b/docs/extension-checklist.md
@@ -1,0 +1,21 @@
+# Checklist para extensiones de JungleMonkAI
+
+## Layout y navegación
+- [ ] Validar que el `Sider` respeta las preferencias almacenadas (posición, ancho y estado colapsado).
+- [ ] Probar breakpoints `xl`, `lg` y `md` para asegurar que Drawer y paneles se muestran correctamente.
+- [ ] Actualizar breadcrumbs y context switcher con el nuevo módulo o vista.
+
+## Componentes reutilizables
+- [ ] Usar `ProSectionCard`, `ProDataTable` o `ProListPanel` antes de crear nuevos contenedores.
+- [ ] Añadir props `aria-label` y `role` cuando corresponda para mantener la accesibilidad.
+- [ ] Documentar cualquier variación de estilo en `README.md` o en comentarios del componente.
+
+## Experiencia de usuario
+- [ ] Registrar atajos adicionales en `App.tsx` siguiendo el patrón existente de notificaciones.
+- [ ] Integrar feedback visual (notificaciones o badges) al introducir nuevos flujos críticos.
+- [ ] Evaluar si se requiere un Drawer o modal ligero antes de abrir un diálogo de pantalla completa.
+
+## QA
+- [ ] Ejecutar `npm run lint` y `npm test` tras los cambios.
+- [ ] Añadir pruebas unitarias para los nuevos componentes o atajos.
+- [ ] Actualizar esta checklist si el flujo de contribución evoluciona.

--- a/src/components/agents/AgentQuickConfigDrawer.tsx
+++ b/src/components/agents/AgentQuickConfigDrawer.tsx
@@ -1,0 +1,113 @@
+import React, { useMemo } from 'react';
+import { Badge, Drawer, Space, Switch, Tag, Typography } from 'antd';
+import type { BadgeProps } from 'antd';
+import { RobotOutlined } from '@ant-design/icons';
+import { useAgents } from '../../core/agents/AgentContext';
+import { getAgentDisplayName } from '../../utils/agentDisplay';
+import type { AgentDefinition } from '../../core/agents/agentRegistry';
+import { ProListPanel } from '../pro';
+
+const STATUS_COLORS: Record<string, BadgeProps['status']> = {
+  Disponible: 'success',
+  Inactivo: 'default',
+  'Sin clave': 'warning',
+  Cargando: 'processing',
+  Error: 'error',
+};
+
+interface AgentQuickConfigDrawerProps {
+  open: boolean;
+  onClose: () => void;
+}
+
+interface AgentItem {
+  id: string;
+  agent: AgentDefinition;
+  title: string;
+  status: string;
+  description?: string;
+  kind: AgentDefinition['kind'];
+  active: boolean;
+}
+
+export const AgentQuickConfigDrawer: React.FC<AgentQuickConfigDrawerProps> = ({ open, onClose }) => {
+  const { agents, toggleAgent } = useAgents();
+
+  const agentItems = useMemo<AgentItem[]>(
+    () =>
+      agents.map(agent => ({
+        id: agent.id,
+        agent,
+        title: getAgentDisplayName(agent),
+        status: agent.status,
+        description: agent.objective ?? agent.description,
+        kind: agent.kind,
+        active: agent.active,
+      })),
+    [agents],
+  );
+
+  return (
+    <Drawer
+      title={
+        <Space size={8} align="center">
+          <RobotOutlined />
+          <Typography.Text strong>Agentes operativos</Typography.Text>
+        </Space>
+      }
+      placement="right"
+      width={420}
+      onClose={onClose}
+      open={open}
+      destroyOnClose={false}
+      className="agent-quick-config"
+    >
+      <Typography.Paragraph type="secondary">
+        Activa o pausa agentes rápidamente. Los cambios se aplican de forma inmediata y se sincronizan con la
+        orquestación activa.
+      </Typography.Paragraph>
+
+      <ProListPanel<AgentItem>
+        dataSource={agentItems}
+        pagination={false}
+        metas={{
+          title: {
+            dataIndex: 'title',
+          },
+          subTitle: {
+            render: (_, row) => (
+              <Space size={6} wrap>
+                <Tag color={row.kind === 'cloud' ? 'geekblue' : 'green'}>{
+                  row.kind === 'cloud' ? 'Cloud' : 'Local'
+                }</Tag>
+                <Badge status={STATUS_COLORS[row.status] ?? 'default'} text={row.status} />
+              </Space>
+            ),
+          },
+          description: {
+            dataIndex: 'description',
+            render: (_, row) =>
+              row.description ? (
+                <Typography.Text type="secondary">{row.description}</Typography.Text>
+              ) : (
+                <Typography.Text type="secondary">Sin descripción</Typography.Text>
+              ),
+          },
+          actions: {
+            render: (_, row) => [
+              <Switch
+                key="toggle"
+                checked={row.active}
+                checkedChildren="Activo"
+                unCheckedChildren="Inactivo"
+                onChange={() => toggleAgent(row.id)}
+              />,
+            ],
+          },
+        }}
+      />
+    </Drawer>
+  );
+};
+
+export default AgentQuickConfigDrawer;

--- a/src/components/chat/ChatInterface.css
+++ b/src/components/chat/ChatInterface.css
@@ -187,6 +187,23 @@
   align-items: stretch;
 }
 
+.topbar-breadcrumbs {
+  min-width: 220px;
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+}
+
+.topbar-breadcrumbs .ant-breadcrumb,
+.topbar-breadcrumbs .ant-breadcrumb a,
+.topbar-breadcrumbs .ant-breadcrumb-separator {
+  color: rgba(255, 255, 255, 0.7);
+}
+
+.context-switcher {
+  min-width: 200px;
+}
+
 .presence-card {
   flex: 1 1 240px;
   display: flex;
@@ -308,6 +325,11 @@
 
   .topbar-presence {
     flex-direction: column;
+  }
+
+  .topbar-breadcrumbs {
+    width: 100%;
+    min-width: 0;
   }
 }
 

--- a/src/components/chat/__tests__/ChatTopBar.test.tsx
+++ b/src/components/chat/__tests__/ChatTopBar.test.tsx
@@ -79,6 +79,13 @@ const renderComponent = (
       onOpenModelManager={vi.fn()}
       activeView="chat"
       onChangeView={vi.fn()}
+      breadcrumbs={[{ key: 'home', title: 'Inicio' }]}
+      contextOptions={[{ value: 'workspace', label: 'Workspace' }]}
+      activeContext="workspace"
+      onContextChange={vi.fn()}
+      canToggleSider
+      isSiderCollapsed={false}
+      onToggleSider={vi.fn()}
     />,
   );
 };

--- a/src/components/chat/__tests__/SidePanel.test.tsx
+++ b/src/components/chat/__tests__/SidePanel.test.tsx
@@ -335,18 +335,27 @@ describe('Resumen de proveedores en SidePanel', () => {
         <ChatTopBar
           agents={[] as AgentDefinition[]}
           presenceSummary={presenceSummary}
+          presenceMap={new Map<string, AgentPresenceEntry>()}
           activeAgents={0}
           totalAgents={0}
           pendingResponses={0}
           activeFilter="all"
           onFilterChange={vi.fn()}
           onRefreshPresence={vi.fn()}
+          onOpenStats={vi.fn()}
           onOpenGlobalSettings={vi.fn()}
           onOpenPlugins={vi.fn()}
           onOpenMcp={vi.fn()}
           onOpenModelManager={vi.fn()}
           activeView="chat"
           onChangeView={vi.fn()}
+          breadcrumbs={[{ key: 'home', title: 'Inicio' }]}
+          contextOptions={[{ value: 'workspace', label: 'Workspace' }]}
+          activeContext="workspace"
+          onContextChange={vi.fn()}
+          canToggleSider
+          isSiderCollapsed={false}
+          onToggleSider={vi.fn()}
         />
       ),
     });

--- a/src/components/layout/QuickActions.css
+++ b/src/components/layout/QuickActions.css
@@ -2,28 +2,24 @@
   display: flex;
   flex-direction: column;
   gap: var(--space-sm);
-  padding: var(--space-sm) var(--space-xs);
   background: rgba(19, 22, 40, 0.68);
   border-radius: var(--radius-md);
   border: 1px solid rgba(255, 255, 255, 0.05);
 }
 
-.quick-actions__header {
-  display: flex;
-  align-items: center;
-  justify-content: space-between;
-  color: var(--color-text-muted);
-}
-
 .quick-actions__grid {
   display: grid;
-  grid-template-columns: repeat(2, minmax(0, 1fr));
+  grid-template-columns: repeat(auto-fill, minmax(140px, 1fr));
   gap: var(--space-xs);
 }
 
 .quick-actions__divider {
   margin: var(--space-xs) 0;
   border-color: rgba(255, 255, 255, 0.08);
+}
+
+.quick-actions__title {
+  color: var(--color-text-muted);
 }
 
 .quick-actions .ant-btn {

--- a/src/components/layout/QuickActions.tsx
+++ b/src/components/layout/QuickActions.tsx
@@ -1,13 +1,16 @@
 import React from 'react';
-import { Button, Divider, Tooltip, Typography } from 'antd';
+import { Button, Divider, Space, Tooltip, Typography } from 'antd';
 import {
   ApiOutlined,
   AppstoreOutlined,
   BarChartOutlined,
+  ClusterOutlined,
+  ControlOutlined,
   PlusCircleOutlined,
   SettingOutlined,
   ThunderboltOutlined,
 } from '@ant-design/icons';
+import { ProSectionCard } from '../pro';
 import './QuickActions.css';
 
 export interface QuickActionsProps {
@@ -17,6 +20,8 @@ export interface QuickActionsProps {
   onOpenModelManager: () => void;
   onOpenStats: () => void;
   onRefreshPresence: () => void;
+  onOpenAgentQuickConfig: () => void;
+  onOpenModelQuickConfig: () => void;
 }
 
 export const QuickActions: React.FC<QuickActionsProps> = ({
@@ -26,11 +31,19 @@ export const QuickActions: React.FC<QuickActionsProps> = ({
   onOpenModelManager,
   onOpenStats,
   onRefreshPresence,
+  onOpenAgentQuickConfig,
+  onOpenModelQuickConfig,
 }) => {
   return (
-    <section className="quick-actions" aria-label="Accesos rápidos">
-      <header className="quick-actions__header">
-        <Typography.Text type="secondary">Acciones rápidas</Typography.Text>
+    <ProSectionCard
+      className="quick-actions"
+      title={
+        <Space align="center" size={6} className="quick-actions__title">
+          <ControlOutlined />
+          <Typography.Text strong>Acciones rápidas</Typography.Text>
+        </Space>
+      }
+      extra={
         <Tooltip title="Refrescar estado de agentes">
           <Button
             type="text"
@@ -40,8 +53,10 @@ export const QuickActions: React.FC<QuickActionsProps> = ({
             aria-label="Refrescar estado"
           />
         </Tooltip>
-      </header>
-
+      }
+      bordered
+      aria-label="Accesos rápidos"
+    >
       <div className="quick-actions__grid">
         <Button block icon={<PlusCircleOutlined />} onClick={onOpenStats}>
           Task history
@@ -52,8 +67,14 @@ export const QuickActions: React.FC<QuickActionsProps> = ({
         <Button block icon={<ApiOutlined />} onClick={onOpenMcp}>
           Perfiles MCP
         </Button>
-        <Button block icon={<BarChartOutlined />} onClick={onOpenModelManager}>
-          Modelos
+        <Button block icon={<ClusterOutlined />} onClick={onOpenAgentQuickConfig}>
+          Agentes
+        </Button>
+        <Button block icon={<BarChartOutlined />} onClick={onOpenModelQuickConfig}>
+          Modelos rápidos
+        </Button>
+        <Button block icon={<SettingOutlined />} onClick={onOpenModelManager}>
+          Gestor avanzado
         </Button>
       </div>
 
@@ -62,7 +83,7 @@ export const QuickActions: React.FC<QuickActionsProps> = ({
       <Button block type="primary" icon={<SettingOutlined />} onClick={onOpenSettings}>
         Preferencias globales
       </Button>
-    </section>
+    </ProSectionCard>
   );
 };
 

--- a/src/components/models/ModelQuickConfigDrawer.tsx
+++ b/src/components/models/ModelQuickConfigDrawer.tsx
@@ -1,0 +1,124 @@
+import React, { useEffect } from 'react';
+import { Drawer, Form, FormInstance, Input, InputNumber, Space, Switch, Typography } from 'antd';
+import { DatabaseOutlined } from '@ant-design/icons';
+import type { ModelPreferences } from '../../types/globalSettings';
+import { ProSectionCard } from '../pro';
+
+interface ModelQuickConfigDrawerProps {
+  open: boolean;
+  preferences: ModelPreferences;
+  onClose: () => void;
+  onPreferencesChange: (next: ModelPreferences) => void;
+}
+
+interface ModelPreferencesForm {
+  storageDir: string | null;
+  huggingFaceApiBaseUrl: string;
+  huggingFaceMaxResults: number;
+  huggingFaceUseStoredToken: boolean;
+}
+
+const mapPreferencesToForm = (preferences: ModelPreferences): ModelPreferencesForm => ({
+  storageDir: preferences.storageDir,
+  huggingFaceApiBaseUrl: preferences.huggingFace.apiBaseUrl,
+  huggingFaceMaxResults: preferences.huggingFace.maxResults,
+  huggingFaceUseStoredToken: preferences.huggingFace.useStoredToken,
+});
+
+const commitFormToPreferences = (
+  formValues: ModelPreferencesForm,
+  previous: ModelPreferences,
+): ModelPreferences => ({
+  ...previous,
+  storageDir: formValues.storageDir ?? null,
+  huggingFace: {
+    ...previous.huggingFace,
+    apiBaseUrl: formValues.huggingFaceApiBaseUrl,
+    maxResults: formValues.huggingFaceMaxResults,
+    useStoredToken: formValues.huggingFaceUseStoredToken,
+  },
+});
+
+const syncFormWithPreferences = (form: FormInstance<ModelPreferencesForm>, preferences: ModelPreferences) => {
+  form.setFieldsValue(mapPreferencesToForm(preferences));
+};
+
+export const ModelQuickConfigDrawer: React.FC<ModelQuickConfigDrawerProps> = ({
+  open,
+  preferences,
+  onClose,
+  onPreferencesChange,
+}) => {
+  const [form] = Form.useForm<ModelPreferencesForm>();
+
+  useEffect(() => {
+    syncFormWithPreferences(form, preferences);
+  }, [form, preferences]);
+
+  return (
+    <Drawer
+      title={
+        <Space size={8} align="center">
+          <DatabaseOutlined />
+          <Typography.Text strong>Configuración rápida de modelos</Typography.Text>
+        </Space>
+      }
+      placement="right"
+      width={460}
+      onClose={onClose}
+      open={open}
+      destroyOnClose={false}
+    >
+      <Typography.Paragraph type="secondary">
+        Ajusta preferencias básicas de almacenamiento y consultas a Hugging Face sin abandonar el flujo de trabajo
+        principal.
+      </Typography.Paragraph>
+
+      <Form<ModelPreferencesForm>
+        form={form}
+        layout="vertical"
+        onValuesChange={(_, values) => onPreferencesChange(commitFormToPreferences(values, preferences))}
+        initialValues={mapPreferencesToForm(preferences)}
+      >
+        <ProSectionCard title="Almacenamiento">
+          <Form.Item<ModelPreferencesForm>
+            label="Directorio local"
+            name="storageDir"
+            tooltip="Ruta donde se almacenan los modelos descargados. Déjalo vacío para usar el valor por defecto."
+          >
+            <Input placeholder="~/modelos" allowClear />
+          </Form.Item>
+        </ProSectionCard>
+
+        <ProSectionCard title="Hugging Face">
+          <Form.Item<ModelPreferencesForm>
+            label="Endpoint"
+            name="huggingFaceApiBaseUrl"
+            tooltip="URL base utilizada para las consultas a la API de Hugging Face."
+          >
+            <Input placeholder="https://huggingface.co" />
+          </Form.Item>
+
+          <Form.Item<ModelPreferencesForm>
+            label="Máximo de resultados"
+            name="huggingFaceMaxResults"
+            tooltip="Número máximo de modelos sugeridos en las búsquedas rápidas."
+          >
+            <InputNumber min={1} max={100} style={{ width: '100%' }} />
+          </Form.Item>
+
+          <Form.Item<ModelPreferencesForm>
+            label="Usar token almacenado"
+            name="huggingFaceUseStoredToken"
+            valuePropName="checked"
+            tooltip="Controla si se utiliza el token guardado en el dispositivo para autenticarse automáticamente."
+          >
+            <Switch checkedChildren="Sí" unCheckedChildren="No" />
+          </Form.Item>
+        </ProSectionCard>
+      </Form>
+    </Drawer>
+  );
+};
+
+export default ModelQuickConfigDrawer;

--- a/src/components/pro/ProDataTable.tsx
+++ b/src/components/pro/ProDataTable.tsx
@@ -1,0 +1,36 @@
+import React from 'react';
+import { ProTable } from '@ant-design/pro-components';
+import type { ProTableProps } from '@ant-design/pro-components';
+
+export type ProDataTableProps<RecordType extends Record<string, any>, Params extends Record<string, any> = Record<string, any>> =
+  ProTableProps<RecordType, Params> & {
+    "aria-label"?: string;
+  };
+
+export const ProDataTable = <RecordType extends Record<string, any>, Params extends Record<string, any> = Record<string, any>>({
+  search,
+  options,
+  pagination,
+  ...rest
+}: ProDataTableProps<RecordType, Params>) => {
+  return (
+    <ProTable<RecordType, Params>
+      rowKey="id"
+      search={search ?? false}
+      options={options ?? { density: false, fullScreen: false, reload: false, setting: false }}
+      pagination={
+        pagination ?? {
+          pageSize: 10,
+          showSizeChanger: true,
+          size: 'small',
+          showTotal: total => `${total} registros`,
+        }
+      }
+      size="small"
+      bordered
+      {...rest}
+    />
+  );
+};
+
+export default ProDataTable;

--- a/src/components/pro/ProListPanel.tsx
+++ b/src/components/pro/ProListPanel.tsx
@@ -1,0 +1,23 @@
+import React from 'react';
+import { ProCard, ProList } from '@ant-design/pro-components';
+import type { ProListProps } from '@ant-design/pro-components';
+
+export interface ProListPanelProps<T extends Record<string, any>, ValueType extends Record<string, any> = Record<string, any>>
+  extends ProListProps<T, ValueType> {
+  title?: React.ReactNode;
+  extra?: React.ReactNode;
+}
+
+export const ProListPanel = <T extends Record<string, any>, ValueType extends Record<string, any> = Record<string, any>>({
+  title,
+  extra,
+  ...rest
+}: ProListPanelProps<T, ValueType>) => {
+  return (
+    <ProCard bordered headerBordered size="small" title={title} extra={extra} bodyStyle={{ padding: 0 }}>
+      <ProList<T, ValueType> rowKey="id" ghost {...rest} />
+    </ProCard>
+  );
+};
+
+export default ProListPanel;

--- a/src/components/pro/ProSectionCard.tsx
+++ b/src/components/pro/ProSectionCard.tsx
@@ -1,0 +1,27 @@
+import React from 'react';
+import { ProCard } from '@ant-design/pro-components';
+import type { ProCardProps } from '@ant-design/pro-components';
+
+export interface ProSectionCardProps extends ProCardProps {
+  "aria-label"?: string;
+}
+
+export const ProSectionCard: React.FC<ProSectionCardProps> = ({
+  children,
+  ...rest
+}) => {
+  return (
+    <ProCard
+      bordered
+      ghost
+      headerBordered
+      size="small"
+      bodyStyle={{ padding: 16 }}
+      {...rest}
+    >
+      {children}
+    </ProCard>
+  );
+};
+
+export default ProSectionCard;

--- a/src/components/pro/index.ts
+++ b/src/components/pro/index.ts
@@ -1,0 +1,3 @@
+export * from './ProSectionCard';
+export * from './ProDataTable';
+export * from './ProListPanel';


### PR DESCRIPTION
## Summary
- implement Proxmox-inspired responsive layout with collapsible sider, mobile drawer, breadcrumbs and context switcher
- add reusable Ant Design Pro wrappers (cards, tables, lists) plus quick drawers for agents and models with keyboard shortcuts & notifications
- modernize quick actions, update chat toolbar styling, document new architecture and add extension checklist

## Testing
- npm run lint
- npm test -- --run

------
https://chatgpt.com/codex/tasks/task_e_68d4436984c483339c4b78d43ddef215