### PR TITLE
Fix ChatWorkspace props destructuring for active tab

### DIFF
--- a/src/components/chat/ChatWorkspace.tsx
+++ b/src/components/chat/ChatWorkspace.tsx
@@ -76,6 +76,8 @@ export const ChatWorkspace: React.FC<ChatWorkspaceProps> = ({
   onSettingsChange,
   presenceMap,
   onActorFilterChange,
+  activeTab,
+  onTabChange,
 }) => {
   const { agents, agentMap } = useAgents();
   const {


### PR DESCRIPTION
## Summary
- include the activeTab and onTabChange props in ChatWorkspace's destructuring so the component can use them at runtime

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68d449a4e24883339796ba3dd5b8bf3d