### PR TITLE
Refine chat input layout and expand sidebar tree

### DIFF
--- a/src/ui/chat.rs
+++ b/src/ui/chat.rs
@@ -7,64 +7,99 @@ pub fn draw_chat_panel(ctx: &egui::Context, state: &mut AppState) {
         ui.separator();
 
         // Display chat messages
-        egui::ScrollArea::vertical().stick_to_bottom(true).show(ui, |ui| {
-            for message in &state.chat_messages {
-                ui.add_space(5.0); // Add some spacing between messages
+        egui::ScrollArea::vertical()
+            .stick_to_bottom(true)
+            .show(ui, |ui| {
+                for message in &state.chat_messages {
+                    ui.add_space(5.0); // Add some spacing between messages
 
-                if message.sender == "User" {
-                    ui.with_layout(egui::Layout::right_to_left(egui::Align::TOP), |ui| {
-                        egui::Frame::none()
-                            .fill(ui.visuals().selection.bg_fill) // Example: use selection color for user messages
-                            .rounding(egui::Rounding::same(5.0))
-                            .inner_margin(egui::Margin::same(8.0))
-                            .show(ui, |ui| {
-                                ui.label(&message.text);
-                            });
-                    });
-                } else {
-                    ui.with_layout(egui::Layout::left_to_right(egui::Align::TOP), |ui| {
-                        egui::Frame::none()
-                            .fill(ui.visuals().widgets.noninteractive.bg_fill) // Example: use noninteractive color for system/model messages
-                            .rounding(egui::Rounding::same(5.0))
-                            .inner_margin(egui::Margin::same(8.0))
-                            .show(ui, |ui| {
-                                ui.strong(format!("{}:", message.sender));
-                                ui.label(&message.text);
-                            });
-                    });
+                    if message.sender == "User" {
+                        ui.with_layout(egui::Layout::right_to_left(egui::Align::TOP), |ui| {
+                            egui::Frame::none()
+                                .fill(ui.visuals().selection.bg_fill)
+                                .rounding(egui::Rounding::same(5.0))
+                                .inner_margin(egui::Margin::same(8.0))
+                                .show(ui, |ui| {
+                                    ui.label(&message.text);
+                                });
+                        });
+                    } else {
+                        ui.with_layout(egui::Layout::left_to_right(egui::Align::TOP), |ui| {
+                            egui::Frame::none()
+                                .fill(ui.visuals().widgets.noninteractive.bg_fill)
+                                .rounding(egui::Rounding::same(5.0))
+                                .inner_margin(egui::Margin::same(8.0))
+                                .show(ui, |ui| {
+                                    ui.strong(format!("{}:", message.sender));
+                                    ui.label(&message.text);
+                                });
+                        });
+                    }
                 }
-            }
-        });
+            });
 
         // Input area at the bottom
         ui.with_layout(egui::Layout::bottom_up(egui::Align::Center), |ui| {
-            egui::Frame::none()
-                .fill(ui.visuals().panel_fill) // Use panel fill for background
-                .stroke(egui::Stroke::new(1.0, ui.visuals().widgets.noninteractive.bg_fill)) // Subtle border
-                .rounding(egui::Rounding::same(10.0)) // Rounded corners
-                .show(ui, |ui| {
-                    ui.horizontal(|ui| {
-                        ui.add(egui::TextEdit::singleline(&mut state.current_chat_input).hint_text("Type your message or command here...").desired_width(f32::INFINITY));
+            ui.add_space(12.0);
 
-                        if ui.button("Send").clicked() {
-                            if !state.current_chat_input.is_empty() {
-                                let input = state.current_chat_input.clone();
-                                state.current_chat_input.clear();
+            ui.vertical_centered(|ui| {
+                let max_width = 720.0;
+                let available_width = ui.available_width().min(max_width);
 
-                                if input.starts_with('/') {
-                                    // It's a command
-                                    state.handle_command(input);
-                                } else {
-                                    // It's a regular message
-                                    state.chat_messages.push(ChatMessage {
-                                        sender: "User".to_string(),
-                                        text: input,
-                                    });
+                ui.scope(|ui| {
+                    ui.set_width(available_width);
+
+                    egui::Frame::none()
+                        .fill(ui.visuals().faint_bg_color)
+                        .stroke(egui::Stroke::new(
+                            1.0,
+                            ui.visuals().widgets.noninteractive.bg_fill,
+                        ))
+                        .rounding(egui::Rounding::same(14.0))
+                        .inner_margin(egui::Margin::symmetric(16.0, 10.0))
+                        .show(ui, |ui| {
+                            let spacing = 10.0;
+                            ui.spacing_mut().item_spacing.x = spacing;
+
+                            let send_button_width = 88.0;
+                            let control_height = 34.0;
+                            let text_width =
+                                (ui.available_width() - send_button_width - spacing).max(200.0);
+
+                            ui.horizontal(|ui| {
+                                let text_edit =
+                                    egui::TextEdit::singleline(&mut state.current_chat_input)
+                                        .hint_text("Type your message or command here...")
+                                        .desired_width(f32::INFINITY)
+                                        .horizontal_align(egui::Align::Center);
+
+                                ui.add_sized([text_width, control_height], text_edit);
+
+                                let send_button = egui::Button::new("Send")
+                                    .rounding(egui::Rounding::same(10.0))
+                                    .min_size(egui::vec2(send_button_width, control_height));
+
+                                if ui.add(send_button).clicked() {
+                                    if !state.current_chat_input.is_empty() {
+                                        let input = state.current_chat_input.clone();
+                                        state.current_chat_input.clear();
+
+                                        if input.starts_with('/') {
+                                            // It's a command
+                                            state.handle_command(input);
+                                        } else {
+                                            // It's a regular message
+                                            state.chat_messages.push(ChatMessage {
+                                                sender: "User".to_string(),
+                                                text: input,
+                                            });
+                                        }
+                                    }
                                 }
-                            }
-                        }
-                    });
+                            });
+                        });
                 });
+            });
         });
     });
 }

--- a/src/ui/sidebar.rs
+++ b/src/ui/sidebar.rs
@@ -11,23 +11,59 @@ pub fn draw_sidebar(ctx: &egui::Context, state: &mut AppState) {
             ui.separator();
 
             egui::ScrollArea::vertical().show(ui, |ui| {
+                ui.label("Live Multimodal");
+                ui.add_space(8.0);
 
-                egui::CollapsingHeader::new("Models")
+                egui::CollapsingHeader::new("Preferences")
                     .default_open(true)
                     .show(ui, |ui| {
-                        ui.label("Claude");
-                        ui.label("OpenAI");
-                        ui.label("Groq");
-                        ui.label("HuggingFace");
-                        ui.label("Local");
-                    });
+                        ui.indent("preferences_system", |ui| {
+                            egui::CollapsingHeader::new("System")
+                                .default_open(true)
+                                .show(ui, |ui| {
+                                    ui.indent("preferences_system_items", |ui| {
+                                        ui.label("GitHub for Projects");
+                                        ui.label("Cache");
+                                        ui.label("System resources");
+                                    });
+                                });
 
-                egui::CollapsingHeader::new("GitHub")
-                    .default_open(true)
-                    .show(ui, |ui| {
-                        ui.label("Repositories");
-                        ui.label("Issues");
-                        ui.label("Pull Requests");
+                            egui::CollapsingHeader::new("Customization")
+                                .default_open(true)
+                                .show(ui, |ui| {
+                                    ui.indent("preferences_customization_items", |ui| {
+                                        ui.label("Custom commands");
+                                        ui.label("Memory");
+                                        ui.label("Profiles");
+                                        ui.label("Projects");
+                                    });
+                                });
+
+                            egui::CollapsingHeader::new("Models")
+                                .default_open(true)
+                                .show(ui, |ui| {
+                                    ui.indent("preferences_models_items", |ui| {
+                                        egui::CollapsingHeader::new("Local (Jarvis)")
+                                            .default_open(true)
+                                            .show(ui, |ui| {
+                                                ui.indent("preferences_models_local", |ui| {
+                                                    ui.label("HuggingFace (explore and install)");
+                                                    ui.label("Settings");
+                                                });
+                                            });
+
+                                        egui::CollapsingHeader::new("Providers")
+                                            .default_open(true)
+                                            .show(ui, |ui| {
+                                                ui.indent("preferences_models_providers", |ui| {
+                                                    ui.label("Anthropic");
+                                                    ui.label("OpenAI");
+                                                    ui.label("Groq");
+                                                });
+                                            });
+                                    });
+                                });
+                        });
                     });
             });
 


### PR DESCRIPTION
## Summary
- restyle the chat composer to mimic a centered, rounded assistant input with constrained width
- expand the left sidebar tree with the new Live Multimodal, Preferences, and nested model/provider sections

## Testing
- `cargo fmt`
- `cargo check`


------
https://chatgpt.com/codex/tasks/task_e_68d46689ab8083338394c3332d58464f