### PR TITLE
Apply graphite dark theme layout redesign

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -17,11 +17,7 @@ fn main() -> anyhow::Result<()> {
     eframe::run_native(
         "Multimodal Agent",
         options,
-        Box::new(|cc| {
-            // Aquí puedes configurar estilos de egui si quieres
-            // cc.egui_ctx.set_visuals(egui::Visuals::dark());
-            Box::new(MultimodalApp::new(cc))
-        }),
+        Box::new(|cc| Box::new(MultimodalApp::new(cc))),
     )
     .map_err(|e| anyhow::anyhow!("Eframe error: {}", e))?;
 
@@ -33,7 +29,9 @@ struct MultimodalApp {
 }
 
 impl MultimodalApp {
-    fn new(_cc: &eframe::CreationContext<'_>) -> Self {
+    fn new(cc: &eframe::CreationContext<'_>) -> Self {
+        ui::theme::apply(&cc.egui_ctx);
+
         Self {
             state: AppState::default(),
         }

--- a/src/ui/header.rs
+++ b/src/ui/header.rs
@@ -1,0 +1,118 @@
+use eframe::egui::{self, Color32, RichText};
+
+use crate::state::AppState;
+
+use super::theme;
+
+pub fn draw_header(ctx: &egui::Context, state: &mut AppState) {
+    egui::TopBottomPanel::top("global_header")
+        .exact_height(44.0)
+        .frame(
+            egui::Frame::none()
+                .fill(theme::COLOR_HEADER)
+                .stroke(theme::subtle_border())
+                .inner_margin(egui::Margin::symmetric(12.0, 6.0)),
+        )
+        .show(ctx, |ui| {
+            ui.set_height(32.0);
+            ui.horizontal(|ui| {
+                ui.spacing_mut().item_spacing.x = 10.0;
+
+                draw_logo(ui);
+                ui.label(
+                    RichText::new("Jungle MonkAI")
+                        .size(18.0)
+                        .color(theme::COLOR_TEXT_PRIMARY)
+                        .strong(),
+                );
+
+                ui.separator();
+                draw_search(ui, state);
+
+                ui.with_layout(egui::Layout::right_to_left(egui::Align::Center), |ui| {
+                    let logs_label = if state.logs_panel_expanded {
+                        "🗂 Ocultar logs"
+                    } else {
+                        "🗂 Mostrar logs"
+                    };
+                    if ui
+                        .add_sized(
+                            [130.0, 28.0],
+                            theme::secondary_button(
+                                RichText::new(logs_label).color(theme::COLOR_TEXT_PRIMARY),
+                            ),
+                        )
+                        .clicked()
+                    {
+                        state.logs_panel_expanded = !state.logs_panel_expanded;
+                    }
+
+                    if ui
+                        .add_sized(
+                            [110.0, 28.0],
+                            theme::secondary_button(
+                                RichText::new("⚙ Ajustes").color(theme::COLOR_TEXT_PRIMARY),
+                            ),
+                        )
+                        .clicked()
+                    {
+                        state.show_settings_modal = true;
+                    }
+
+                    ui.add_space(6.0);
+                    if ui
+                        .add_sized(
+                            [120.0, 28.0],
+                            theme::primary_button(
+                                RichText::new("▶ Ejecutar").color(Color32::from_rgb(240, 240, 240)),
+                            ),
+                        )
+                        .clicked()
+                    {
+                        state.command_feedback =
+                            Some("Simulando ejecución rápida de tareas programadas.".to_string());
+                    }
+                });
+            });
+        });
+}
+
+fn draw_logo(ui: &mut egui::Ui) {
+    let (rect, _) = ui.allocate_exact_size(egui::vec2(30.0, 30.0), egui::Sense::hover());
+    let painter = ui.painter_at(rect);
+
+    let outer = rect.expand2(egui::vec2(0.0, 0.0));
+    painter.rect(
+        outer,
+        egui::Rounding::same(4.0),
+        Color32::from_rgb(0, 204, 102),
+        egui::Stroke::new(1.5, Color32::from_rgb(10, 70, 40)),
+    );
+
+    let inner_rect = egui::Rect::from_center_size(outer.center(), egui::vec2(22.0, 22.0));
+    painter.circle(
+        inner_rect.center(),
+        inner_rect.width() * 0.35,
+        theme::COLOR_HEADER,
+        egui::Stroke::new(1.2, Color32::from_rgb(0, 204, 102)),
+    );
+
+    painter.text(
+        inner_rect.center(),
+        egui::Align2::CENTER_CENTER,
+        "JM",
+        egui::FontId::proportional(12.0),
+        Color32::from_rgb(12, 18, 16),
+    );
+}
+
+fn draw_search(ui: &mut egui::Ui, state: &mut AppState) {
+    ui.horizontal(|ui| {
+        ui.spacing_mut().item_spacing.x = 4.0;
+        ui.label(RichText::new("🔍").color(theme::COLOR_TEXT_WEAK));
+        ui.add_sized(
+            [200.0, 26.0],
+            egui::TextEdit::singleline(&mut state.search_buffer).hint_text("Buscar recursos..."),
+        );
+    });
+}

--- a/src/ui/logs.rs
+++ b/src/ui/logs.rs
@@ -1,0 +1,112 @@
+use eframe::egui::{self, RichText};
+use egui_extras::{Column, TableBuilder};
+
+use crate::state::{AppState, LogStatus};
+
+use super::theme;
+
+pub fn draw_logs_panel(ctx: &egui::Context, state: &mut AppState) {
+    egui::TopBottomPanel::bottom("logs_panel")
+        .frame(
+            egui::Frame::none()
+                .fill(theme::COLOR_PANEL)
+                .stroke(theme::subtle_border())
+                .inner_margin(egui::Margin::symmetric(14.0, 10.0)),
+        )
+        .min_height(140.0)
+        .max_height(320.0)
+        .resizable(true)
+        .show_animated(ctx, state.logs_panel_expanded, |ui| {
+            ui.horizontal(|ui| {
+                ui.heading(RichText::new("Registros & tareas").color(theme::COLOR_TEXT_PRIMARY));
+                ui.with_layout(egui::Layout::right_to_left(egui::Align::Center), |ui| {
+                    if ui
+                        .add_sized(
+                            [110.0, 26.0],
+                            theme::secondary_button(
+                                RichText::new("Ocultar").color(theme::COLOR_TEXT_PRIMARY),
+                            ),
+                        )
+                        .clicked()
+                    {
+                        state.logs_panel_expanded = false;
+                    }
+                });
+            });
+            ui.add_space(6.0);
+
+            egui::ScrollArea::both()
+                .auto_shrink([false, false])
+                .show(ui, |ui| {
+                    let header_bg = egui::Color32::from_rgb(36, 36, 36);
+                    let row_even = egui::Color32::from_rgb(38, 38, 38);
+                    let row_odd = egui::Color32::from_rgb(46, 46, 46);
+
+                    TableBuilder::new(ui)
+                        .striped(false)
+                        .cell_layout(egui::Layout::left_to_right(egui::Align::Center))
+                        .column(Column::exact(36.0))
+                        .column(Column::exact(120.0))
+                        .column(Column::remainder())
+                        .column(Column::exact(120.0))
+                        .header(24.0, |mut header| {
+                            header.col(|ui| {
+                                ui.painter().rect_filled(ui.max_rect(), 0.0, header_bg);
+                                ui.label(RichText::new("Estado").color(theme::COLOR_TEXT_WEAK));
+                            });
+                            header.col(|ui| {
+                                ui.painter().rect_filled(ui.max_rect(), 0.0, header_bg);
+                                ui.label(RichText::new("Origen").color(theme::COLOR_TEXT_WEAK));
+                            });
+                            header.col(|ui| {
+                                ui.painter().rect_filled(ui.max_rect(), 0.0, header_bg);
+                                ui.label(RichText::new("Detalle").color(theme::COLOR_TEXT_WEAK));
+                            });
+                            header.col(|ui| {
+                                ui.painter().rect_filled(ui.max_rect(), 0.0, header_bg);
+                                ui.label(RichText::new("Hora").color(theme::COLOR_TEXT_WEAK));
+                            });
+                        })
+                        .body(|mut body| {
+                            for (index, entry) in state.activity_logs.iter().enumerate() {
+                                let bg = if index % 2 == 0 { row_even } else { row_odd };
+                                body.row(26.0, |mut row| {
+                                    row.col(|ui| {
+                                        ui.painter().rect_filled(ui.max_rect(), 0.0, bg);
+                                        ui.label(status_badge(entry.status));
+                                    });
+                                    row.col(|ui| {
+                                        ui.painter().rect_filled(ui.max_rect(), 0.0, bg);
+                                        ui.label(
+                                            RichText::new(&entry.source)
+                                                .color(theme::COLOR_TEXT_PRIMARY),
+                                        );
+                                    });
+                                    row.col(|ui| {
+                                        ui.painter().rect_filled(ui.max_rect(), 0.0, bg);
+                                        ui.label(
+                                            RichText::new(&entry.message)
+                                                .color(theme::COLOR_TEXT_PRIMARY),
+                                        );
+                                    });
+                                    row.col(|ui| {
+                                        ui.painter().rect_filled(ui.max_rect(), 0.0, bg);
+                                        ui.label(
+                                            RichText::new(&entry.timestamp)
+                                                .color(theme::COLOR_TEXT_WEAK),
+                                        );
+                                    });
+                                });
+                            }
+                        });
+                });
+        });
+}
+
+fn status_badge(status: LogStatus) -> RichText {
+    match status {
+        LogStatus::Ok => RichText::new("✔ OK").color(theme::COLOR_SUCCESS),
+        LogStatus::Error => RichText::new("❌ Error").color(theme::COLOR_DANGER),
+        LogStatus::Running => RichText::new("⏳ En curso").color(theme::COLOR_PRIMARY),
+    }
+}

--- a/src/ui/mod.rs
+++ b/src/ui/mod.rs
@@ -1,17 +1,20 @@
-use crate::state::{AppState, MainView};
+use crate::state::AppState;
 use eframe::egui;
 
 pub mod chat;
+pub mod header;
+pub mod logs;
 pub mod modals;
 pub mod sidebar;
+pub mod theme;
 
 pub fn draw_ui(ctx: &egui::Context, state: &mut AppState) {
+    theme::apply(ctx);
+    header::draw_header(ctx, state);
     sidebar::draw_sidebar(ctx, state);
-    sidebar::draw_right_sidebar(ctx, state); // New call for right sidebar
-    match state.active_main_view {
-        MainView::ChatMultimodal => chat::draw_chat_panel(ctx, state),
-        MainView::Preferences => chat::draw_preferences_panel(ctx, state),
-    }
+    logs::draw_logs_panel(ctx, state);
+    chat::draw_main_content(ctx, state);
+
     modals::draw_settings_modal(ctx, state);
     modals::draw_functions_modal(ctx, state);
 }

--- a/src/ui/sidebar.rs
+++ b/src/ui/sidebar.rs
@@ -1,226 +1,329 @@
 use crate::state::{AppState, MainView, PreferenceSection};
-use eframe::egui;
+use eframe::egui::{self, Color32, RichText};
+
+use super::theme;
 
 pub fn draw_sidebar(ctx: &egui::Context, state: &mut AppState) {
-    egui::SidePanel::left("sidebar")
+    egui::SidePanel::left("navigation_panel")
         .resizable(true)
-        .default_width(250.0)
-        .width_range(200.0..=400.0)
+        .default_width(280.0)
+        .width_range(220.0..=420.0)
+        .frame(
+            egui::Frame::none()
+                .fill(theme::COLOR_PANEL)
+                .stroke(theme::subtle_border())
+                .inner_margin(egui::Margin::same(16.0)),
+        )
         .show(ctx, |ui| {
-            ui.heading("Multimodal Agent");
-            ui.separator();
-
-            egui::ScrollArea::vertical().show(ui, |ui| {
-                ui.selectable_value(
-                    &mut state.active_main_view,
-                    MainView::ChatMultimodal,
-                    "Chat Multimodal",
-                );
-                ui.add_space(8.0);
-
-                egui::CollapsingHeader::new("Preferences")
-                    .default_open(true)
-                    .show(ui, |ui| {
-                        ui.indent("preferences_system", |ui| {
-                            egui::CollapsingHeader::new("System")
-                                .default_open(true)
-                                .show(ui, |ui| {
-                                    ui.indent("preferences_system_items", |ui| {
-                                        if ui
-                                            .selectable_value(
-                                                &mut state.selected_section,
-                                                PreferenceSection::SystemGithub,
-                                                "GitHub for Projects",
-                                            )
-                                            .changed()
-                                        {
-                                            state.active_main_view = MainView::Preferences;
-                                        }
-                                        if ui
-                                            .selectable_value(
-                                                &mut state.selected_section,
-                                                PreferenceSection::SystemCache,
-                                                "Cache",
-                                            )
-                                            .changed()
-                                        {
-                                            state.active_main_view = MainView::Preferences;
-                                        }
-                                        if ui
-                                            .selectable_value(
-                                                &mut state.selected_section,
-                                                PreferenceSection::SystemResources,
-                                                "System resources",
-                                            )
-                                            .changed()
-                                        {
-                                            state.active_main_view = MainView::Preferences;
-                                        }
-                                    });
-                                });
-
-                            egui::CollapsingHeader::new("Customization")
-                                .default_open(true)
-                                .show(ui, |ui| {
-                                    ui.indent("preferences_customization_items", |ui| {
-                                        if ui
-                                            .selectable_value(
-                                                &mut state.selected_section,
-                                                PreferenceSection::CustomizationCommands,
-                                                "Custom commands",
-                                            )
-                                            .changed()
-                                        {
-                                            state.active_main_view = MainView::Preferences;
-                                        }
-                                        if ui
-                                            .selectable_value(
-                                                &mut state.selected_section,
-                                                PreferenceSection::CustomizationMemory,
-                                                "Memory",
-                                            )
-                                            .changed()
-                                        {
-                                            state.active_main_view = MainView::Preferences;
-                                        }
-                                        if ui
-                                            .selectable_value(
-                                                &mut state.selected_section,
-                                                PreferenceSection::CustomizationProfiles,
-                                                "Profiles",
-                                            )
-                                            .changed()
-                                        {
-                                            state.active_main_view = MainView::Preferences;
-                                        }
-                                        if ui
-                                            .selectable_value(
-                                                &mut state.selected_section,
-                                                PreferenceSection::CustomizationProjects,
-                                                "Projects",
-                                            )
-                                            .changed()
-                                        {
-                                            state.active_main_view = MainView::Preferences;
-                                        }
-                                    });
-                                });
-
-                            egui::CollapsingHeader::new("Models")
-                                .default_open(true)
-                                .show(ui, |ui| {
-                                    ui.indent("preferences_models_items", |ui| {
-                                        egui::CollapsingHeader::new("Local (Jarvis)")
-                                            .default_open(true)
-                                            .show(ui, |ui| {
-                                                ui.indent("preferences_models_local", |ui| {
-                                                    if ui
-                                                        .selectable_value(
-                                                            &mut state.selected_section,
-                                                            PreferenceSection::ModelsLocalHuggingFace,
-                                                            "HuggingFace (explore and install)",
-                                                        )
-                                                        .changed()
-                                                    {
-                                                        state.active_main_view = MainView::Preferences;
-                                                    }
-                                                    if ui
-                                                        .selectable_value(
-                                                            &mut state.selected_section,
-                                                            PreferenceSection::ModelsLocalSettings,
-                                                            "Settings",
-                                                        )
-                                                        .changed()
-                                                    {
-                                                        state.active_main_view = MainView::Preferences;
-                                                    }
-                                                });
-                                            });
-
-                                        egui::CollapsingHeader::new("Providers")
-                                            .default_open(true)
-                                            .show(ui, |ui| {
-                                                ui.indent("preferences_models_providers", |ui| {
-                                                    if ui
-                                                        .selectable_value(
-                                                            &mut state.selected_section,
-                                                            PreferenceSection::ModelsProviderAnthropic,
-                                                            "Anthropic",
-                                                        )
-                                                        .changed()
-                                                    {
-                                                        state.active_main_view = MainView::Preferences;
-                                                    }
-                                                    if ui
-                                                        .selectable_value(
-                                                            &mut state.selected_section,
-                                                            PreferenceSection::ModelsProviderOpenAi,
-                                                            "OpenAI",
-                                                        )
-                                                        .changed()
-                                                    {
-                                                        state.active_main_view = MainView::Preferences;
-                                                    }
-                                                    if ui
-                                                        .selectable_value(
-                                                            &mut state.selected_section,
-                                                            PreferenceSection::ModelsProviderGroq,
-                                                            "Groq",
-                                                        )
-                                                        .changed()
-                                                    {
-                                                        state.active_main_view = MainView::Preferences;
-                                                    }
-                                                });
-                                            });
-                                    });
-                                });
-                        });
-                    });
-            });
-
-            ui.with_layout(egui::Layout::bottom_up(egui::Align::LEFT), |ui| {
-                ui.separator();
-                if ui.button("⚙ Settings").clicked() {
-                    state.show_settings_modal = true;
-                }
-            });
+            egui::ScrollArea::vertical()
+                .auto_shrink([false, false])
+                .show(ui, |ui| {
+                    for node in NAV_TREE {
+                        draw_nav_node(ui, state, node, 0);
+                        ui.add_space(4.0);
+                    }
+                });
         });
 }
 
-pub fn draw_right_sidebar(ctx: &egui::Context, state: &mut AppState) {
-    egui::SidePanel::right("right_sidebar")
-        .resizable(true)
-        .default_width(200.0)
-        .width_range(150.0..=300.0)
-        .show(ctx, |ui| {
-            ui.heading("Providers & Local Model");
-            ui.separator();
-            ui.label("Loaded Providers:");
-            ui.label(format!("OpenAI · model {}", state.openai_default_model));
-            ui.label(format!("Claude · model {}", state.claude_default_model));
-            ui.label(format!("Groq · model {}", state.groq_default_model));
+#[derive(Clone, Copy)]
+struct NavNode {
+    id: &'static str,
+    label: &'static str,
+    icon: &'static str,
+    view: Option<MainView>,
+    section: Option<PreferenceSection>,
+    children: &'static [NavNode],
+}
 
-            if let Some(status) = &state.openai_test_status {
-                ui.colored_label(ui.visuals().weak_text_color(), status);
-            }
-            if let Some(status) = &state.anthropic_test_status {
-                ui.colored_label(ui.visuals().weak_text_color(), status);
-            }
-            if let Some(status) = &state.groq_test_status {
-                ui.colored_label(ui.visuals().weak_text_color(), status);
-            }
+const NAV_TREE: &[NavNode] = &[
+    NavNode {
+        id: "chat",
+        label: "Panel multimodal",
+        icon: "💬",
+        view: Some(MainView::ChatMultimodal),
+        section: None,
+        children: &[],
+    },
+    NavNode {
+        id: "resources",
+        label: "Recursos",
+        icon: "📦",
+        view: None,
+        section: None,
+        children: RESOURCE_CHILDREN,
+    },
+    NavNode {
+        id: "customization",
+        label: "Personalización",
+        icon: "🛠️",
+        view: Some(MainView::Preferences),
+        section: Some(PreferenceSection::CustomizationCommands),
+        children: CUSTOMIZATION_DETAILS,
+    },
+];
 
-            ui.separator();
-            ui.label("Local Model (Jarvis):");
-            ui.label(format!("Path: {}", state.jarvis_model_path));
-            ui.label(if state.jarvis_auto_start {
-                "Auto start: enabled"
-            } else {
-                "Auto start: disabled"
-            });
-            if let Some(status) = &state.jarvis_status {
-                ui.colored_label(ui.visuals().weak_text_color(), status);
+const RESOURCE_CHILDREN: &[NavNode] = &[
+    NavNode {
+        id: "system",
+        label: "Sistema",
+        icon: "🖥️",
+        view: Some(MainView::Preferences),
+        section: Some(PreferenceSection::SystemResources),
+        children: SYSTEM_DETAILS,
+    },
+    NavNode {
+        id: "providers",
+        label: "Proveedores",
+        icon: "🖲️",
+        view: Some(MainView::Preferences),
+        section: Some(PreferenceSection::ModelsProviderOpenAi),
+        children: PROVIDER_DETAILS,
+    },
+    NavNode {
+        id: "local_model",
+        label: "Modelo local",
+        icon: "💽",
+        view: Some(MainView::Preferences),
+        section: Some(PreferenceSection::ModelsLocalSettings),
+        children: LOCAL_DETAILS,
+    },
+    NavNode {
+        id: "network",
+        label: "Red",
+        icon: "🌐",
+        view: Some(MainView::Preferences),
+        section: Some(PreferenceSection::SystemGithub),
+        children: NETWORK_DETAILS,
+    },
+];
+
+const SYSTEM_DETAILS: &[NavNode] = &[
+    NavNode {
+        id: "system_github",
+        label: "GitHub",
+        icon: "☁",
+        view: Some(MainView::Preferences),
+        section: Some(PreferenceSection::SystemGithub),
+        children: &[],
+    },
+    NavNode {
+        id: "system_cache",
+        label: "Caché",
+        icon: "🧹",
+        view: Some(MainView::Preferences),
+        section: Some(PreferenceSection::SystemCache),
+        children: &[],
+    },
+    NavNode {
+        id: "system_resources",
+        label: "Recursos",
+        icon: "📊",
+        view: Some(MainView::Preferences),
+        section: Some(PreferenceSection::SystemResources),
+        children: &[],
+    },
+];
+
+const PROVIDER_DETAILS: &[NavNode] = &[
+    NavNode {
+        id: "provider_anthropic",
+        label: "Anthropic",
+        icon: "🤖",
+        view: Some(MainView::Preferences),
+        section: Some(PreferenceSection::ModelsProviderAnthropic),
+        children: &[],
+    },
+    NavNode {
+        id: "provider_openai",
+        label: "OpenAI",
+        icon: "✨",
+        view: Some(MainView::Preferences),
+        section: Some(PreferenceSection::ModelsProviderOpenAi),
+        children: &[],
+    },
+    NavNode {
+        id: "provider_groq",
+        label: "Groq",
+        icon: "⚡",
+        view: Some(MainView::Preferences),
+        section: Some(PreferenceSection::ModelsProviderGroq),
+        children: &[],
+    },
+];
+
+const LOCAL_DETAILS: &[NavNode] = &[
+    NavNode {
+        id: "local_hf",
+        label: "HuggingFace",
+        icon: "📦",
+        view: Some(MainView::Preferences),
+        section: Some(PreferenceSection::ModelsLocalHuggingFace),
+        children: &[],
+    },
+    NavNode {
+        id: "local_settings",
+        label: "Configuración",
+        icon: "⚙",
+        view: Some(MainView::Preferences),
+        section: Some(PreferenceSection::ModelsLocalSettings),
+        children: &[],
+    },
+];
+
+const NETWORK_DETAILS: &[NavNode] = &[NavNode {
+    id: "network_providers",
+    label: "Red de proveedores",
+    icon: "🌐",
+    view: Some(MainView::Preferences),
+    section: Some(PreferenceSection::ModelsProviderOpenAi),
+    children: &[],
+}];
+
+const CUSTOMIZATION_DETAILS: &[NavNode] = &[
+    NavNode {
+        id: "custom_commands",
+        label: "Comandos",
+        icon: "🧰",
+        view: Some(MainView::Preferences),
+        section: Some(PreferenceSection::CustomizationCommands),
+        children: &[],
+    },
+    NavNode {
+        id: "custom_memory",
+        label: "Memoria",
+        icon: "🧠",
+        view: Some(MainView::Preferences),
+        section: Some(PreferenceSection::CustomizationMemory),
+        children: &[],
+    },
+    NavNode {
+        id: "custom_profiles",
+        label: "Perfiles",
+        icon: "👤",
+        view: Some(MainView::Preferences),
+        section: Some(PreferenceSection::CustomizationProfiles),
+        children: &[],
+    },
+    NavNode {
+        id: "custom_projects",
+        label: "Proyectos",
+        icon: "📁",
+        view: Some(MainView::Preferences),
+        section: Some(PreferenceSection::CustomizationProjects),
+        children: &[],
+    },
+];
+
+fn draw_nav_node(ui: &mut egui::Ui, state: &mut AppState, node: &NavNode, depth: usize) {
+    let indent = (depth as f32) * 18.0;
+    let available_width = ui.available_width();
+    let (rect, response) =
+        ui.allocate_at_least(egui::vec2(available_width, 30.0), egui::Sense::click());
+
+    let is_expanded = state.expanded_nav_nodes.contains(node.id);
+    let is_selected = node_is_selected(state, node);
+    let branch_active = node_is_active(state, node);
+
+    let base_fill = if depth == 0 {
+        egui::Color32::from_rgb(28, 28, 28)
+    } else {
+        egui::Color32::from_rgb(24, 24, 24)
+    };
+
+    let fill = if is_selected {
+        egui::Color32::from_rgb(52, 62, 78)
+    } else if branch_active {
+        egui::Color32::from_rgb(34, 40, 52)
+    } else {
+        base_fill
+    };
+
+    let border = if is_selected {
+        egui::Stroke::new(1.0, Color32::from_rgb(70, 110, 150))
+    } else {
+        theme::subtle_border()
+    };
+
+    let painter = ui.painter();
+    painter.rect(rect.shrink2(egui::vec2(0.5, 1.0)), 0.0, fill, border);
+
+    let mut content_ui = ui.child_ui(
+        egui::Rect::from_min_max(
+            egui::pos2(rect.min.x + 12.0 + indent, rect.min.y),
+            egui::pos2(rect.max.x - 12.0, rect.max.y),
+        ),
+        egui::Layout::left_to_right(egui::Align::Center),
+    );
+
+    if !node.children.is_empty() {
+        let arrow = if is_expanded { "▾" } else { "▸" };
+        content_ui.label(RichText::new(arrow).color(theme::COLOR_TEXT_WEAK));
+    } else {
+        content_ui.add_space(16.0);
+    }
+
+    let icon_color = if branch_active {
+        theme::COLOR_SUCCESS
+    } else {
+        theme::COLOR_TEXT_WEAK
+    };
+
+    content_ui.label(RichText::new(node.icon).color(icon_color));
+    content_ui.add_space(6.0);
+    content_ui.label(RichText::new(node.label).color(theme::COLOR_TEXT_PRIMARY));
+
+    if response.clicked() {
+        if !node.children.is_empty() {
+            toggle_branch(state, node.id, is_expanded);
+        }
+
+        if let Some(view) = node.view {
+            state.active_main_view = view;
+        }
+        if let Some(section) = node.section {
+            state.selected_section = section;
+            if state.active_main_view != MainView::Preferences {
+                state.active_main_view = MainView::Preferences;
             }
-        });
+        }
+    }
+
+    if !node.children.is_empty() && (is_expanded || depth == 0) {
+        for child in node.children {
+            draw_nav_node(ui, state, child, depth + 1);
+        }
+    }
+}
+
+fn toggle_branch(state: &mut AppState, id: &'static str, expanded: bool) {
+    if expanded {
+        state.expanded_nav_nodes.remove(id);
+    } else {
+        state.expanded_nav_nodes.insert(id);
+    }
+}
+
+fn node_is_selected(state: &AppState, node: &NavNode) -> bool {
+    if let Some(view) = node.view {
+        if state.active_main_view == view && node.section.is_none() {
+            return true;
+        }
+    }
+    if let Some(section) = node.section {
+        if state.selected_section == section && state.active_main_view == MainView::Preferences {
+            return true;
+        }
+    }
+    false
+}
+
+fn node_is_active(state: &AppState, node: &NavNode) -> bool {
+    if node_is_selected(state, node) {
+        return true;
+    }
+
+    node.children
+        .iter()
+        .any(|child| node_is_active(state, child))
 }

--- a/src/ui/theme.rs
+++ b/src/ui/theme.rs
@@ -1,0 +1,109 @@
+use eframe::egui::{self, style::ScrollStyle, Color32, Stroke};
+
+const BG_ROOT: Color32 = Color32::from_rgb(28, 28, 28);
+const BG_PANEL: Color32 = Color32::from_rgb(32, 32, 32);
+const BG_HOVER: Color32 = Color32::from_rgb(44, 44, 44);
+const BG_ACTIVE: Color32 = Color32::from_rgb(25, 118, 210);
+const BG_SECONDARY: Color32 = Color32::from_rgb(38, 38, 38);
+const TEXT_PRIMARY: Color32 = Color32::from_rgb(224, 224, 224);
+const TEXT_WEAK: Color32 = Color32::from_rgb(170, 170, 170);
+const BORDER: Color32 = Color32::from_rgb(48, 48, 48);
+
+pub fn apply(ctx: &egui::Context) {
+    let mut style = (*ctx.style()).clone();
+    style.visuals = build_visuals();
+
+    style.spacing.item_spacing = egui::vec2(12.0, 8.0);
+    style.spacing.button_padding = egui::vec2(12.0, 6.0);
+    style.spacing.interact_size.y = 28.0;
+    style.spacing.scroll = ScrollStyle {
+        floating: false,
+        bar_width: 6.0,
+        bar_inner_margin: 2.0,
+        bar_outer_margin: 4.0,
+        floating_width: 6.0,
+        handle_min_length: 12.0,
+        floating_allocated_width: 0.0,
+        foreground_color: true,
+        dormant_background_opacity: 0.0,
+        active_background_opacity: 0.4,
+        interact_background_opacity: 0.6,
+        dormant_handle_opacity: 0.0,
+        active_handle_opacity: 0.6,
+        interact_handle_opacity: 0.9,
+    };
+    style.visuals.widgets.noninteractive.bg_stroke = Stroke::new(1.0, BORDER);
+
+    ctx.set_style(style);
+}
+
+fn build_visuals() -> egui::Visuals {
+    let mut visuals = egui::Visuals::dark();
+    visuals.dark_mode = true;
+    visuals.override_text_color = Some(TEXT_PRIMARY);
+    visuals.window_fill = BG_PANEL;
+    visuals.panel_fill = BG_ROOT;
+    visuals.extreme_bg_color = Color32::from_rgb(18, 18, 18);
+    visuals.faint_bg_color = Color32::from_rgb(30, 30, 30);
+    visuals.hyperlink_color = Color32::from_rgb(0, 102, 204);
+    visuals.selection.bg_fill = Color32::from_rgb(42, 60, 88);
+    visuals.selection.stroke = Stroke::new(1.0, Color32::from_rgb(64, 120, 180));
+    visuals.window_rounding = egui::Rounding::ZERO;
+    visuals.menu_rounding = egui::Rounding::ZERO;
+    visuals.widgets.noninteractive.rounding = egui::Rounding::ZERO;
+
+    let mut noninteractive = visuals.widgets.noninteractive.clone();
+    noninteractive.bg_fill = BG_PANEL;
+    noninteractive.bg_stroke = Stroke::new(1.0, BORDER);
+    noninteractive.fg_stroke = Stroke::new(1.0, TEXT_PRIMARY);
+    noninteractive.rounding = egui::Rounding::ZERO;
+
+    let mut inactive = visuals.widgets.inactive.clone();
+    inactive.bg_fill = BG_SECONDARY;
+    inactive.weak_bg_fill = BG_ROOT;
+    inactive.bg_stroke = Stroke::new(1.0, BORDER);
+    inactive.fg_stroke = Stroke::new(1.0, TEXT_PRIMARY);
+    inactive.rounding = egui::Rounding::ZERO;
+
+    let mut hovered = visuals.widgets.hovered.clone();
+    hovered.bg_fill = BG_HOVER;
+    hovered.weak_bg_fill = BG_SECONDARY;
+    hovered.bg_stroke = Stroke::new(1.0, Color32::from_rgb(70, 70, 70));
+    hovered.fg_stroke = Stroke::new(1.0, TEXT_PRIMARY);
+    hovered.rounding = egui::Rounding::ZERO;
+
+    let mut active = visuals.widgets.active.clone();
+    active.bg_fill = BG_ACTIVE;
+    active.weak_bg_fill = BG_ACTIVE;
+    active.bg_stroke = Stroke::new(1.0, Color32::from_rgb(23, 105, 185));
+    active.fg_stroke = Stroke::new(1.0, Color32::from_rgb(240, 240, 240));
+    active.rounding = egui::Rounding::ZERO;
+
+    visuals.widgets.noninteractive = noninteractive;
+    visuals.widgets.inactive = inactive;
+    visuals.widgets.hovered = hovered;
+    visuals.widgets.active = active.clone();
+    visuals.widgets.open = active;
+
+    visuals
+}
+
+pub fn primary_button<'a>(text: impl Into<egui::WidgetText>) -> egui::Button<'a> {
+    egui::Button::new(text).fill(BG_ACTIVE)
+}
+
+pub fn secondary_button<'a>(text: impl Into<egui::WidgetText>) -> egui::Button<'a> {
+    egui::Button::new(text).fill(BG_SECONDARY)
+}
+
+pub fn subtle_border() -> Stroke {
+    Stroke::new(1.0, BORDER)
+}
+
+pub const COLOR_TEXT_WEAK: Color32 = TEXT_WEAK;
+pub const COLOR_TEXT_PRIMARY: Color32 = TEXT_PRIMARY;
+pub const COLOR_SUCCESS: Color32 = Color32::from_rgb(0, 204, 102);
+pub const COLOR_DANGER: Color32 = Color32::from_rgb(204, 51, 51);
+pub const COLOR_PRIMARY: Color32 = Color32::from_rgb(25, 118, 210);
+pub const COLOR_PANEL: Color32 = BG_ROOT;
+pub const COLOR_HEADER: Color32 = Color32::from_rgb(42, 42, 42);


### PR DESCRIPTION
## Summary
- introduce a reusable graphite-inspired theme module and apply it at startup
- add a structured header, navigation sidebar, and retractable logs panel to refresh the global layout
- rebuild the chat content area with tab navigation, resource summaries, and updated inputs while extending state for navigation and logging

## Testing
- `cargo check`


------
https://chatgpt.com/codex/tasks/task_e_68d5062f6edc8333b9fbb7382da18670