### PR TITLE
Fix production load path for Electron window

### DIFF
--- a/electron.cjs
+++ b/electron.cjs
@@ -290,9 +290,11 @@ const resolveDevServerUrl = () => {
   return 'http://localhost:5173';
 };
 
-const startUrl = isDev
-  ? resolveDevServerUrl()
-  : `file://${path.join(__dirname, 'dist', 'index.html')}`;
+const distIndexPath = path.join(__dirname, 'dist', 'index.html');
+
+const startTarget = isDev
+  ? { type: 'url', value: resolveDevServerUrl() }
+  : { type: 'file', value: distIndexPath };
 
 let pluginManagerInstance = null;
 let pluginManagerReadyPromise = null;
@@ -666,9 +668,15 @@ function createWindow() {
     },
   });
 
-  console.log('Loading URL:', startUrl);
-
-  mainWindow.loadURL(startUrl);
+  if (startTarget.type === 'url') {
+    console.log('Loading URL:', startTarget.value);
+    mainWindow.loadURL(startTarget.value);
+  } else {
+    console.log('Loading file:', startTarget.value);
+    mainWindow.loadFile(startTarget.value).catch(error => {
+      console.error('❌ Failed to load local file:', startTarget.value, error);
+    });
+  }
 
   mainWindow.once('ready-to-show', () => {
     mainWindow.show();


### PR DESCRIPTION
## Summary
- ensure production builds load the bundled renderer using BrowserWindow.loadFile
- keep dev builds loading the Vite dev server while logging the proper target
- add error logging for failures to load the local HTML entry

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68d4511d8da0833398f11cb64ddcfd23