### PR TITLE
Persist preferences and add provider integrations

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -937,6 +937,27 @@ dependencies = [
 ]
 
 [[package]]
+name = "dirs"
+version = "5.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "44c45a9d03d6676652bcb5e724c7e988de1acad23a711b5217ab9cbecbec2225"
+dependencies = [
+ "dirs-sys",
+]
+
+[[package]]
+name = "dirs-sys"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "520f05a5cbd335fae5a99ff7a6ab8627577660ee5cfd6a94a6a929b52ff0321c"
+dependencies = [
+ "libc",
+ "option-ext",
+ "redox_users",
+ "windows-sys 0.48.0",
+]
+
+[[package]]
 name = "dispatch"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2388,6 +2409,7 @@ version = "0.1.0"
 dependencies = [
  "anyhow",
  "chrono",
+ "dirs",
  "eframe",
  "egui_extras",
  "octocrab",
@@ -2778,6 +2800,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "option-ext"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "04744f49eae99ab78e0d5c0b603ab218f515ea8cfe5a456d7629ad883a3b6e7d"
+
+[[package]]
 name = "orbclient"
 version = "0.3.48"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3138,6 +3166,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5407465600fb0548f1442edf71dd20683c6ed326200ace4b1ef0763521bb3b77"
 dependencies = [
  "bitflags 2.9.4",
+]
+
+[[package]]
+name = "redox_users"
+version = "0.4.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ba009ff324d1fc1b900bd1fdb31564febe58a8ccc8a6fdbb93b543d33b13ca43"
+dependencies = [
+ "getrandom 0.2.16",
+ "libredox",
+ "thiserror 1.0.69",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,3 +22,4 @@ serde_json = "1.0"
 
 # Error Handling
 anyhow = "1.0"
+dirs = "5.0"

--- a/src/api/claude.rs
+++ b/src/api/claude.rs
@@ -1,1 +1,70 @@
-// Lógica para interactuar con la API de Anthropic Claude.
+use anyhow::{Context, Result};
+use reqwest::blocking::Client;
+use serde::Deserialize;
+use serde_json::json;
+use std::time::Duration;
+
+#[derive(Debug, Deserialize)]
+struct AnthropicContent {
+    #[serde(default)]
+    text: String,
+}
+
+#[derive(Debug, Deserialize)]
+struct AnthropicResponse {
+    #[serde(default)]
+    content: Vec<AnthropicContent>,
+}
+
+/// Envía un mensaje a la API de Anthropic Claude y devuelve la primera respuesta textual.
+pub fn send_message(api_key: &str, model: &str, prompt: &str) -> Result<String> {
+    let client = Client::builder()
+        .timeout(Duration::from_secs(45))
+        .build()
+        .context("No se pudo crear el cliente HTTP para Anthropic")?;
+
+    let payload = json!({
+        "model": model,
+        "max_tokens": 256,
+        "messages": [
+            {
+                "role": "user",
+                "content": [
+                    {
+                        "type": "text",
+                        "text": prompt,
+                    }
+                ],
+            }
+        ],
+    });
+
+    let response = client
+        .post("https://api.anthropic.com/v1/messages")
+        .header("x-api-key", api_key)
+        .header("anthropic-version", "2023-06-01")
+        .json(&payload)
+        .send()
+        .context("Error enviando la solicitud a Anthropic")?
+        .error_for_status()
+        .context("Anthropic devolvió un estado de error")?;
+
+    let parsed: AnthropicResponse = response
+        .json()
+        .context("No se pudo interpretar la respuesta de Anthropic")?;
+
+    let reply = parsed
+        .content
+        .into_iter()
+        .find_map(|content| {
+            let trimmed = content.text.trim();
+            if trimmed.is_empty() {
+                None
+            } else {
+                Some(trimmed.to_string())
+            }
+        })
+        .unwrap_or_else(|| "(respuesta vacía)".to_string());
+
+    Ok(reply)
+}

--- a/src/api/groq.rs
+++ b/src/api/groq.rs
@@ -1,1 +1,68 @@
-// Lógica para interactuar con la API de Groq.
+use anyhow::{Context, Result};
+use reqwest::blocking::Client;
+use serde::Deserialize;
+use serde_json::json;
+use std::time::Duration;
+
+#[derive(Debug, Deserialize)]
+struct ChatMessage {
+    #[serde(default)]
+    content: String,
+}
+
+#[derive(Debug, Deserialize)]
+struct ChatChoice {
+    message: ChatMessage,
+}
+
+#[derive(Debug, Deserialize)]
+struct ChatResponse {
+    #[serde(default)]
+    choices: Vec<ChatChoice>,
+}
+
+/// Envía un mensaje utilizando la API compatible de Groq.
+pub fn send_message(api_key: &str, model: &str, prompt: &str) -> Result<String> {
+    let client = Client::builder()
+        .timeout(Duration::from_secs(45))
+        .build()
+        .context("No se pudo crear el cliente HTTP para Groq")?;
+
+    let payload = json!({
+        "model": model,
+        "max_tokens": 256,
+        "temperature": 0.2,
+        "messages": [
+            {"role": "system", "content": "Responde brevemente."},
+            {"role": "user", "content": prompt},
+        ],
+    });
+
+    let response = client
+        .post("https://api.groq.com/openai/v1/chat/completions")
+        .bearer_auth(api_key)
+        .json(&payload)
+        .send()
+        .context("Error enviando la solicitud a Groq")?
+        .error_for_status()
+        .context("Groq devolvió un estado de error")?;
+
+    let parsed: ChatResponse = response
+        .json()
+        .context("No se pudo interpretar la respuesta de Groq")?;
+
+    let reply = parsed
+        .choices
+        .into_iter()
+        .find_map(|choice| {
+            let trimmed = choice.message.content.trim();
+            if trimmed.is_empty() {
+                None
+            } else {
+                Some(trimmed.to_string())
+            }
+        })
+        .unwrap_or_else(|| "(respuesta vacía)".to_string());
+
+    Ok(reply)
+}

--- a/src/api/huggingface.rs
+++ b/src/api/huggingface.rs
@@ -1,1 +1,80 @@
-// Lógica para interactuar con la API de Hugging Face.
+use anyhow::{Context, Result};
+use reqwest::blocking::Client;
+use serde::Deserialize;
+use serde_json::Value;
+use std::fs;
+use std::path::{Path, PathBuf};
+use std::time::Duration;
+
+#[derive(Debug, Deserialize)]
+struct ModelSummary {
+    #[serde(rename = "modelId")]
+    model_id: String,
+}
+
+/// Busca modelos en Hugging Face y devuelve una lista de identificadores.
+pub fn search_models(query: &str, token: Option<&str>) -> Result<Vec<String>> {
+    let client = Client::builder()
+        .timeout(Duration::from_secs(30))
+        .user_agent("JungleMonkAI/0.1")
+        .build()
+        .context("No se pudo crear el cliente HTTP para Hugging Face")?;
+
+    let mut request = client
+        .get("https://huggingface.co/api/models")
+        .query(&[("search", query), ("limit", "25")]);
+
+    if let Some(token) = token {
+        if !token.trim().is_empty() {
+            request = request.bearer_auth(token.trim());
+        }
+    }
+
+    let response = request
+        .send()
+        .context("Error enviando la búsqueda a Hugging Face")?
+        .error_for_status()
+        .context("Hugging Face devolvió un estado de error")?;
+
+    let models: Vec<ModelSummary> = response
+        .json()
+        .context("No se pudo interpretar la respuesta de búsqueda de Hugging Face")?;
+
+    Ok(models.into_iter().map(|m| m.model_id).collect())
+}
+
+/// Descarga metadatos básicos del modelo y los almacena en disco dentro del directorio indicado.
+pub fn download_model(model_id: &str, install_dir: &Path, token: Option<&str>) -> Result<PathBuf> {
+    let client = Client::builder()
+        .timeout(Duration::from_secs(60))
+        .user_agent("JungleMonkAI/0.1")
+        .build()
+        .context("No se pudo crear el cliente HTTP para Hugging Face")?;
+
+    let mut request = client.get(format!("https://huggingface.co/api/models/{}", model_id));
+    if let Some(token) = token {
+        if !token.trim().is_empty() {
+            request = request.bearer_auth(token.trim());
+        }
+    }
+
+    let response = request
+        .send()
+        .context("Error descargando metadatos del modelo en Hugging Face")?
+        .error_for_status()
+        .context("Hugging Face devolvió un estado de error al descargar metadatos")?;
+
+    let metadata: Value = response
+        .json()
+        .context("No se pudo interpretar los metadatos del modelo de Hugging Face")?;
+
+    let target_dir = install_dir.join(model_id.replace('/', "_"));
+    fs::create_dir_all(&target_dir)
+        .with_context(|| format!("No se pudo crear el directorio {:?}", target_dir))?;
+
+    let metadata_path = target_dir.join("metadata.json");
+    fs::write(&metadata_path, serde_json::to_string_pretty(&metadata)?)
+        .with_context(|| format!("No se pudo escribir {:?}", metadata_path))?;
+
+    Ok(target_dir)
+}

--- a/src/api/openai.rs
+++ b/src/api/openai.rs
@@ -1,1 +1,68 @@
-// Lógica para interactuar con la API de OpenAI.
+use anyhow::{Context, Result};
+use reqwest::blocking::Client;
+use serde::Deserialize;
+use serde_json::json;
+use std::time::Duration;
+
+#[derive(Debug, Deserialize)]
+struct ChatMessage {
+    #[serde(default)]
+    content: String,
+}
+
+#[derive(Debug, Deserialize)]
+struct ChatChoice {
+    message: ChatMessage,
+}
+
+#[derive(Debug, Deserialize)]
+struct ChatResponse {
+    #[serde(default)]
+    choices: Vec<ChatChoice>,
+}
+
+/// Envía un mensaje a la API de OpenAI y devuelve la respuesta de chat generada.
+pub fn send_message(api_key: &str, model: &str, prompt: &str) -> Result<String> {
+    let client = Client::builder()
+        .timeout(Duration::from_secs(45))
+        .build()
+        .context("No se pudo crear el cliente HTTP para OpenAI")?;
+
+    let payload = json!({
+        "model": model,
+        "max_tokens": 256,
+        "temperature": 0.2,
+        "messages": [
+            {"role": "system", "content": "Eres un asistente que responde con frases breves."},
+            {"role": "user", "content": prompt},
+        ],
+    });
+
+    let response = client
+        .post("https://api.openai.com/v1/chat/completions")
+        .bearer_auth(api_key)
+        .json(&payload)
+        .send()
+        .context("Error enviando la solicitud a OpenAI")?
+        .error_for_status()
+        .context("OpenAI devolvió un estado de error")?;
+
+    let parsed: ChatResponse = response
+        .json()
+        .context("No se pudo interpretar la respuesta de OpenAI")?;
+
+    let reply = parsed
+        .choices
+        .into_iter()
+        .find_map(|choice| {
+            let trimmed = choice.message.content.trim();
+            if trimmed.is_empty() {
+                None
+            } else {
+                Some(trimmed.to_string())
+            }
+        })
+        .unwrap_or_else(|| "(respuesta vacía)".to_string());
+
+    Ok(reply)
+}

--- a/src/config.rs
+++ b/src/config.rs
@@ -1,10 +1,147 @@
+use anyhow::Context;
 use serde::{Deserialize, Serialize};
+use std::fs;
+use std::path::{Path, PathBuf};
 
-/// Estructura para la configuración de la aplicación, cargada desde un archivo.
-#[derive(Serialize, Deserialize, Default)]
+/// Datos de configuración específicos de un proveedor de modelos.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ProviderConfig {
+    /// API key opcional (algunos proveedores permiten tokens vacíos para cuentas gratuitas).
+    pub api_key: Option<String>,
+    /// Modelo por defecto con el que se realizarán las peticiones.
+    pub default_model: String,
+    /// Alias que el usuario utilizará dentro del chat para invocar al proveedor.
+    pub alias: String,
+}
+
+impl Default for ProviderConfig {
+    fn default() -> Self {
+        Self {
+            api_key: None,
+            default_model: String::new(),
+            alias: String::new(),
+        }
+    }
+}
+
+/// Preferencias para gestionar el agente local "Jarvis".
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct JarvisConfig {
+    pub model_path: String,
+    pub install_dir: String,
+    pub auto_start: bool,
+    pub installed_models: Vec<String>,
+}
+
+impl Default for JarvisConfig {
+    fn default() -> Self {
+        Self {
+            model_path: "/models/jarvis/latest.bin".to_string(),
+            install_dir: "models/jarvis".to_string(),
+            auto_start: true,
+            installed_models: Vec::new(),
+        }
+    }
+}
+
+/// Preferencias relacionadas con Hugging Face.
+#[derive(Debug, Clone, Serialize, Deserialize, Default)]
+pub struct HuggingFaceConfig {
+    pub access_token: Option<String>,
+    pub last_search_query: String,
+}
+
+/// Estructura para la configuración persistente de la aplicación.
+#[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct AppConfig {
-    pub openai_api_key: Option<String>,
-    pub claude_api_key: Option<String>,
-    pub groq_api_key: Option<String>,
-    // ... otros campos de configuración
+    pub anthropic: ProviderConfig,
+    pub openai: ProviderConfig,
+    pub groq: ProviderConfig,
+    pub github_token: Option<String>,
+    pub cache_directory: String,
+    pub cache_size_limit_gb: f32,
+    pub enable_auto_cleanup: bool,
+    pub cache_cleanup_interval_hours: u32,
+    pub resource_memory_limit_gb: f32,
+    pub resource_disk_limit_gb: f32,
+    pub custom_commands: Vec<crate::state::CustomCommand>,
+    pub enable_memory_tracking: bool,
+    pub memory_retention_days: u32,
+    pub profiles: Vec<String>,
+    pub selected_profile: Option<usize>,
+    pub projects: Vec<String>,
+    pub selected_project: Option<usize>,
+    pub jarvis: JarvisConfig,
+    pub huggingface: HuggingFaceConfig,
+}
+
+impl Default for AppConfig {
+    fn default() -> Self {
+        Self {
+            anthropic: ProviderConfig {
+                api_key: None,
+                default_model: "claude-3-opus".to_string(),
+                alias: "claude".to_string(),
+            },
+            openai: ProviderConfig {
+                api_key: None,
+                default_model: "gpt-4.1-mini".to_string(),
+                alias: "gpt".to_string(),
+            },
+            groq: ProviderConfig {
+                api_key: None,
+                default_model: "llama3-70b-8192".to_string(),
+                alias: "groq".to_string(),
+            },
+            github_token: None,
+            cache_directory: "/var/tmp/jungle/cache".to_string(),
+            cache_size_limit_gb: 8.0,
+            enable_auto_cleanup: true,
+            cache_cleanup_interval_hours: 24,
+            resource_memory_limit_gb: 32.0,
+            resource_disk_limit_gb: 128.0,
+            custom_commands: crate::state::default_custom_commands(),
+            enable_memory_tracking: true,
+            memory_retention_days: 30,
+            profiles: vec![
+                "Default".to_string(),
+                "Research".to_string(),
+                "Operations".to_string(),
+            ],
+            selected_profile: Some(0),
+            projects: vec!["Autonomous Agent".to_string(), "RAG Pipeline".to_string()],
+            selected_project: Some(0),
+            jarvis: JarvisConfig::default(),
+            huggingface: HuggingFaceConfig::default(),
+        }
+    }
+}
+
+impl AppConfig {
+    fn config_path() -> anyhow::Result<PathBuf> {
+        let base = dirs::config_dir().unwrap_or_else(|| Path::new(".").to_path_buf());
+        let dir = base.join("JungleMonkAI");
+        fs::create_dir_all(&dir).with_context(|| format!("No se pudo crear {:?}", dir))?;
+        Ok(dir.join("config.json"))
+    }
+
+    pub fn load_or_default() -> Self {
+        let path = match Self::config_path() {
+            Ok(path) => path,
+            Err(_) => return Self::default(),
+        };
+
+        let data = match fs::read_to_string(&path) {
+            Ok(content) => content,
+            Err(_) => return Self::default(),
+        };
+
+        serde_json::from_str(&data).unwrap_or_else(|_| Self::default())
+    }
+
+    pub fn save(&self) -> anyhow::Result<()> {
+        let path = Self::config_path()?;
+        let json = serde_json::to_string_pretty(self)?;
+        fs::write(&path, json).with_context(|| format!("No se pudo guardar {:?}", path))
+    }
 }


### PR DESCRIPTION
## Summary
- persist UI preferences to a JSON config file under the user's config directory and reuse the saved state on startup
- integrate Anthropc, OpenAI, and Groq chat APIs with alias-based routing plus improved provider settings UX
- add Hugging Face search & install tooling that stores model metadata for the local Jarvis agent

## Testing
- cargo check

------
https://chatgpt.com/codex/tasks/task_e_68d477b04cc8833381695ad760f24f59