### PR TITLE
Add settings sections and reposition chat input

### DIFF
--- a/src/state.rs
+++ b/src/state.rs
@@ -1,7 +1,97 @@
 use crate::config::AppConfig; // New import
 
+/// Identifica la sección actualmente seleccionada en el árbol de preferencias.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum PreferenceSection {
+    SystemGithub,
+    SystemCache,
+    SystemResources,
+    CustomizationCommands,
+    CustomizationMemory,
+    CustomizationProfiles,
+    CustomizationProjects,
+    ModelsLocalHuggingFace,
+    ModelsLocalSettings,
+    ModelsProviderAnthropic,
+    ModelsProviderOpenAi,
+    ModelsProviderGroq,
+}
+
+impl PreferenceSection {
+    pub fn title(self) -> &'static str {
+        match self {
+            PreferenceSection::SystemGithub => "Preferences › System › GitHub for Projects",
+            PreferenceSection::SystemCache => "Preferences › System › Cache",
+            PreferenceSection::SystemResources => "Preferences › System › System resources",
+            PreferenceSection::CustomizationCommands => {
+                "Preferences › Customization › Custom commands"
+            }
+            PreferenceSection::CustomizationMemory => "Preferences › Customization › Memory",
+            PreferenceSection::CustomizationProfiles => "Preferences › Customization › Profiles",
+            PreferenceSection::CustomizationProjects => "Preferences › Customization › Projects",
+            PreferenceSection::ModelsLocalHuggingFace => {
+                "Preferences › Models › Local (Jarvis) › HuggingFace"
+            }
+            PreferenceSection::ModelsLocalSettings => {
+                "Preferences › Models › Local (Jarvis) › Settings"
+            }
+            PreferenceSection::ModelsProviderAnthropic => {
+                "Preferences › Models › Providers › Anthropic"
+            }
+            PreferenceSection::ModelsProviderOpenAi => "Preferences › Models › Providers › OpenAI",
+            PreferenceSection::ModelsProviderGroq => "Preferences › Models › Providers › Groq",
+        }
+    }
+
+    pub fn description(self) -> &'static str {
+        match self {
+            PreferenceSection::SystemGithub => {
+                "Configure GitHub integration, authentication tokens, and project repositories."
+            }
+            PreferenceSection::SystemCache => {
+                "Adjust cache storage, automatic cleanup schedules, and manual maintenance actions."
+            }
+            PreferenceSection::SystemResources => {
+                "Limit how much memory and disk space the agent may allocate for cached data."
+            }
+            PreferenceSection::CustomizationCommands => {
+                "Manage reusable custom commands that are available inside the chat interface."
+            }
+            PreferenceSection::CustomizationMemory => {
+                "Tune how the assistant stores and retains contextual memories across sessions."
+            }
+            PreferenceSection::CustomizationProfiles => {
+                "Switch between predefined profiles and edit their metadata."
+            }
+            PreferenceSection::CustomizationProjects => {
+                "Organize the active projects that the assistant tracks and syncs."
+            }
+            PreferenceSection::ModelsLocalHuggingFace => {
+                "Search for local models published on HuggingFace and install them into Jarvis."
+            }
+            PreferenceSection::ModelsLocalSettings => {
+                "Configure how the local Jarvis runtime boots and where models are stored."
+            }
+            PreferenceSection::ModelsProviderAnthropic => {
+                "Provide Anthropic credentials and defaults for Claude based workflows."
+            }
+            PreferenceSection::ModelsProviderOpenAi => {
+                "Configure OpenAI access tokens and preferred GPT models."
+            }
+            PreferenceSection::ModelsProviderGroq => {
+                "Enter Groq API keys and select the default Groq-hosted model."
+            }
+        }
+    }
+}
+
+impl Default for PreferenceSection {
+    fn default() -> Self {
+        PreferenceSection::SystemGithub
+    }
+}
+
 /// Contiene el estado global de la aplicación.
