### PR TITLE
Fix RepoWorkflow handler wiring to avoid circular import crash

### DIFF
--- a/src/core/codex/workflowBridge.ts
+++ b/src/core/codex/workflowBridge.ts
@@ -1,0 +1,59 @@
+import type { RepoWorkflowSubmission } from './bridge';
+
+export interface RepoWorkflowQueuePayload {
+  messageId: string;
+  canonicalCode?: string;
+  repositoryPath?: string;
+  branch?: string;
+  riskLevel?: RepoWorkflowSubmission['request']['context']['riskLevel'];
+}
+
+export interface RepoWorkflowSyncOptions {
+  repositoryPath: string;
+  remote?: string | null;
+  branch?: string | null;
+}
+
+type QueueHandler = (payload: RepoWorkflowQueuePayload) => void;
+type SyncHandler = (options: RepoWorkflowSyncOptions) => Promise<string | null>;
+
+let queueHandler: QueueHandler | null = null;
+let syncHandler: SyncHandler | null = null;
+
+export const registerRepoWorkflowHandlers = (handlers: {
+  queueRequest: QueueHandler;
+  syncRepository: SyncHandler;
+}): void => {
+  queueHandler = handlers.queueRequest;
+  syncHandler = handlers.syncRepository;
+};
+
+export const unregisterRepoWorkflowHandlers = (handlers: {
+  queueRequest: QueueHandler;
+  syncRepository: SyncHandler;
+}): void => {
+  if (queueHandler === handlers.queueRequest) {
+    queueHandler = null;
+  }
+  if (syncHandler === handlers.syncRepository) {
+    syncHandler = null;
+  }
+};
+
+export const enqueueRepoWorkflowRequest = (payload: RepoWorkflowQueuePayload): void => {
+  if (!queueHandler) {
+    console.warn('No hay proveedor activo de Repo Studio para procesar la solicitud.');
+    return;
+  }
+  queueHandler(payload);
+};
+
+export const syncRepositoryViaWorkflow = async (
+  options: RepoWorkflowSyncOptions,
+): Promise<string | null> => {
+  if (!syncHandler) {
+    console.warn('No hay proveedor activo de Repo Studio para sincronizar el repositorio.');
+    return null;
+  }
+  return syncHandler(options);
+};

--- a/src/core/messages/MessageContext.tsx
+++ b/src/core/messages/MessageContext.tsx
@@ -42,7 +42,7 @@ import {
   type SharedConversationSnapshot,
 } from '../orchestration';
 import { useProjects } from '../projects/ProjectContext';
-import { enqueueRepoWorkflowRequest, syncRepositoryViaWorkflow } from '../codex';
+import { enqueueRepoWorkflowRequest, syncRepositoryViaWorkflow } from '../codex/workflowBridge';
 import { isTauriEnvironment } from '../storage/userDataPathsClient';
 import { useJarvisCore } from '../jarvis/JarvisCoreContext';
 import type { JarvisActionKind } from '../../services/jarvisCoreClient';

--- a/src/core/messages/__tests__/MessageContext.test.tsx
+++ b/src/core/messages/__tests__/MessageContext.test.tsx
@@ -21,7 +21,7 @@ vi.mock('../../utils/runtimeBridge', () => {
   };
 });
 
-vi.mock('../../codex', () => ({
+vi.mock('../../codex/workflowBridge', () => ({
   enqueueRepoWorkflowRequest: hoistedMocks.enqueue,
   syncRepositoryViaWorkflow: hoistedMocks.sync,
 }));


### PR DESCRIPTION
## Summary
- extract the Repo Studio queue/sync bridge into its own module to remove the MessageContext circular dependency
- update RepoWorkflowProvider to register/unregister the new bridge handlers
- point MessageContext and its tests at the bridge module so shared messaging uses the decoupled hooks

## Testing
- npm run lint
- npm run test -- MessageContext
- npx vite build

------
https://chatgpt.com/codex/tasks/task_e_68d44b8f81a88333acc896e8d5987f53