### PR TITLE
Refactor views and enrich command engine

### DIFF
--- a/src/state.rs
+++ b/src/state.rs
@@ -1,5 +1,6 @@
 use crate::config::AppConfig; // New import
 use chrono::Local;
+use std::collections::{BTreeMap, BTreeSet};
 
 /// Identifica la sección actualmente seleccionada en el árbol de preferencias.
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
@@ -95,7 +96,7 @@ impl Default for PreferenceSection {
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub enum MainView {
     ChatMultimodal,
-    LiveMultimodal,
+    Preferences,
 }
 
 impl Default for MainView {
@@ -237,6 +238,8 @@ pub struct AppState {
     pub new_custom_command_action: CustomCommandAction,
     /// Mensaje de retroalimentación para comandos.
     pub command_feedback: Option<String>,
+    /// Controla la visibilidad de la documentación de funciones disponibles.
+    pub show_functions_modal: bool,
     /// Indica si se almacena memoria de contexto.
     pub enable_memory_tracking: bool,
     /// Días que se conserva la memoria contextual.
@@ -275,8 +278,6 @@ pub struct AppState {
     pub groq_default_model: String,
     /// Mensaje de prueba de conexión con Groq.
     pub groq_test_status: Option<String>,
-    /// Eventos recientes del panel live multimodal.
-    pub live_events: Vec<String>,
 }
 
 impl Default for AppState {
@@ -317,6 +318,7 @@ impl Default for AppState {
             new_custom_command: String::new(),
             new_custom_command_action: CustomCommandAction::ShowCurrentTime,
             command_feedback: None,
+            show_functions_modal: false,
             enable_memory_tracking: true,
             memory_retention_days: 30,
             profiles: vec![
@@ -344,11 +346,6 @@ impl Default for AppState {
             openai_test_status: None,
             groq_default_model: "llama3-70b-8192".to_string(),
             groq_test_status: None,
-            live_events: vec![
-                "Agent boot sequence completed.".to_string(),
-                "Connected to OpenAI, Anthropic and Groq providers.".to_string(),
-                "Jarvis local runtime idle. Awaiting first job.".to_string(),
-            ],
         }
     }
 }
@@ -368,6 +365,162 @@ impl Default for ChatMessage {
     }
 }
 
+pub const MAX_COMMAND_DEPTH: usize = 5;
+
+#[derive(Clone, Debug, Default)]
+pub struct CommandInvocation {
+    pub raw: String,
+    pub name: String,
+    pub args: BTreeMap<String, String>,
+    pub flags: BTreeSet<String>,
+    pub positional: Vec<String>,
+}
+
+impl CommandInvocation {
+    pub fn parse(input: &str) -> Self {
+        let mut invocation = CommandInvocation {
+            raw: input.trim().to_string(),
+            ..Default::default()
+        };
+
+        let mut tokens = input.split_whitespace();
+        if let Some(first) = tokens.next() {
+            invocation.name = first.to_string();
+        } else {
+            return invocation;
+        }
+
+        for token in tokens {
+            if token.starts_with("--") {
+                let stripped = &token[2..];
+                if let Some((key, value)) = stripped.split_once('=') {
+                    invocation.args.insert(key.to_string(), value.to_string());
+                } else {
+                    invocation.flags.insert(stripped.to_string());
+                }
+            } else if let Some((key, value)) = token.split_once('=') {
+                invocation.args.insert(key.to_string(), value.to_string());
+            } else {
+                invocation.positional.push(token.to_string());
+            }
+        }
+
+        invocation
+    }
+
+    pub fn arg(&self, key: &str) -> Option<&str> {
+        self.args.get(key).map(|s| s.as_str())
+    }
+
+    pub fn flag(&self, key: &str) -> bool {
+        self.flags.contains(key)
+    }
+}
+
+pub struct CommandOutcome {
+    pub messages: Vec<String>,
+}
+
+impl CommandOutcome {
+    pub fn single(message: String) -> Self {
+        CommandOutcome {
+            messages: vec![message],
+        }
+    }
+}
+
+pub struct CommandDocumentation {
+    pub signature: &'static str,
+    pub summary: &'static str,
+    pub parameters: &'static [&'static str],
+    pub examples: &'static [&'static str],
+}
+
+impl CustomCommandAction {
+    pub fn documentation(self) -> CommandDocumentation {
+        match self {
+            CustomCommandAction::ShowCurrentTime => CommandDocumentation {
+                signature: "showCurrentTime(format=human)",
+                summary: "Muestra la hora actual con distintos formatos de salida.",
+                parameters: &["format → human | 24 | iso"],
+                examples: &["/time", "/time --format=24", "/time format=iso"],
+            },
+            CustomCommandAction::ShowSystemStatus => CommandDocumentation {
+                signature: "showSystemStatus(detail=summary)",
+                summary: "Resume el estado del sistema y permite profundizar en recursos concretos.",
+                parameters: &[
+                    "detail → summary | memory | disk | cache",
+                    "verbose → flag que incluye notas adicionales",
+                ],
+                examples: &["/status", "/status --detail=memory --verbose"],
+            },
+            CustomCommandAction::ShowUsageStatistics => CommandDocumentation {
+                signature: "showUsageStatistics(window=session)",
+                summary: "Entrega estadísticas de uso y métricas de comandos.",
+                parameters: &[
+                    "window → session | day | week",
+                    "include → commands | messages (separar con comas)",
+                ],
+                examples: &["/stats", "/stats include=commands,messages"],
+            },
+            CustomCommandAction::ListActiveProjects => CommandDocumentation {
+                signature: "listActiveProjects(limit=all)",
+                summary: "Lista los proyectos activos y permite limitar la salida.",
+                parameters: &["limit → número máximo de proyectos"],
+                examples: &["/projects", "/projects --limit=1"],
+            },
+            CustomCommandAction::ListConfiguredProfiles => CommandDocumentation {
+                signature: "listConfiguredProfiles(sort=asc)",
+                summary: "Muestra los perfiles configurados con orden opcional.",
+                parameters: &["sort → asc | desc"],
+                examples: &["/profiles", "/profiles --sort=desc"],
+            },
+            CustomCommandAction::ShowCacheConfiguration => CommandDocumentation {
+                signature: "showCacheConfiguration(include=limits)",
+                summary: "Describe la configuración actual de la caché del agente.",
+                parameters: &["include → limits | schedule | path (separar con comas)"],
+                examples: &["/cache", "/cache --include=limits,schedule"],
+            },
+            CustomCommandAction::ListAvailableModels => CommandDocumentation {
+                signature: "listAvailableModels(provider=all)",
+                summary: "Lista los modelos disponibles filtrando por proveedor si se desea.",
+                parameters: &["provider → openai | anthropic | groq | jarvis | huggingface"],
+                examples: &["/models", "/models provider=openai"],
+            },
+            CustomCommandAction::ShowGithubSummary => CommandDocumentation {
+                signature: "showGithubSummary(include=repos)",
+                summary: "Entrega un resumen de la conexión con GitHub y opcionalmente los repositorios.",
+                parameters: &["include → repos (muestra la lista completa)"],
+                examples: &["/github", "/github --include=repos"],
+            },
+            CustomCommandAction::ShowMemorySettings => CommandDocumentation {
+                signature: "showMemorySettings(detail=summary)",
+                summary: "Explica la configuración de memoria contextual.",
+                parameters: &["detail → summary | retention"],
+                examples: &["/memory", "/memory detail=retention"],
+            },
+            CustomCommandAction::ShowActiveProviders => CommandDocumentation {
+                signature: "showActiveProviders(include=models)",
+                summary: "Lista los proveedores activos con información opcional de modelos.",
+                parameters: &["include → models | status"],
+                examples: &["/providers", "/providers --include=models"],
+            },
+            CustomCommandAction::ShowJarvisStatus => CommandDocumentation {
+                signature: "showJarvisStatus(detail=summary)",
+                summary: "Describe el estado del runtime local Jarvis con posibilidad de ver rutas y logs.",
+                parameters: &["detail → summary | path | logs"],
+                examples: &["/jarvis", "/jarvis detail=path"],
+            },
+            CustomCommandAction::ShowCommandHelp => CommandDocumentation {
+                signature: "showCommandHelp(mode=all)",
+                summary: "Lista todos los comandos disponibles y su propósito.",
+                parameters: &["mode → all | builtins | custom"],
+                examples: &["/help", "/help mode=custom"],
+            },
+        }
+    }
+}
+
 impl AppState {
     pub fn handle_command(&mut self, command_input: String) {
         let trimmed = command_input.trim();
@@ -375,178 +528,642 @@ impl AppState {
             return;
         }
 
-        let parts: Vec<&str> = trimmed.split_whitespace().collect();
-        if parts.is_empty() {
+        let invocation = CommandInvocation::parse(trimmed);
+        if invocation.name.is_empty() {
             return;
         }
 
-        let command = parts[0];
-
-        if let Some(custom) = self
-            .custom_commands
-            .iter()
-            .find(|cmd| cmd.trigger == command)
-        {
-            let response = self.execute_custom_action(custom.action);
-            self.chat_messages.push(ChatMessage {
-                sender: "System".to_string(),
-                text: response,
-            });
+        let outcome = self.resolve_command(invocation, 0);
+        if outcome.messages.is_empty() {
             return;
         }
 
-        let response = match command {
-            "/status" | "/system" => {
-                Some(self.execute_custom_action(CustomCommandAction::ShowSystemStatus))
-            }
-            "/models" => {
-                Some(self.execute_custom_action(CustomCommandAction::ListAvailableModels))
-            }
-            "/stats" => {
-                Some(self.execute_custom_action(CustomCommandAction::ShowUsageStatistics))
-            }
-            "/reload" => Some(
-                "Recargando configuraciones... Los proveedores y la caché se sincronizarán en segundo plano.".to_string(),
-            ),
-            "/help" => {
-                Some(self.execute_custom_action(CustomCommandAction::ShowCommandHelp))
-            }
-            _ => None,
-        };
-
-        if let Some(message) = response {
+        for message in outcome.messages {
             self.chat_messages.push(ChatMessage {
                 sender: "System".to_string(),
                 text: message,
             });
+        }
+    }
+
+    fn resolve_command(&mut self, invocation: CommandInvocation, depth: usize) -> CommandOutcome {
+        if depth > MAX_COMMAND_DEPTH {
+            return CommandOutcome::single(
+                "Recursión de comandos demasiado profunda. Revisa tus condicionales.".to_string(),
+            );
+        }
+
+        if invocation.name == "/if" {
+            return self.execute_conditional(invocation, depth);
+        }
+
+        if let Some(custom) = self
+            .custom_commands
+            .iter()
+            .find(|cmd| cmd.trigger == invocation.name)
+            .cloned()
+        {
+            return CommandOutcome {
+                messages: self.execute_custom_action(custom.action, &invocation),
+            };
+        }
+
+        match invocation.name.as_str() {
+            "/status" | "/system" => CommandOutcome {
+                messages: self
+                    .execute_custom_action(CustomCommandAction::ShowSystemStatus, &invocation),
+            },
+            "/models" => CommandOutcome {
+                messages: self
+                    .execute_custom_action(CustomCommandAction::ListAvailableModels, &invocation),
+            },
+            "/stats" => CommandOutcome {
+                messages: self
+                    .execute_custom_action(CustomCommandAction::ShowUsageStatistics, &invocation),
+            },
+            "/reload" => {
+                let mut message =
+                    "Recargando configuraciones... Los proveedores y la caché se sincronizarán en segundo plano.".to_string();
+                if invocation.flag("force") {
+                    message.push_str(" Forzando refresco inmediato de todas las credenciales.");
+                }
+                CommandOutcome::single(message)
+            }
+            "/help" => CommandOutcome {
+                messages: self
+                    .execute_custom_action(CustomCommandAction::ShowCommandHelp, &invocation),
+            },
+            "/time" => CommandOutcome {
+                messages: self
+                    .execute_custom_action(CustomCommandAction::ShowCurrentTime, &invocation),
+            },
+            "/projects" => CommandOutcome {
+                messages: self
+                    .execute_custom_action(CustomCommandAction::ListActiveProjects, &invocation),
+            },
+            "/profiles" => CommandOutcome {
+                messages: self.execute_custom_action(
+                    CustomCommandAction::ListConfiguredProfiles,
+                    &invocation,
+                ),
+            },
+            "/cache" => CommandOutcome {
+                messages: self.execute_custom_action(
+                    CustomCommandAction::ShowCacheConfiguration,
+                    &invocation,
+                ),
+            },
+            "/github" => CommandOutcome {
+                messages: self
+                    .execute_custom_action(CustomCommandAction::ShowGithubSummary, &invocation),
+            },
+            "/memory" => CommandOutcome {
+                messages: self
+                    .execute_custom_action(CustomCommandAction::ShowMemorySettings, &invocation),
+            },
+            "/providers" => CommandOutcome {
+                messages: self
+                    .execute_custom_action(CustomCommandAction::ShowActiveProviders, &invocation),
+            },
+            "/jarvis" => CommandOutcome {
+                messages: self
+                    .execute_custom_action(CustomCommandAction::ShowJarvisStatus, &invocation),
+            },
+            _ => CommandOutcome::single(format!("Unknown command: {}", invocation.raw)),
+        }
+    }
+
+    fn execute_conditional(
+        &mut self,
+        invocation: CommandInvocation,
+        depth: usize,
+    ) -> CommandOutcome {
+        let condition_text = invocation
+            .raw
+            .trim_start_matches("/if")
+            .trim_start()
+            .to_string();
+
+        if condition_text.is_empty() {
+            return CommandOutcome::single(
+                "Uso: /if <condición> then <comando> [else <comando>]".to_string(),
+            );
+        }
+
+        let (condition_part, outcome_part) = match condition_text.split_once(" then ") {
+            Some(parts) => parts,
+            None => {
+                return CommandOutcome::single(
+                    "La instrucción condicional necesita la palabra clave 'then'.".to_string(),
+                );
+            }
+        };
+
+        let (then_command, else_command) =
+            if let Some((then, otherwise)) = outcome_part.split_once(" else ") {
+                (then.trim(), Some(otherwise.trim()))
+            } else {
+                (outcome_part.trim(), None)
+            };
+
+        let evaluation = match self.evaluate_condition(condition_part.trim()) {
+            Ok(value) => value,
+            Err(err) => return CommandOutcome::single(err),
+        };
+
+        let mut messages = Vec::new();
+        messages.push(format!(
+            "Condición '{}' evaluada como {}.",
+            condition_part.trim(),
+            if evaluation { "verdadera" } else { "falsa" }
+        ));
+
+        let branch = if evaluation {
+            then_command
+        } else if let Some(else_cmd) = else_command {
+            else_cmd
         } else {
-            self.chat_messages.push(ChatMessage {
-                sender: "System".to_string(),
-                text: format!("Unknown command: {}", trimmed),
-            });
+            messages.push("No se especificó comando 'else'.".to_string());
+            return CommandOutcome { messages };
+        };
+
+        if branch.is_empty() {
+            messages.push("No hay comando que ejecutar tras la condición.".to_string());
+            return CommandOutcome { messages };
+        }
+
+        let nested_invocation = CommandInvocation::parse(branch);
+        if nested_invocation.name.is_empty() {
+            messages.push("No se pudo interpretar el comando de la rama seleccionada.".to_string());
+            return CommandOutcome { messages };
+        }
+
+        messages.push(format!("Ejecutando '{}'.", branch));
+        let nested = self.resolve_command(nested_invocation, depth + 1);
+        messages.extend(nested.messages);
+        CommandOutcome { messages }
+    }
+
+    fn evaluate_condition(&self, expression: &str) -> Result<bool, String> {
+        let parts: Vec<&str> = expression.split_whitespace().collect();
+        if parts.len() < 3 {
+            return Err(
+                "La condición debe tener el formato <campo> <operador> <valor>.".to_string(),
+            );
+        }
+
+        let field = parts[0];
+        let operator = parts[1];
+        let value = parts[2..].join(" ");
+
+        let lhs = self.resolve_condition_value(field)?;
+        lhs.compare(operator, value.trim())
+    }
+
+    fn resolve_condition_value(&self, field: &str) -> Result<ConditionValue, String> {
+        match field {
+            "memory.enabled" => Ok(ConditionValue::Boolean(self.enable_memory_tracking)),
+            "profiles.count" => Ok(ConditionValue::Number(self.profiles.len() as f64)),
+            "projects.count" => Ok(ConditionValue::Number(self.projects.len() as f64)),
+            "cache.auto_cleanup" => Ok(ConditionValue::Boolean(self.enable_auto_cleanup)),
+            "providers.total" => Ok(ConditionValue::Number(3.0)),
+            "github.connected" => Ok(ConditionValue::Boolean(self.github_username.is_some())),
+            "jarvis.auto_start" => Ok(ConditionValue::Boolean(self.jarvis_auto_start)),
+            "commands.count" => Ok(ConditionValue::Number(self.custom_commands.len() as f64)),
+            _ => Err(format!("Campo desconocido en la condición: {}", field)),
+        }
+    }
+
+    fn execute_custom_action(
+        &mut self,
+        action: CustomCommandAction,
+        invocation: &CommandInvocation,
+    ) -> Vec<String> {
+        match action {
+            CustomCommandAction::ShowCurrentTime => {
+                let format = invocation.arg("format").unwrap_or("human");
+                let now = Local::now();
+                let rendered = match format {
+                    "24" => now.format("%H:%M:%S").to_string(),
+                    "iso" => now.to_rfc3339(),
+                    _ => now.format("%I:%M %p").to_string(),
+                };
+                vec![format!("Hora actual: {}", rendered.trim())]
+            }
+            CustomCommandAction::ShowSystemStatus => {
+                let detail = invocation.arg("detail").unwrap_or("summary");
+                let verbose = invocation.flag("verbose");
+                let mut lines = vec![format!(
+                    "Sistema operativo estable. Límites configurados → Memoria: {:.1} GB · Disco: {:.1} GB.",
+                    self.resource_memory_limit_gb, self.resource_disk_limit_gb
+                )];
+
+                match detail {
+                    "memory" => lines.push(format!(
+                        "Memoria disponible para caché: {:.1} GB. Auto limpieza: {}.",
+                        self.resource_memory_limit_gb,
+                        if self.enable_auto_cleanup {
+                            "activada"
+                        } else {
+                            "desactivada"
+                        }
+                    )),
+                    "disk" => lines.push(format!(
+                        "Espacio de disco reservado para caché: {:.1} GB en {}.",
+                        self.resource_disk_limit_gb, self.cache_directory
+                    )),
+                    "cache" => lines.push(format!(
+                        "Limpieza automática cada {} horas. Última ejecución: {}.",
+                        self.cache_cleanup_interval_hours,
+                        self.last_cache_cleanup
+                            .clone()
+                            .unwrap_or_else(|| "nunca".to_string())
+                    )),
+                    _ => {}
+                }
+
+                if verbose {
+                    lines.push("Modo detallado activado: recuerda revisar la configuración de recursos en Preferencias.".to_string());
+                }
+
+                lines
+            }
+            CustomCommandAction::ShowUsageStatistics => {
+                let window = invocation.arg("window").unwrap_or("session");
+                let include = invocation
+                    .arg("include")
+                    .map(|value| {
+                        value
+                            .split(',')
+                            .map(|s| s.trim().to_string())
+                            .collect::<Vec<_>>()
+                    })
+                    .unwrap_or_default();
+
+                let mut lines = vec![format!(
+                    "Estadísticas (ventana: {}): {} mensajes registrados en esta sesión y {} comandos personalizados disponibles.",
+                    window,
+                    self.chat_messages.len(),
+                    self.custom_commands.len()
+                )];
+
+                if include.iter().any(|s| s == "commands") {
+                    lines.push(format!(
+                        "Triggers personalizados: {}",
+                        self.custom_commands
+                            .iter()
+                            .map(|cmd| cmd.trigger.clone())
+                            .collect::<Vec<_>>()
+                            .join(", ")
+                    ));
+                }
+
+                if include.iter().any(|s| s == "messages") {
+                    lines.push(format!(
+                        "Último mensaje de usuario: {}",
+                        self.chat_messages
+                            .iter()
+                            .rev()
+                            .find(|msg| msg.sender == "User")
+                            .map(|msg| msg.text.clone())
+                            .unwrap_or_else(|| "sin actividad".to_string())
+                    ));
+                }
+
+                lines
+            }
+            CustomCommandAction::ListActiveProjects => {
+                let limit = invocation
+                    .arg("limit")
+                    .and_then(|value| value.parse::<usize>().ok());
+                let mut projects = self.projects.clone();
+                if let Some(max) = limit {
+                    projects.truncate(max);
+                }
+
+                if projects.is_empty() {
+                    vec!["No hay proyectos configurados actualmente.".to_string()]
+                } else {
+                    vec![format!("Proyectos activos: {}.", projects.join(", "))]
+                }
+            }
+            CustomCommandAction::ListConfiguredProfiles => {
+                let mut profiles = self.profiles.clone();
+                match invocation.arg("sort").unwrap_or("asc") {
+                    "desc" => profiles.sort_by(|a, b| b.cmp(a)),
+                    _ => profiles.sort(),
+                }
+
+                if profiles.is_empty() {
+                    vec!["No hay perfiles configurados.".to_string()]
+                } else {
+                    vec![format!("Perfiles disponibles: {}.", profiles.join(", "))]
+                }
+            }
+            CustomCommandAction::ShowCacheConfiguration => {
+                let include = invocation
+                    .arg("include")
+                    .map(|value| {
+                        value
+                            .split(',')
+                            .map(|s| s.trim().to_string())
+                            .collect::<Vec<_>>()
+                    })
+                    .unwrap_or_else(|| vec!["limits".to_string()]);
+                let mut lines = Vec::new();
+
+                if include.iter().any(|s| s == "path") {
+                    lines.push(format!("Directorio de caché: {}", self.cache_directory));
+                }
+                if include.iter().any(|s| s == "limits") {
+                    lines.push(format!(
+                        "Límite configurado: {:.1} GB, limpieza automática: {}.",
+                        self.cache_size_limit_gb,
+                        if self.enable_auto_cleanup {
+                            "sí"
+                        } else {
+                            "no"
+                        }
+                    ));
+                }
+                if include.iter().any(|s| s == "schedule") {
+                    lines.push(format!(
+                        "La limpieza se programa cada {} horas. Última ejecución: {}.",
+                        self.cache_cleanup_interval_hours,
+                        self.last_cache_cleanup
+                            .clone()
+                            .unwrap_or_else(|| "nunca".to_string())
+                    ));
+                }
+
+                if lines.is_empty() {
+                    lines.push("No se reconocieron parámetros para mostrar.".to_string());
+                }
+                lines
+            }
+            CustomCommandAction::ListAvailableModels => {
+                let provider = invocation.arg("provider").unwrap_or("all");
+                let mut lines = Vec::new();
+
+                match provider {
+                    "openai" => lines.push(format!(
+                        "Modelo OpenAI activo: {}",
+                        self.openai_default_model
+                    )),
+                    "anthropic" => lines.push(format!(
+                        "Modelo Claude activo: {}",
+                        self.claude_default_model
+                    )),
+                    "groq" => {
+                        lines.push(format!("Modelo Groq activo: {}", self.groq_default_model))
+                    }
+                    "jarvis" => lines.push(format!(
+                        "Jarvis está configurado con: {}",
+                        self.jarvis_model_path
+                    )),
+                    "huggingface" => {
+                        if self.huggingface_models.is_empty() {
+                            lines.push("No hay modelos de HuggingFace registrados.".to_string());
+                        } else {
+                            lines.push(format!(
+                                "Modelos de HuggingFace: {}",
+                                self.huggingface_models.join(", ")
+                            ));
+                        }
+                    }
+                    "all" => {
+                        lines.push(format!(
+                            "OpenAI: {} · Claude: {} · Groq: {} · Jarvis: {}",
+                            self.openai_default_model,
+                            self.claude_default_model,
+                            self.groq_default_model,
+                            self.jarvis_model_path
+                        ));
+                        if self.huggingface_models.is_empty() {
+                            lines.push("HuggingFace: sin resultados cargados.".to_string());
+                        } else {
+                            lines.push(format!(
+                                "HuggingFace ({} modelos): {}",
+                                self.huggingface_models.len(),
+                                self.huggingface_models
+                                    .iter()
+                                    .take(5)
+                                    .cloned()
+                                    .collect::<Vec<_>>()
+                                    .join(", ")
+                            ));
+                        }
+                    }
+                    other => lines.push(format!("Proveedor desconocido: {}", other)),
+                }
+
+                lines
+            }
+            CustomCommandAction::ShowGithubSummary => {
+                let include_repos = invocation
+                    .arg("include")
+                    .map(|value| value.split(',').any(|v| v.trim() == "repos"))
+                    .unwrap_or(false);
+
+                let mut lines =
+                    vec![
+                        match (&self.github_username, self.github_repositories.is_empty()) {
+                            (Some(username), false) => format!(
+                                "GitHub autenticado como {} con {} repositorios sincronizables.",
+                                username,
+                                self.github_repositories.len()
+                            ),
+                            (Some(username), true) => format!(
+                        "GitHub autenticado como {}, pero no se encontraron repositorios visibles.",
+                        username
+                    ),
+                            _ => "GitHub no está conectado todavía.".to_string(),
+                        },
+                    ];
+
+                if include_repos && !self.github_repositories.is_empty() {
+                    lines.push(format!(
+                        "Repositorios: {}",
+                        self.github_repositories.join(", ")
+                    ));
+                }
+
+                lines
+            }
+            CustomCommandAction::ShowMemorySettings => {
+                let detail = invocation.arg("detail").unwrap_or("summary");
+                let mut lines = vec![format!(
+                    "Memoria contextual {} con retención de {} días.",
+                    if self.enable_memory_tracking {
+                        "activada"
+                    } else {
+                        "desactivada"
+                    },
+                    self.memory_retention_days
+                )];
+
+                if detail == "retention" {
+                    lines.push("Los recuerdos más antiguos se archivan para mantener el contexto relevante.".to_string());
+                }
+
+                lines
+            }
+            CustomCommandAction::ShowActiveProviders => {
+                let include = invocation
+                    .arg("include")
+                    .map(|value| {
+                        value
+                            .split(',')
+                            .map(|s| s.trim().to_string())
+                            .collect::<Vec<_>>()
+                    })
+                    .unwrap_or_default();
+                let mut lines = vec![format!(
+                    "Proveedores activos → OpenAI ({}) · Claude ({}) · Groq ({})",
+                    self.openai_default_model, self.claude_default_model, self.groq_default_model
+                )];
+
+                if include.iter().any(|s| s == "models") {
+                    lines.push(format!(
+                        "Jarvis usa {} y hay {} modelos de HuggingFace listos.",
+                        self.jarvis_model_path,
+                        self.huggingface_models.len()
+                    ));
+                }
+                if include.iter().any(|s| s == "status") {
+                    lines.push(format!(
+                        "Estado de pruebas → OpenAI: {} · Claude: {} · Groq: {}",
+                        self.openai_test_status
+                            .clone()
+                            .unwrap_or_else(|| "sin ejecutar".to_string()),
+                        self.anthropic_test_status
+                            .clone()
+                            .unwrap_or_else(|| "sin ejecutar".to_string()),
+                        self.groq_test_status
+                            .clone()
+                            .unwrap_or_else(|| "sin ejecutar".to_string())
+                    ));
+                }
+
+                lines
+            }
+            CustomCommandAction::ShowJarvisStatus => {
+                let detail = invocation.arg("detail").unwrap_or("summary");
+                let mut lines = vec![format!(
+                    "Jarvis en '{}' ({}) → {}",
+                    self.jarvis_model_path,
+                    if self.jarvis_auto_start {
+                        "autoarranque habilitado"
+                    } else {
+                        "autoarranque deshabilitado"
+                    },
+                    self.jarvis_status
+                        .clone()
+                        .unwrap_or_else(|| "Jarvis esperando tareas.".to_string())
+                )];
+
+                match detail {
+                    "path" => lines.push(format!(
+                        "El modelo local se puede actualizar reemplazando el archivo en {}.",
+                        self.jarvis_model_path
+                    )),
+                    "logs" => lines.push("Los registros en tiempo real no están disponibles en modo demo, pero se guardan en /var/log/jarvis.".to_string()),
+                    _ => {}
+                }
+
+                lines
+            }
+            CustomCommandAction::ShowCommandHelp => {
+                let mode = invocation.arg("mode").unwrap_or("all");
+                let mut builtins = vec!["/status", "/models", "/stats", "/reload", "/help", "/if"];
+                builtins.extend([
+                    "/time",
+                    "/projects",
+                    "/profiles",
+                    "/cache",
+                    "/github",
+                    "/memory",
+                    "/providers",
+                    "/jarvis",
+                ]);
+                let custom: Vec<String> = self
+                    .custom_commands
+                    .iter()
+                    .map(|cmd| cmd.trigger.clone())
+                    .collect();
+
+                let mut lines = Vec::new();
+                match mode {
+                    "builtins" => lines.push(format!("Comandos base: {}", builtins.join(", "))),
+                    "custom" => {
+                        if custom.is_empty() {
+                            lines.push("No hay comandos personalizados.".to_string());
+                        } else {
+                            lines.push(format!("Comandos personalizados: {}", custom.join(", ")));
+                        }
+                    }
+                    _ => {
+                        lines.push(format!("Comandos base: {}", builtins.join(", ")));
+                        if custom.is_empty() {
+                            lines.push("Comandos personalizados: ninguno configurado.".to_string());
+                        } else {
+                            lines.push(format!("Comandos personalizados: {}", custom.join(", ")));
+                        }
+                    }
+                }
+
+                if mode == "all" || mode == "builtins" {
+                    lines.push(
+                        "Utiliza '/if <condición> then <cmd>' para ejecutar lógica condicional."
+                            .to_string(),
+                    );
+                }
+
+                lines
+            }
         }
     }
 }
 
-impl AppState {
-    pub fn execute_custom_action(&self, action: CustomCommandAction) -> String {
-        match action {
-            CustomCommandAction::ShowCurrentTime => {
-                let now = Local::now();
-                let formatted = now.format("%I:%M %p").to_string();
-                let normalized = formatted
-                    .trim_start_matches('0')
-                    .replace(' ', "")
-                    .to_lowercase();
-                format!("Son las {}.", normalized)
-            }
-            CustomCommandAction::ShowSystemStatus => {
-                format!(
-                    "Sistema operativo estable. Límites configurados → Memoria: {:.1} GB · Disco: {:.1} GB.",
-                    self.resource_memory_limit_gb, self.resource_disk_limit_gb
-                )
-            }
-            CustomCommandAction::ShowUsageStatistics => {
-                let total_messages = self.chat_messages.len();
-                let custom_count = self.custom_commands.len();
-                format!(
-                    "Estadísticas de uso: {} mensajes registrados en esta sesión y {} comandos personalizados disponibles.",
-                    total_messages, custom_count
-                )
-            }
-            CustomCommandAction::ListActiveProjects => {
-                if self.projects.is_empty() {
-                    "No hay proyectos configurados actualmente.".to_string()
-                } else {
-                    format!("Proyectos activos: {}.", self.projects.join(", "))
-                }
-            }
-            CustomCommandAction::ListConfiguredProfiles => {
-                if self.profiles.is_empty() {
-                    "No hay perfiles configurados.".to_string()
-                } else {
-                    format!("Perfiles disponibles: {}.", self.profiles.join(", "))
-                }
-            }
-            CustomCommandAction::ShowCacheConfiguration => {
-                format!(
-                    "Caché en '{}', límite {:.1} GB con limpieza automática cada {} h.",
-                    self.cache_directory,
-                    self.cache_size_limit_gb,
-                    self.cache_cleanup_interval_hours
-                )
-            }
-            CustomCommandAction::ListAvailableModels => {
-                let hf_preview = if self.huggingface_models.is_empty() {
-                    "sin resultados".to_string()
-                } else {
-                    self.huggingface_models
-                        .iter()
-                        .take(3)
-                        .cloned()
-                        .collect::<Vec<_>>()
-                        .join(", ")
-                };
+enum ConditionValue {
+    Boolean(bool),
+    Number(f64),
+}
 
-                format!(
-                    "Modelos configurados → OpenAI: {} · Claude: {} · Groq: {} · Jarvis: {} · HuggingFace: {}",
-                    self.openai_default_model,
-                    self.claude_default_model,
-                    self.groq_default_model,
-                    self.jarvis_model_path,
-                    hf_preview
-                )
-            }
-            CustomCommandAction::ShowGithubSummary => {
-                match (&self.github_username, self.github_repositories.is_empty()) {
-                    (Some(username), false) => format!(
-                        "GitHub autenticado como {} con {} repositorios sincronizables.",
-                        username,
-                        self.github_repositories.len()
-                    ),
-                    (Some(username), true) => format!(
-                        "GitHub autenticado como {}, pero no se encontraron repositorios visibles.",
-                        username
-                    ),
-                    _ => "GitHub no está conectado todavía.".to_string(),
+impl ConditionValue {
+    fn compare(&self, operator: &str, rhs: &str) -> Result<bool, String> {
+        match self {
+            ConditionValue::Boolean(lhs) => {
+                let rhs_bool = match rhs {
+                    "true" | "1" => Ok(true),
+                    "false" | "0" => Ok(false),
+                    _ => Err("Se esperaba un valor booleano (true/false).".to_string()),
+                }?;
+                match operator {
+                    "==" => Ok(*lhs == rhs_bool),
+                    "!=" => Ok(*lhs != rhs_bool),
+                    _ => Err(format!(
+                        "Operador '{}' no soportado para booleanos.",
+                        operator
+                    )),
                 }
             }
-            CustomCommandAction::ShowMemorySettings => {
-                let status = if self.enable_memory_tracking {
-                    "activada"
-                } else {
-                    "desactivada"
-                };
-                format!(
-                    "Memoria contextual {} con retención de {} días.",
-                    status, self.memory_retention_days
-                )
-            }
-            CustomCommandAction::ShowActiveProviders => {
-                format!(
-                    "Proveedores activos → OpenAI ({}) · Claude ({}) · Groq ({})",
-                    self.openai_default_model, self.claude_default_model, self.groq_default_model
-                )
-            }
-            CustomCommandAction::ShowJarvisStatus => {
-                let auto_start = if self.jarvis_auto_start {
-                    "autoarranque habilitado"
-                } else {
-                    "autoarranque deshabilitado"
-                };
-                let status = self
-                    .jarvis_status
-                    .clone()
-                    .unwrap_or_else(|| "Jarvis esperando tareas.".to_string());
-                format!(
-                    "Jarvis en '{}' ({}) → {}",
-                    self.jarvis_model_path, auto_start, status
-                )
-            }
-            CustomCommandAction::ShowCommandHelp => {
-                let mut commands = vec!["/status", "/models", "/stats", "/reload", "/help"];
-                commands.extend(self.custom_commands.iter().map(|cmd| cmd.trigger.as_str()));
-                format!("Comandos disponibles: {}.", commands.join(", "))
+            ConditionValue::Number(lhs) => {
+                let rhs_num = rhs
+                    .parse::<f64>()
+                    .map_err(|_| "Se esperaba un número en la comparación.".to_string())?;
+                match operator {
+                    "==" => Ok((*lhs - rhs_num).abs() < f64::EPSILON),
+                    "!=" => Ok((*lhs - rhs_num).abs() >= f64::EPSILON),
+                    ">" => Ok(*lhs > rhs_num),
+                    ">=" => Ok(*lhs >= rhs_num),
+                    "<" => Ok(*lhs < rhs_num),
+                    "<=" => Ok(*lhs <= rhs_num),
+                    _ => Err(format!(
+                        "Operador '{}' no soportado para números.",
+                        operator
+                    )),
+                }
             }
         }
     }

--- a/src/ui/chat.rs
+++ b/src/ui/chat.rs
@@ -48,6 +48,17 @@ pub fn draw_chat_panel(ctx: &egui::Context, state: &mut AppState) {
                 });
 
             ui.add_space(12.0);
+        });
+    });
+}
+
+pub fn draw_preferences_panel(ctx: &egui::Context, state: &mut AppState) {
+    egui::CentralPanel::default().show(ctx, |ui| {
+        ui.heading(state.selected_section.title());
+        ui.label(state.selected_section.description());
+        ui.separator();
+
+        egui::ScrollArea::vertical().show(ui, |ui| {
             draw_selected_section(ui, state);
         });
     });
@@ -137,10 +148,6 @@ fn submit_chat_message(state: &mut AppState) {
 }
 
 fn draw_selected_section(ui: &mut egui::Ui, state: &mut AppState) {
-    ui.heading(state.selected_section.title());
-    ui.label(state.selected_section.description());
-    ui.separator();
-
     match state.selected_section {
         PreferenceSection::SystemGithub => draw_system_github(ui, state),
         PreferenceSection::SystemCache => draw_system_cache(ui, state),
@@ -371,13 +378,13 @@ fn draw_custom_commands(ui: &mut egui::Ui, state: &mut AppState) {
     }
 
     ui.add_space(8.0);
-    egui::CollapsingHeader::new("Available functions")
-        .default_open(false)
-        .show(ui, |ui| {
-            for action in AVAILABLE_CUSTOM_ACTIONS {
-                ui.label(format!("{} — {}", action.label(), action.description()));
-            }
-        });
+    if ui
+        .button("Available functions")
+        .on_hover_text("Consulta documentación detallada y ejemplos")
+        .clicked()
+    {
+        state.show_functions_modal = true;
+    }
 }
 
 fn draw_customization_memory(ui: &mut egui::Ui, state: &mut AppState) {

--- a/src/ui/mod.rs
+++ b/src/ui/mod.rs
@@ -2,7 +2,6 @@ use crate::state::{AppState, MainView};
 use eframe::egui;
 
 pub mod chat;
-pub mod live;
 pub mod modals;
 pub mod sidebar;
 
@@ -11,7 +10,8 @@ pub fn draw_ui(ctx: &egui::Context, state: &mut AppState) {
     sidebar::draw_right_sidebar(ctx, state); // New call for right sidebar
     match state.active_main_view {
         MainView::ChatMultimodal => chat::draw_chat_panel(ctx, state),
-        MainView::LiveMultimodal => live::draw_live_panel(ctx, state),
+        MainView::Preferences => chat::draw_preferences_panel(ctx, state),
     }
     modals::draw_settings_modal(ctx, state);
+    modals::draw_functions_modal(ctx, state);
 }

--- a/src/ui/modals.rs
+++ b/src/ui/modals.rs
@@ -1,4 +1,4 @@
-use crate::state::AppState;
+use crate::state::{AppState, AVAILABLE_CUSTOM_ACTIONS};
 use eframe::egui;
 
 pub fn draw_settings_modal(ctx: &egui::Context, state: &mut AppState) {
@@ -21,4 +21,87 @@ pub fn draw_settings_modal(ctx: &egui::Context, state: &mut AppState) {
         });
 
     state.show_settings_modal = is_open;
+}
+
+pub fn draw_functions_modal(ctx: &egui::Context, state: &mut AppState) {
+    if !state.show_functions_modal {
+        return;
+    }
+
+    let mut is_open = state.show_functions_modal;
+    egui::Window::new("Available Functions")
+        .collapsible(false)
+        .resizable(true)
+        .min_size(egui::vec2(540.0, 420.0))
+        .open(&mut is_open)
+        .show(ctx, |ui| {
+            ui.label("Consulta la documentación ampliada de cada comando y función disponible.");
+            ui.separator();
+
+            egui::ScrollArea::vertical().show(ui, |ui| {
+                ui.heading("Comandos integrados");
+                ui.add_space(6.0);
+
+                for (signature, summary, examples) in builtin_documentation() {
+                    ui.group(|ui| {
+                        ui.strong(signature);
+                        ui.label(summary);
+                        if !examples.is_empty() {
+                            ui.label("Ejemplos:");
+                            for example in examples.iter() {
+                                ui.monospace(*example);
+                            }
+                        }
+                    });
+                    ui.add_space(10.0);
+                }
+
+                ui.separator();
+                ui.heading("Funciones personalizables");
+                ui.add_space(6.0);
+
+                for action in AVAILABLE_CUSTOM_ACTIONS {
+                    let doc = action.documentation();
+                    ui.group(|ui| {
+                        ui.strong(doc.signature);
+                        ui.label(doc.summary);
+                        if !doc.parameters.is_empty() {
+                            ui.add_space(4.0);
+                            ui.label("Parámetros:");
+                            for parameter in doc.parameters {
+                                ui.horizontal(|ui| {
+                                    ui.label("•");
+                                    ui.label(*parameter);
+                                });
+                            }
+                        }
+                        if !doc.examples.is_empty() {
+                            ui.add_space(4.0);
+                            ui.label("Ejemplos:");
+                            for example in doc.examples.iter() {
+                                ui.monospace(*example);
+                            }
+                        }
+                    });
+                    ui.add_space(10.0);
+                }
+            });
+        });
+
+    state.show_functions_modal = is_open;
+}
+
+fn builtin_documentation() -> Vec<(&'static str, &'static str, &'static [&'static str])> {
+    vec![
+        (
+            "/if <condición> then <cmd> [else <cmd>]",
+            "Ejecuta comandos condicionalmente evaluando campos del sistema (por ejemplo memory.enabled o projects.count).",
+            &["/if memory.enabled == true then /status", "/if projects.count > 2 then /models else /help"],
+        ),
+        (
+            "/reload [--force]",
+            "Sincroniza la configuración y admite la bandera --force para reiniciar credenciales.",
+            &["/reload", "/reload --force"],
+        ),
+    ]
 }

--- a/src/ui/sidebar.rs
+++ b/src/ui/sidebar.rs
@@ -16,11 +16,6 @@ pub fn draw_sidebar(ctx: &egui::Context, state: &mut AppState) {
                     MainView::ChatMultimodal,
                     "Chat Multimodal",
                 );
-                ui.selectable_value(
-                    &mut state.active_main_view,
-                    MainView::LiveMultimodal,
-                    "Live Multimodal",
-                );
                 ui.add_space(8.0);
 
                 egui::CollapsingHeader::new("Preferences")
@@ -31,21 +26,36 @@ pub fn draw_sidebar(ctx: &egui::Context, state: &mut AppState) {
                                 .default_open(true)
                                 .show(ui, |ui| {
                                     ui.indent("preferences_system_items", |ui| {
-                                        ui.selectable_value(
-                                            &mut state.selected_section,
-                                            PreferenceSection::SystemGithub,
-                                            "GitHub for Projects",
-                                        );
-                                        ui.selectable_value(
-                                            &mut state.selected_section,
-                                            PreferenceSection::SystemCache,
-                                            "Cache",
-                                        );
-                                        ui.selectable_value(
-                                            &mut state.selected_section,
-                                            PreferenceSection::SystemResources,
-                                            "System resources",
-                                        );
+                                        if ui
+                                            .selectable_value(
+                                                &mut state.selected_section,
+                                                PreferenceSection::SystemGithub,
+                                                "GitHub for Projects",
+                                            )
+                                            .changed()
+                                        {
+                                            state.active_main_view = MainView::Preferences;
+                                        }
+                                        if ui
+                                            .selectable_value(
+                                                &mut state.selected_section,
+                                                PreferenceSection::SystemCache,
+                                                "Cache",
+                                            )
+                                            .changed()
+                                        {
+                                            state.active_main_view = MainView::Preferences;
+                                        }
+                                        if ui
+                                            .selectable_value(
+                                                &mut state.selected_section,
+                                                PreferenceSection::SystemResources,
+                                                "System resources",
+                                            )
+                                            .changed()
+                                        {
+                                            state.active_main_view = MainView::Preferences;
+                                        }
                                     });
                                 });
 
@@ -53,26 +63,46 @@ pub fn draw_sidebar(ctx: &egui::Context, state: &mut AppState) {
                                 .default_open(true)
                                 .show(ui, |ui| {
                                     ui.indent("preferences_customization_items", |ui| {
-                                        ui.selectable_value(
-                                            &mut state.selected_section,
-                                            PreferenceSection::CustomizationCommands,
-                                            "Custom commands",
-                                        );
-                                        ui.selectable_value(
-                                            &mut state.selected_section,
-                                            PreferenceSection::CustomizationMemory,
-                                            "Memory",
-                                        );
-                                        ui.selectable_value(
-                                            &mut state.selected_section,
-                                            PreferenceSection::CustomizationProfiles,
-                                            "Profiles",
-                                        );
-                                        ui.selectable_value(
-                                            &mut state.selected_section,
-                                            PreferenceSection::CustomizationProjects,
-                                            "Projects",
-                                        );
+                                        if ui
+                                            .selectable_value(
+                                                &mut state.selected_section,
+                                                PreferenceSection::CustomizationCommands,
+                                                "Custom commands",
+                                            )
+                                            .changed()
+                                        {
+                                            state.active_main_view = MainView::Preferences;
+                                        }
+                                        if ui
+                                            .selectable_value(
+                                                &mut state.selected_section,
+                                                PreferenceSection::CustomizationMemory,
+                                                "Memory",
+                                            )
+                                            .changed()
+                                        {
+                                            state.active_main_view = MainView::Preferences;
+                                        }
+                                        if ui
+                                            .selectable_value(
+                                                &mut state.selected_section,
+                                                PreferenceSection::CustomizationProfiles,
+                                                "Profiles",
+                                            )
+                                            .changed()
+                                        {
+                                            state.active_main_view = MainView::Preferences;
+                                        }
+                                        if ui
+                                            .selectable_value(
+                                                &mut state.selected_section,
+                                                PreferenceSection::CustomizationProjects,
+                                                "Projects",
+                                            )
+                                            .changed()
+                                        {
+                                            state.active_main_view = MainView::Preferences;
+                                        }
                                     });
                                 });
 
@@ -84,16 +114,26 @@ pub fn draw_sidebar(ctx: &egui::Context, state: &mut AppState) {
                                             .default_open(true)
                                             .show(ui, |ui| {
                                                 ui.indent("preferences_models_local", |ui| {
-                                                    ui.selectable_value(
-                                                        &mut state.selected_section,
-                                                        PreferenceSection::ModelsLocalHuggingFace,
-                                                        "HuggingFace (explore and install)",
-                                                    );
-                                                    ui.selectable_value(
-                                                        &mut state.selected_section,
-                                                        PreferenceSection::ModelsLocalSettings,
-                                                        "Settings",
-                                                    );
+                                                    if ui
+                                                        .selectable_value(
+                                                            &mut state.selected_section,
+                                                            PreferenceSection::ModelsLocalHuggingFace,
+                                                            "HuggingFace (explore and install)",
+                                                        )
+                                                        .changed()
+                                                    {
+                                                        state.active_main_view = MainView::Preferences;
+                                                    }
+                                                    if ui
+                                                        .selectable_value(
+                                                            &mut state.selected_section,
+                                                            PreferenceSection::ModelsLocalSettings,
+                                                            "Settings",
+                                                        )
+                                                        .changed()
+                                                    {
+                                                        state.active_main_view = MainView::Preferences;
+                                                    }
                                                 });
                                             });
 
@@ -101,21 +141,36 @@ pub fn draw_sidebar(ctx: &egui::Context, state: &mut AppState) {
                                             .default_open(true)
                                             .show(ui, |ui| {
                                                 ui.indent("preferences_models_providers", |ui| {
-                                                    ui.selectable_value(
-                                                        &mut state.selected_section,
-                                                        PreferenceSection::ModelsProviderAnthropic,
-                                                        "Anthropic",
-                                                    );
-                                                    ui.selectable_value(
-                                                        &mut state.selected_section,
-                                                        PreferenceSection::ModelsProviderOpenAi,
-                                                        "OpenAI",
-                                                    );
-                                                    ui.selectable_value(
-                                                        &mut state.selected_section,
-                                                        PreferenceSection::ModelsProviderGroq,
-                                                        "Groq",
-                                                    );
+                                                    if ui
+                                                        .selectable_value(
+                                                            &mut state.selected_section,
+                                                            PreferenceSection::ModelsProviderAnthropic,
+                                                            "Anthropic",
+                                                        )
+                                                        .changed()
+                                                    {
+                                                        state.active_main_view = MainView::Preferences;
+                                                    }
+                                                    if ui
+                                                        .selectable_value(
+                                                            &mut state.selected_section,
+                                                            PreferenceSection::ModelsProviderOpenAi,
+                                                            "OpenAI",
+                                                        )
+                                                        .changed()
+                                                    {
+                                                        state.active_main_view = MainView::Preferences;
+                                                    }
+                                                    if ui
+                                                        .selectable_value(
+                                                            &mut state.selected_section,
+                                                            PreferenceSection::ModelsProviderGroq,
+                                                            "Groq",
+                                                        )
+                                                        .changed()
+                                                    {
+                                                        state.active_main_view = MainView::Preferences;
+                                                    }
                                                 });
                                             });
                                     });


### PR DESCRIPTION
## Summary
- remove the Live Multimodal option and switch the sidebar to drive only the chat and preference tree
- split the central layout so Chat Multimodal shows only the feed/input and preferences render in their own panel when selected
- expand the slash-command engine with argument parsing, conditional /if execution, richer responses, and a new Available Functions modal with detailed docs

## Testing
- cargo fmt
- cargo check

------
https://chatgpt.com/codex/tasks/task_e_68d47362d8bc8333b6e6f3cd4034420c