-#[derive(Default)]
 pub struct AppState {
     /// Controla la visibilidad de la ventana modal de configuración.
     pub show_settings_modal: bool,
@@ -11,11 +101,131 @@ pub struct AppState {
     pub chat_messages: Vec<ChatMessage>,
     /// Configuración de la aplicación.
     pub config: AppConfig, // New field
-    // Aquí irían otros estados, como:
-    // pub current_model: Option<String>,
-    // pub active_chat: Vec<ChatMessage>,
-    // pub github_repos: Vec<Repo>,
-    // pub api_keys: ApiKeys,
+    /// Sección de preferencias seleccionada en el árbol lateral.
+    pub selected_section: PreferenceSection,
+    /// Token de acceso personal de GitHub.
+    pub github_token: String,
+    /// Repositorios disponibles para sincronizar.
+    pub github_repositories: Vec<String>,
+    /// Índice del repositorio seleccionado.
+    pub selected_github_repo: Option<usize>,
+    /// Mensaje de estado tras intentar conectar con GitHub.
+    pub github_connection_status: Option<String>,
+    /// Ruta base donde se almacena la caché.
+    pub cache_directory: String,
+    /// Límite máximo de caché en GB.
+    pub cache_size_limit_gb: f32,
+    /// Habilita la limpieza automática de caché.
+    pub enable_auto_cleanup: bool,
+    /// Intervalo en horas entre limpiezas automáticas.
+    pub cache_cleanup_interval_hours: u32,
+    /// Registro del último mensaje de limpieza manual.
+    pub last_cache_cleanup: Option<String>,
+    /// Límite de memoria en GB para la caché.
+    pub resource_memory_limit_gb: f32,
+    /// Límite de disco en GB para la caché.
+    pub resource_disk_limit_gb: f32,
+    /// Lista de comandos personalizados disponibles.
+    pub custom_commands: Vec<String>,
+    /// Campo auxiliar para agregar un nuevo comando.
+    pub new_custom_command: String,
+    /// Mensaje de retroalimentación para comandos.
+    pub command_feedback: Option<String>,
+    /// Indica si se almacena memoria de contexto.
+    pub enable_memory_tracking: bool,
+    /// Días que se conserva la memoria contextual.
+    pub memory_retention_days: u32,
+    /// Perfiles configurados.
+    pub profiles: Vec<String>,
+    /// Perfil actualmente seleccionado.
+    pub selected_profile: Option<usize>,
+    /// Proyectos configurados.
+    pub projects: Vec<String>,
+    /// Proyecto actualmente seleccionado.
+    pub selected_project: Option<usize>,
+    /// Consulta actual para buscar modelos en HuggingFace.
+    pub huggingface_search_query: String,
+    /// Resultados disponibles en HuggingFace.
+    pub huggingface_models: Vec<String>,
+    /// Modelo seleccionado dentro de HuggingFace.
+    pub selected_huggingface_model: Option<usize>,
+    /// Mensaje de estado tras intentar instalar un modelo local.
+    pub huggingface_install_status: Option<String>,
+    /// Ruta del modelo local de Jarvis.
+    pub jarvis_model_path: String,
+    /// Determina si Jarvis inicia automáticamente.
+    pub jarvis_auto_start: bool,
+    /// Mensaje de estado sobre la configuración local de Jarvis.
+    pub jarvis_status: Option<String>,
+    /// Modelo por defecto de Anthropic/Claude.
+    pub claude_default_model: String,
+    /// Mensaje de prueba de conexión con Anthropic.
+    pub anthropic_test_status: Option<String>,
+    /// Modelo por defecto de OpenAI.
+    pub openai_default_model: String,
+    /// Mensaje de prueba de conexión con OpenAI.
+    pub openai_test_status: Option<String>,
+    /// Modelo por defecto de Groq.
+    pub groq_default_model: String,
+    /// Mensaje de prueba de conexión con Groq.
+    pub groq_test_status: Option<String>,
+}
+
+impl Default for AppState {
+    fn default() -> Self {
+        Self {
+            show_settings_modal: false,
+            current_chat_input: String::new(),
+            chat_messages: vec![ChatMessage::default()],
+            config: AppConfig::default(),
+            selected_section: PreferenceSection::default(),
+            github_token: String::new(),
+            github_repositories: vec![
+                "agent-platform".to_string(),
+                "knowledge-graph".to_string(),
+                "workspace-sync".to_string(),
+            ],
+            selected_github_repo: None,
+            github_connection_status: None,
+            cache_directory: "/var/tmp/jungle/cache".to_string(),
+            cache_size_limit_gb: 8.0,
+            enable_auto_cleanup: true,
+            cache_cleanup_interval_hours: 24,
+            last_cache_cleanup: None,
+            resource_memory_limit_gb: 32.0,
+            resource_disk_limit_gb: 128.0,
+            custom_commands: vec!["/summarize".to_string(), "/deploy".to_string()],
+            new_custom_command: String::new(),
+            command_feedback: None,
+            enable_memory_tracking: true,
+            memory_retention_days: 30,
+            profiles: vec![
+                "Default".to_string(),
+                "Research".to_string(),
+                "Operations".to_string(),
+            ],
+            selected_profile: Some(0),
+            projects: vec!["Autonomous Agent".to_string(), "RAG Pipeline".to_string()],
+            selected_project: Some(0),
+            huggingface_search_query: String::new(),
+            huggingface_models: vec![
+                "sentence-transformers/all-MiniLM-L6-v2".to_string(),
+                "openai/whisper-small".to_string(),
+                "stabilityai/stable-diffusion-xl".to_string(),
+            ],
+            selected_huggingface_model: None,
+            huggingface_install_status: None,
+            jarvis_model_path: "/models/jarvis/latest.bin".to_string(),
+            jarvis_auto_start: true,
+            jarvis_status: None,
+            claude_default_model: "claude-3-opus".to_string(),
+            anthropic_test_status: None,
+            openai_default_model: "gpt-4.1-mini".to_string(),
+            openai_test_status: None,
+            groq_default_model: "llama3-70b-8192".to_string(),
+            groq_test_status: None,
+        }
+    }
 }
 
 // Define ChatMessage struct
@@ -49,7 +259,8 @@ impl AppState {
             "/models" => {
                 self.chat_messages.push(ChatMessage {
                     sender: "System".to_string(),
-                    text: "Available models: OpenAI, Claude, Groq, HuggingFace, Jarvis (local).".to_string(),
+                    text: "Available models: OpenAI, Claude, Groq, HuggingFace, Jarvis (local)."
+                        .to_string(),
                 });
             }
             "/system" => {

--- a/src/ui/chat.rs
+++ b/src/ui/chat.rs
@@ -1,105 +1,533 @@
-use crate::state::{AppState, ChatMessage};
+use crate::state::{AppState, ChatMessage, PreferenceSection};
 use eframe::egui;
 
 pub fn draw_chat_panel(ctx: &egui::Context, state: &mut AppState) {
     egui::CentralPanel::default().show(ctx, |ui| {
-        ui.heading("Chat Multimodal");
-        ui.separator();
-
-        // Display chat messages
-        egui::ScrollArea::vertical()
-            .stick_to_bottom(true)
-            .show(ui, |ui| {
-                for message in &state.chat_messages {
-                    ui.add_space(5.0); // Add some spacing between messages
-
-                    if message.sender == "User" {
-                        ui.with_layout(egui::Layout::right_to_left(egui::Align::TOP), |ui| {
-                            egui::Frame::none()
-                                .fill(ui.visuals().selection.bg_fill)
-                                .rounding(egui::Rounding::same(5.0))
-                                .inner_margin(egui::Margin::same(8.0))
-                                .show(ui, |ui| {
-                                    ui.label(&message.text);
-                                });
-                        });
-                    } else {
-                        ui.with_layout(egui::Layout::left_to_right(egui::Align::TOP), |ui| {
-                            egui::Frame::none()
-                                .fill(ui.visuals().widgets.noninteractive.bg_fill)
-                                .rounding(egui::Rounding::same(5.0))
-                                .inner_margin(egui::Margin::same(8.0))
-                                .show(ui, |ui| {
-                                    ui.strong(format!("{}:", message.sender));
-                                    ui.label(&message.text);
-                                });
-                        });
-                    }
-                }
+        egui::TopBottomPanel::bottom("chat_input_panel")
+            .resizable(false)
+            .show_inside(ui, |ui| {
+                draw_chat_input(ui, state);
             });
 
-        // Input area at the bottom
-        ui.with_layout(egui::Layout::bottom_up(egui::Align::Center), |ui| {
-            ui.add_space(12.0);
+        egui::CentralPanel::default().show_inside(ui, |ui| {
+            ui.heading("Chat Multimodal");
+            ui.separator();
 
-            ui.vertical_centered(|ui| {
-                let max_width = 720.0;
-                let available_width = ui.available_width().min(max_width);
+            let max_height = ui.available_height() * 0.55;
+            egui::ScrollArea::vertical()
+                .stick_to_bottom(true)
+                .max_height(max_height)
+                .show(ui, |ui| {
+                    for message in &state.chat_messages {
+                        ui.add_space(5.0); // Add some spacing between messages
 
-                ui.scope(|ui| {
-                    ui.set_width(available_width);
-
-                    egui::Frame::none()
-                        .fill(ui.visuals().faint_bg_color)
-                        .stroke(egui::Stroke::new(
-                            1.0,
-                            ui.visuals().widgets.noninteractive.bg_fill,
-                        ))
-                        .rounding(egui::Rounding::same(14.0))
-                        .inner_margin(egui::Margin::symmetric(16.0, 10.0))
-                        .show(ui, |ui| {
-                            let spacing = 10.0;
-                            ui.spacing_mut().item_spacing.x = spacing;
-
-                            let send_button_width = 88.0;
-                            let control_height = 34.0;
-                            let text_width =
-                                (ui.available_width() - send_button_width - spacing).max(200.0);
-
-                            ui.horizontal(|ui| {
-                                let text_edit =
-                                    egui::TextEdit::singleline(&mut state.current_chat_input)
-                                        .hint_text("Type your message or command here...")
-                                        .desired_width(f32::INFINITY)
-                                        .horizontal_align(egui::Align::Center);
-
-                                ui.add_sized([text_width, control_height], text_edit);
-
-                                let send_button = egui::Button::new("Send")
-                                    .rounding(egui::Rounding::same(10.0))
-                                    .min_size(egui::vec2(send_button_width, control_height));
-
-                                if ui.add(send_button).clicked() {
-                                    if !state.current_chat_input.is_empty() {
-                                        let input = state.current_chat_input.clone();
-                                        state.current_chat_input.clear();
-
-                                        if input.starts_with('/') {
-                                            // It's a command
-                                            state.handle_command(input);
-                                        } else {
-                                            // It's a regular message
-                                            state.chat_messages.push(ChatMessage {
-                                                sender: "User".to_string(),
-                                                text: input,
-                                            });
-                                        }
-                                    }
-                                }
+                        if message.sender == "User" {
+                            ui.with_layout(egui::Layout::right_to_left(egui::Align::TOP), |ui| {
+                                egui::Frame::none()
+                                    .fill(ui.visuals().selection.bg_fill)
+                                    .rounding(egui::Rounding::same(5.0))
+                                    .inner_margin(egui::Margin::same(8.0))
+                                    .show(ui, |ui| {
+                                        ui.label(&message.text);
+                                    });
                             });
-                        });
+                        } else {
+                            ui.with_layout(egui::Layout::left_to_right(egui::Align::TOP), |ui| {
+                                egui::Frame::none()
+                                    .fill(ui.visuals().widgets.noninteractive.bg_fill)
+                                    .rounding(egui::Rounding::same(5.0))
+                                    .inner_margin(egui::Margin::same(8.0))
+                                    .show(ui, |ui| {
+                                        ui.strong(format!("{}:", message.sender));
+                                        ui.label(&message.text);
+                                    });
+                            });
+                        }
+                    }
                 });
-            });
+
+            ui.add_space(12.0);
+            draw_selected_section(ui, state);
         });
     });
+}
+
+fn draw_chat_input(ui: &mut egui::Ui, state: &mut AppState) {
+    ui.add_space(12.0);
+
+    ui.vertical_centered(|ui| {
+        let max_width = 720.0;
+        let available_width = ui.available_width().min(max_width);
+
+        ui.scope(|ui| {
+            ui.set_width(available_width);
+
+            egui::Frame::none()
+                .fill(ui.visuals().faint_bg_color)
+                .stroke(egui::Stroke::new(
+                    1.0,
+                    ui.visuals().widgets.noninteractive.bg_fill,
+                ))
+                .rounding(egui::Rounding::same(14.0))
+                .inner_margin(egui::Margin::symmetric(16.0, 10.0))
+                .show(ui, |ui| {
+                    let spacing = 10.0;
+                    ui.spacing_mut().item_spacing.x = spacing;
+
+                    let send_button_width = 88.0;
+                    let control_height = 34.0;
+                    let text_width =
+                        (ui.available_width() - send_button_width - spacing).max(200.0);
+
+                    let mut should_send = false;
+
+                    ui.horizontal(|ui| {
+                        let text_edit = egui::TextEdit::singleline(&mut state.current_chat_input)
+                            .hint_text("Type your message or command here...")
+                            .desired_width(f32::INFINITY)
+                            .horizontal_align(egui::Align::Center);
+
+                        let response = ui.add_sized([text_width, control_height], text_edit);
+                        if response.lost_focus()
+                            && ui.input(|input| input.key_pressed(egui::Key::Enter))
+                        {
+                            should_send = true;
+                            ui.memory_mut(|mem| mem.request_focus(response.id));
+                        }
+
+                        let send_button = egui::Button::new("Send")
+                            .rounding(egui::Rounding::same(10.0))
+                            .min_size(egui::vec2(send_button_width, control_height));
+
+                        if ui.add(send_button).clicked() {
+                            should_send = true;
+                        }
+                    });
+
+                    if should_send {
+                        submit_chat_message(state);
+                    }
+                });
+        });
+    });
+}
+
+fn submit_chat_message(state: &mut AppState) {
+    if state.current_chat_input.trim().is_empty() {
+        state.current_chat_input.clear();
+        return;
+    }
+
+    let input = state.current_chat_input.trim().to_string();
+    state.current_chat_input.clear();
+
+    if input.starts_with('/') {
+        state.handle_command(input);
+    } else {
+        state.chat_messages.push(ChatMessage {
+            sender: "User".to_string(),
+            text: input,
+        });
+    }
+}
+
+fn draw_selected_section(ui: &mut egui::Ui, state: &mut AppState) {
+    ui.heading(state.selected_section.title());
+    ui.label(state.selected_section.description());
+    ui.separator();
+
+    match state.selected_section {
+        PreferenceSection::SystemGithub => draw_system_github(ui, state),
+        PreferenceSection::SystemCache => draw_system_cache(ui, state),
+        PreferenceSection::SystemResources => draw_system_resources(ui, state),
+        PreferenceSection::CustomizationCommands => draw_custom_commands(ui, state),
+        PreferenceSection::CustomizationMemory => draw_customization_memory(ui, state),
+        PreferenceSection::CustomizationProfiles => draw_customization_profiles(ui, state),
+        PreferenceSection::CustomizationProjects => draw_customization_projects(ui, state),
+        PreferenceSection::ModelsLocalHuggingFace => draw_local_huggingface(ui, state),
+        PreferenceSection::ModelsLocalSettings => draw_local_settings(ui, state),
+        PreferenceSection::ModelsProviderAnthropic => draw_provider_anthropic(ui, state),
+        PreferenceSection::ModelsProviderOpenAi => draw_provider_openai(ui, state),
+        PreferenceSection::ModelsProviderGroq => draw_provider_groq(ui, state),
+    }
+}
+
+fn draw_system_github(ui: &mut egui::Ui, state: &mut AppState) {
+    ui.label("Personal access token");
+    ui.text_edit_singleline(&mut state.github_token);
+
+    if ui.button("Save token").clicked() {
+        state.github_connection_status = if state.github_token.trim().is_empty() {
+            Some("Please enter a valid GitHub token before saving.".to_string())
+        } else {
+            Some("GitHub token stored locally for future sessions.".to_string())
+        };
+    }
+
+    egui::ComboBox::from_label("Select repository")
+        .selected_text(
+            state
+                .selected_github_repo
+                .and_then(|idx| state.github_repositories.get(idx))
+                .cloned()
+                .unwrap_or_else(|| "Choose a repository".to_string()),
+        )
+        .show_ui(ui, |ui| {
+            for (idx, repo) in state.github_repositories.iter().enumerate() {
+                ui.selectable_value(&mut state.selected_github_repo, Some(idx), repo);
+            }
+        });
+
+    if ui.button("Sync repository").clicked() {
+        let message = match (
+            state.github_token.trim().is_empty(),
+            state.selected_github_repo,
+        ) {
+            (true, _) => "Cannot sync without a GitHub token.".to_string(),
+            (_, None) => "Please select a repository to sync.".to_string(),
+            (_, Some(idx)) => {
+                let repo = state.github_repositories[idx].clone();
+                format!("Repository '{}' scheduled for synchronization.", repo)
+            }
+        };
+        state.github_connection_status = Some(message);
+    }
+
+    if let Some(status) = &state.github_connection_status {
+        ui.add_space(8.0);
+        ui.colored_label(ui.visuals().weak_text_color(), status);
+    }
+}
+
+fn draw_system_cache(ui: &mut egui::Ui, state: &mut AppState) {
+    ui.horizontal(|ui| {
+        ui.label("Cache directory");
+        ui.text_edit_singleline(&mut state.cache_directory);
+    });
+
+    ui.add(
+        egui::Slider::new(&mut state.cache_size_limit_gb, 1.0..=256.0)
+            .text("Cache size limit (GB)"),
+    );
+
+    ui.checkbox(&mut state.enable_auto_cleanup, "Enable automatic cleanup");
+
+    ui.add(
+        egui::Slider::new(&mut state.cache_cleanup_interval_hours, 1..=168)
+            .text("Cleanup interval (hours)"),
+    );
+
+    if ui.button("Run cleanup now").clicked() {
+        state.last_cache_cleanup = Some(format!(
+            "Manual cleanup triggered. Next automatic run in {} hours.",
+            state.cache_cleanup_interval_hours
+        ));
+    }
+
+    if let Some(status) = &state.last_cache_cleanup {
+        ui.add_space(8.0);
+        ui.colored_label(ui.visuals().weak_text_color(), status);
+    }
+}
+
+fn draw_system_resources(ui: &mut egui::Ui, state: &mut AppState) {
+    ui.label("Memory limit for cache");
+    ui.add(egui::Slider::new(&mut state.resource_memory_limit_gb, 1.0..=512.0).suffix(" GB"));
+
+    ui.label("Disk limit for cache");
+    ui.add(egui::Slider::new(&mut state.resource_disk_limit_gb, 8.0..=4096.0).suffix(" GB"));
+
+    ui.colored_label(
+        ui.visuals().weak_text_color(),
+        format!(
+            "Current limits: {:.1} GB memory · {:.1} GB disk",
+            state.resource_memory_limit_gb, state.resource_disk_limit_gb
+        ),
+    );
+}
+
+fn draw_custom_commands(ui: &mut egui::Ui, state: &mut AppState) {
+    ui.label("Available commands");
+
+    let mut remove_index = None;
+    for (idx, command) in state.custom_commands.iter().enumerate() {
+        ui.horizontal(|ui| {
+            ui.label(command);
+            if ui.button("Remove").clicked() {
+                remove_index = Some(idx);
+            }
+        });
+    }
+
+    if let Some(idx) = remove_index {
+        if let Some(command) = state.custom_commands.get(idx).cloned() {
+            state.custom_commands.remove(idx);
+            state.command_feedback = Some(format!("Removed custom command '{}'.", command));
+        }
+    }
+
+    ui.add_space(8.0);
+    ui.horizontal(|ui| {
+        ui.add(
+            egui::TextEdit::singleline(&mut state.new_custom_command)
+                .hint_text("Add new command (e.g. /deploy-staging)"),
+        );
+        if ui.button("Add").clicked() {
+            let trimmed = state.new_custom_command.trim();
+            if trimmed.is_empty() {
+                state.command_feedback = Some("Command cannot be empty.".to_string());
+            } else if state.custom_commands.iter().any(|cmd| cmd == trimmed) {
+                state.command_feedback = Some(format!("Command '{}' already exists.", trimmed));
+            } else {
+                state.custom_commands.push(trimmed.to_string());
+                state.command_feedback = Some(format!("Added custom command '{}'.", trimmed));
+                state.new_custom_command.clear();
+            }
+        }
+    });
+
+    if let Some(feedback) = &state.command_feedback {
+        ui.add_space(6.0);
+        ui.colored_label(ui.visuals().weak_text_color(), feedback);
+    }
+}
+
+fn draw_customization_memory(ui: &mut egui::Ui, state: &mut AppState) {
+    ui.checkbox(
+        &mut state.enable_memory_tracking,
+        "Enable contextual memory",
+    );
+
+    ui.add(egui::Slider::new(&mut state.memory_retention_days, 1..=365).text("Retention (days)"));
+
+    ui.colored_label(
+        ui.visuals().weak_text_color(),
+        format!(
+            "Memories older than {} days will be archived.",
+            state.memory_retention_days
+        ),
+    );
+}
+
+fn draw_customization_profiles(ui: &mut egui::Ui, state: &mut AppState) {
+    egui::ComboBox::from_label("Active profile")
+        .selected_text(
+            state
+                .selected_profile
+                .and_then(|idx| state.profiles.get(idx))
+                .cloned()
+                .unwrap_or_else(|| "Choose a profile".to_string()),
+        )
+        .show_ui(ui, |ui| {
+            for (idx, profile) in state.profiles.iter().enumerate() {
+                ui.selectable_value(&mut state.selected_profile, Some(idx), profile);
+            }
+        });
+
+    ui.add_space(6.0);
+    ui.horizontal(|ui| {
+        if ui.button("Duplicate profile").clicked() {
+            if let Some(idx) = state.selected_profile {
+                let new_profile = format!("{} (copy)", state.profiles[idx]);
+                state.profiles.push(new_profile);
+            }
+        }
+        if ui.button("Delete profile").clicked() {
+            if let Some(idx) = state.selected_profile {
+                if state.profiles.len() > 1 {
+                    state.profiles.remove(idx);
+                    if state.profiles.is_empty() {
+                        state.selected_profile = None;
+                    } else if idx >= state.profiles.len() {
+                        state.selected_profile = Some(state.profiles.len() - 1);
+                    }
+                }
+            }
+        }
+    });
+
+    ui.colored_label(
+        ui.visuals().weak_text_color(),
+        "Profiles let you quickly change between workspace presets.",
+    );
+}
+
+fn draw_customization_projects(ui: &mut egui::Ui, state: &mut AppState) {
+    egui::ComboBox::from_label("Active project")
+        .selected_text(
+            state
+                .selected_project
+                .and_then(|idx| state.projects.get(idx))
+                .cloned()
+                .unwrap_or_else(|| "Choose a project".to_string()),
+        )
+        .show_ui(ui, |ui| {
+            for (idx, project) in state.projects.iter().enumerate() {
+                ui.selectable_value(&mut state.selected_project, Some(idx), project);
+            }
+        });
+
+    ui.add_space(6.0);
+    if ui.button("Create placeholder project").clicked() {
+        let new_project = format!("New Project {}", state.projects.len() + 1);
+        state.projects.push(new_project);
+    }
+
+    ui.colored_label(
+        ui.visuals().weak_text_color(),
+        "Projects determine what repositories and documents are prioritised.",
+    );
+}
+
+fn draw_local_huggingface(ui: &mut egui::Ui, state: &mut AppState) {
+    ui.horizontal(|ui| {
+        ui.add(
+            egui::TextEdit::singleline(&mut state.huggingface_search_query)
+                .hint_text("Search models, e.g. whisper"),
+        );
+        if ui.button("Search").clicked() {
+            // Placeholder search that filters the static list.
+            let query = state.huggingface_search_query.to_lowercase();
+            if query.is_empty() {
+                state.huggingface_models = vec![
+                    "sentence-transformers/all-MiniLM-L6-v2".to_string(),
+                    "openai/whisper-small".to_string(),
+                    "stabilityai/stable-diffusion-xl".to_string(),
+                ];
+            } else {
+                state
+                    .huggingface_models
+                    .retain(|model| model.to_lowercase().contains(&query));
+            }
+        }
+    });
+
+    egui::ComboBox::from_label("Available models")
+        .selected_text(
+            state
+                .selected_huggingface_model
+                .and_then(|idx| state.huggingface_models.get(idx))
+                .cloned()
+                .unwrap_or_else(|| "Select a model".to_string()),
+        )
+        .show_ui(ui, |ui| {
+            for (idx, model) in state.huggingface_models.iter().enumerate() {
+                ui.selectable_value(&mut state.selected_huggingface_model, Some(idx), model);
+            }
+        });
+
+    if ui.button("Install model").clicked() {
+        let status = state
+            .selected_huggingface_model
+            .and_then(|idx| state.huggingface_models.get(idx))
+            .map(|model| format!("Model '{}' added to the local Jarvis registry.", model))
+            .unwrap_or_else(|| "Select a model to install.".to_string());
+        state.huggingface_install_status = Some(status);
+    }
+
+    if let Some(status) = &state.huggingface_install_status {
+        ui.add_space(6.0);
+        ui.colored_label(ui.visuals().weak_text_color(), status);
+    }
+}
+
+fn draw_local_settings(ui: &mut egui::Ui, state: &mut AppState) {
+    ui.label("Model path");
+    ui.text_edit_singleline(&mut state.jarvis_model_path);
+    ui.checkbox(&mut state.jarvis_auto_start, "Start Jarvis automatically");
+
+    if ui.button("Apply settings").clicked() {
+        state.jarvis_status = Some(format!(
+            "Jarvis will {} at startup with model at {}.",
+            if state.jarvis_auto_start {
+                "start"
+            } else {
+                "remain stopped"
+            },
+            state.jarvis_model_path
+        ));
+    }
+
+    if let Some(status) = &state.jarvis_status {
+        ui.add_space(6.0);
+        ui.colored_label(ui.visuals().weak_text_color(), status);
+    }
+}
+
+fn draw_provider_anthropic(ui: &mut egui::Ui, state: &mut AppState) {
+    let key = state.config.claude_api_key.get_or_insert_with(String::new);
+
+    ui.label("Anthropic API key");
+    ui.text_edit_singleline(key);
+
+    ui.label("Default Claude model");
+    ui.text_edit_singleline(&mut state.claude_default_model);
+
+    if ui.button("Test connection").clicked() {
+        if key.trim().is_empty() {
+            state.anthropic_test_status = Some("Enter an API key before testing.".to_string());
+        } else {
+            state.anthropic_test_status = Some(format!(
+                "Successfully validated token against model {} (simulated).",
+                state.claude_default_model
+            ));
+        }
+    }
+
+    if let Some(status) = &state.anthropic_test_status {
+        ui.add_space(6.0);
+        ui.colored_label(ui.visuals().weak_text_color(), status);
+    }
+}
+
+fn draw_provider_openai(ui: &mut egui::Ui, state: &mut AppState) {
+    let key = state.config.openai_api_key.get_or_insert_with(String::new);
+
+    ui.label("OpenAI API key");
+    ui.text_edit_singleline(key);
+
+    ui.label("Default OpenAI model");
+    ui.text_edit_singleline(&mut state.openai_default_model);
+
+    if ui.button("Test connection").clicked() {
+        if key.trim().is_empty() {
+            state.openai_test_status = Some("Enter an API key before testing.".to_string());
+        } else {
+            state.openai_test_status = Some(format!(
+                "Test request accepted for model {} (simulated).",
+                state.openai_default_model
+            ));
+        }
+    }
+
+    if let Some(status) = &state.openai_test_status {
+        ui.add_space(6.0);
+        ui.colored_label(ui.visuals().weak_text_color(), status);
+    }
+}
+
+fn draw_provider_groq(ui: &mut egui::Ui, state: &mut AppState) {
+    let key = state.config.groq_api_key.get_or_insert_with(String::new);
+
+    ui.label("Groq API key");
+    ui.text_edit_singleline(key);
+
+    ui.label("Default Groq model");
+    ui.text_edit_singleline(&mut state.groq_default_model);
+
+    if ui.button("Test connection").clicked() {
+        if key.trim().is_empty() {
+            state.groq_test_status = Some("Enter an API key before testing.".to_string());
+        } else {
+            state.groq_test_status = Some(format!(
+                "Latency check successful for model {} (simulated).",
+                state.groq_default_model
+            ));
+        }
+    }
+
+    if let Some(status) = &state.groq_test_status {
+        ui.add_space(6.0);
+        ui.colored_label(ui.visuals().weak_text_color(), status);
+    }
 }

--- a/src/ui/mod.rs
+++ b/src/ui/mod.rs
@@ -1,5 +1,5 @@
-use eframe::egui;
 use crate::state::AppState;
+use eframe::egui;
 
 pub mod chat;
 pub mod modals;

--- a/src/ui/sidebar.rs
+++ b/src/ui/sidebar.rs
@@ -1,4 +1,4 @@
-use crate::state::AppState;
+use crate::state::{AppState, PreferenceSection};
 use eframe::egui;
 
 pub fn draw_sidebar(ctx: &egui::Context, state: &mut AppState) {
@@ -22,9 +22,21 @@ pub fn draw_sidebar(ctx: &egui::Context, state: &mut AppState) {
                                 .default_open(true)
                                 .show(ui, |ui| {
                                     ui.indent("preferences_system_items", |ui| {
-                                        ui.label("GitHub for Projects");
-                                        ui.label("Cache");
-                                        ui.label("System resources");
+                                        ui.selectable_value(
+                                            &mut state.selected_section,
+                                            PreferenceSection::SystemGithub,
+                                            "GitHub for Projects",
+                                        );
+                                        ui.selectable_value(
+                                            &mut state.selected_section,
+                                            PreferenceSection::SystemCache,
+                                            "Cache",
+                                        );
+                                        ui.selectable_value(
+                                            &mut state.selected_section,
+                                            PreferenceSection::SystemResources,
+                                            "System resources",
+                                        );
                                     });
                                 });
 
@@ -32,10 +44,26 @@ pub fn draw_sidebar(ctx: &egui::Context, state: &mut AppState) {
                                 .default_open(true)
                                 .show(ui, |ui| {
                                     ui.indent("preferences_customization_items", |ui| {
-                                        ui.label("Custom commands");
-                                        ui.label("Memory");
-                                        ui.label("Profiles");
-                                        ui.label("Projects");
+                                        ui.selectable_value(
+                                            &mut state.selected_section,
+                                            PreferenceSection::CustomizationCommands,
+                                            "Custom commands",
+                                        );
+                                        ui.selectable_value(
+                                            &mut state.selected_section,
+                                            PreferenceSection::CustomizationMemory,
+                                            "Memory",
+                                        );
+                                        ui.selectable_value(
+                                            &mut state.selected_section,
+                                            PreferenceSection::CustomizationProfiles,
+                                            "Profiles",
+                                        );
+                                        ui.selectable_value(
+                                            &mut state.selected_section,
+                                            PreferenceSection::CustomizationProjects,
+                                            "Projects",
+                                        );
                                     });
                                 });
 
@@ -47,8 +75,16 @@ pub fn draw_sidebar(ctx: &egui::Context, state: &mut AppState) {
                                             .default_open(true)
                                             .show(ui, |ui| {
                                                 ui.indent("preferences_models_local", |ui| {
-                                                    ui.label("HuggingFace (explore and install)");
-                                                    ui.label("Settings");
+                                                    ui.selectable_value(
+                                                        &mut state.selected_section,
+                                                        PreferenceSection::ModelsLocalHuggingFace,
+                                                        "HuggingFace (explore and install)",
+                                                    );
+                                                    ui.selectable_value(
+                                                        &mut state.selected_section,
+                                                        PreferenceSection::ModelsLocalSettings,
+                                                        "Settings",
+                                                    );
                                                 });
                                             });
 
@@ -56,9 +92,21 @@ pub fn draw_sidebar(ctx: &egui::Context, state: &mut AppState) {
                                             .default_open(true)
                                             .show(ui, |ui| {
                                                 ui.indent("preferences_models_providers", |ui| {
-                                                    ui.label("Anthropic");
-                                                    ui.label("OpenAI");
-                                                    ui.label("Groq");
+                                                    ui.selectable_value(
+                                                        &mut state.selected_section,
+                                                        PreferenceSection::ModelsProviderAnthropic,
+                                                        "Anthropic",
+                                                    );
+                                                    ui.selectable_value(
+                                                        &mut state.selected_section,
+                                                        PreferenceSection::ModelsProviderOpenAi,
+                                                        "OpenAI",
+                                                    );
+                                                    ui.selectable_value(
+                                                        &mut state.selected_section,
+                                                        PreferenceSection::ModelsProviderGroq,
+                                                        "Groq",
+                                                    );
                                                 });
                                             });
                                     });
@@ -76,7 +124,7 @@ pub fn draw_sidebar(ctx: &egui::Context, state: &mut AppState) {
         });
 }
 
-pub fn draw_right_sidebar(ctx: &egui::Context, _state: &mut AppState) {
+pub fn draw_right_sidebar(ctx: &egui::Context, state: &mut AppState) {
     egui::SidePanel::right("right_sidebar")
         .resizable(true)
         .default_width(200.0)
@@ -85,14 +133,30 @@ pub fn draw_right_sidebar(ctx: &egui::Context, _state: &mut AppState) {
             ui.heading("Providers & Local Model");
             ui.separator();
             ui.label("Loaded Providers:");
-            // TODO: Display loaded remote models here
-            ui.label("OpenAI");
-            ui.label("Claude");
-            ui.label("Groq");
-            ui.label("HuggingFace");
+            ui.label(format!("OpenAI · model {}", state.openai_default_model));
+            ui.label(format!("Claude · model {}", state.claude_default_model));
+            ui.label(format!("Groq · model {}", state.groq_default_model));
+
+            if let Some(status) = &state.openai_test_status {
+                ui.colored_label(ui.visuals().weak_text_color(), status);
+            }
+            if let Some(status) = &state.anthropic_test_status {
+                ui.colored_label(ui.visuals().weak_text_color(), status);
+            }
+            if let Some(status) = &state.groq_test_status {
+                ui.colored_label(ui.visuals().weak_text_color(), status);
+            }
+
             ui.separator();
             ui.label("Local Model (Jarvis):");
-            // TODO: Display local Jarvis model status here
-            ui.label("Status: Loaded");
+            ui.label(format!("Path: {}", state.jarvis_model_path));
+            ui.label(if state.jarvis_auto_start {
+                "Auto start: enabled"
+            } else {
+                "Auto start: disabled"
+            });
+            if let Some(status) = &state.jarvis_status {
+                ui.colored_label(ui.visuals().weak_text_color(), status);
+            }
         });
 }


### PR DESCRIPTION
## Summary
- add a `PreferenceSection` enum and extend `AppState` with the fields needed to drive the settings sections in the UI
- refactor the central chat panel so the input frame stays pinned at the bottom while the main area shows the configuration form for the selected tree item
- update the sidebars to hook into the new state, letting every preference entry surface an interactive configuration view and exposing provider/Jarvis status info

## Testing
- cargo fmt
- cargo check

------
https://chatgpt.com/codex/tasks/task_e_68d46a305bcc8333a23035229e6aab19