### PR TITLE
Enhance chat UI and HuggingFace model gallery

### DIFF
--- a/src/ui/logs.rs
+++ b/src/ui/logs.rs
@@ -40,61 +40,64 @@ pub fn draw_logs_panel(ctx: &egui::Context, state: &mut AppState) {
                 egui::ScrollArea::both()
                     .auto_shrink([false, false])
                     .show(ui, |ui| {
-                        let header_bg = egui::Color32::from_rgb(36, 36, 36);
-                        let row_even = egui::Color32::from_rgb(38, 38, 38);
-                        let row_odd = egui::Color32::from_rgb(46, 46, 46);
+                        let header_bg = egui::Color32::from_rgb(40, 42, 48);
+                        let row_even = egui::Color32::from_rgb(36, 38, 44);
+                        let row_odd = egui::Color32::from_rgb(32, 34, 40);
+
+                        ui.set_width(ui.available_width());
 
                         TableBuilder::new(ui)
                             .striped(false)
                             .cell_layout(egui::Layout::left_to_right(egui::Align::Center))
-                            .column(Column::exact(36.0))
-                            .column(Column::exact(120.0))
+                            .column(Column::exact(48.0))
+                            .column(Column::exact(150.0))
                             .column(Column::remainder())
                             .column(Column::exact(120.0))
-                            .header(24.0, |mut header| {
+                            .header(28.0, |mut header| {
                                 header.col(|ui| {
-                                    ui.painter().rect_filled(ui.max_rect(), 0.0, header_bg);
+                                    paint_header_cell(ui, header_bg);
                                     ui.label(RichText::new("Estado").color(theme::COLOR_TEXT_WEAK));
                                 });
                                 header.col(|ui| {
-                                    ui.painter().rect_filled(ui.max_rect(), 0.0, header_bg);
+                                    paint_header_cell(ui, header_bg);
                                     ui.label(RichText::new("Origen").color(theme::COLOR_TEXT_WEAK));
                                 });
                                 header.col(|ui| {
-                                    ui.painter().rect_filled(ui.max_rect(), 0.0, header_bg);
+                                    paint_header_cell(ui, header_bg);
                                     ui.label(
                                         RichText::new("Detalle").color(theme::COLOR_TEXT_WEAK),
                                     );
                                 });
                                 header.col(|ui| {
-                                    ui.painter().rect_filled(ui.max_rect(), 0.0, header_bg);
+                                    paint_header_cell(ui, header_bg);
                                     ui.label(RichText::new("Hora").color(theme::COLOR_TEXT_WEAK));
                                 });
                             })
                             .body(|mut body| {
                                 for (index, entry) in state.activity_logs.iter().enumerate() {
                                     let bg = if index % 2 == 0 { row_even } else { row_odd };
-                                    body.row(26.0, |mut row| {
+                                    body.row(28.0, |mut row| {
                                         row.col(|ui| {
-                                            ui.painter().rect_filled(ui.max_rect(), 0.0, bg);
+                                            paint_cell(ui, bg);
                                             ui.label(status_badge(entry.status));
                                         });
                                         row.col(|ui| {
-                                            ui.painter().rect_filled(ui.max_rect(), 0.0, bg);
+                                            paint_cell(ui, bg);
                                             ui.label(
                                                 RichText::new(&entry.source)
-                                                    .color(theme::COLOR_TEXT_PRIMARY),
+                                                    .color(theme::COLOR_TEXT_PRIMARY)
+                                                    .strong(),
                                             );
                                         });
                                         row.col(|ui| {
-                                            ui.painter().rect_filled(ui.max_rect(), 0.0, bg);
+                                            paint_cell(ui, bg);
                                             ui.label(
                                                 RichText::new(&entry.message)
                                                     .color(theme::COLOR_TEXT_PRIMARY),
                                             );
                                         });
                                         row.col(|ui| {
-                                            ui.painter().rect_filled(ui.max_rect(), 0.0, bg);
+                                            paint_cell(ui, bg);
                                             ui.label(
                                                 RichText::new(&entry.timestamp)
                                                     .color(theme::COLOR_TEXT_WEAK),
@@ -157,4 +160,16 @@ fn status_badge(status: LogStatus) -> RichText {
         LogStatus::Error => RichText::new("❌ Error").color(theme::COLOR_DANGER),
         LogStatus::Running => RichText::new("⏳ En curso").color(theme::COLOR_PRIMARY),
     }
+}
+
+fn paint_header_cell(ui: &mut egui::Ui, color: egui::Color32) {
+    let rect = ui.max_rect();
+    ui.painter()
+        .rect_filled(rect, egui::Rounding::same(6.0), color);
+}
+
+fn paint_cell(ui: &mut egui::Ui, color: egui::Color32) {
+    let rect = ui.max_rect();
+    ui.painter()
+        .rect_filled(rect, egui::Rounding::same(4.0), color);
 }

--- a/src/ui/resource_sidebar.rs
+++ b/src/ui/resource_sidebar.rs
@@ -8,6 +8,7 @@ const ICON_JARVIS: &str = "\u{f0a0}"; // hard-drive
 const ICON_OPENAI: &str = "\u{f544}"; // robot
 const ICON_CLAUDE: &str = "\u{e2ca}"; // wand-magic-sparkles
 const ICON_GROQ: &str = "\u{f0e7}"; // bolt
+const COLOR_WARNING: Color32 = Color32::from_rgb(255, 196, 0);
 
 pub fn draw_resource_sidebar(ctx: &egui::Context, state: &AppState) {
     egui::SidePanel::right("resource_panel")
@@ -62,23 +63,27 @@ fn draw_resource_row(ui: &mut egui::Ui, row: &ResourceRow) {
             ui.label(RichText::new(&row.detail).color(theme::COLOR_TEXT_WEAK));
         });
         ui.add_space(ui.available_width());
-        match &row.indicator {
-            StatusIndicator::Led { color, label } => draw_led(ui, *color, label),
-            StatusIndicator::Text(text) => {
-                ui.label(text.clone());
-            }
-        }
+        ui.with_layout(egui::Layout::right_to_left(egui::Align::Center), |ui| {
+            let StatusIndicator::Led { color, status } = &row.indicator;
+            draw_led(ui, *color, status);
+        });
     });
 }
 
 fn draw_led(ui: &mut egui::Ui, color: Color32, label: &str) {
+    ui.spacing_mut().item_spacing.x = 6.0;
     let (rect, response) = ui.allocate_exact_size(egui::vec2(18.0, 18.0), egui::Sense::hover());
     let painter = ui.painter_at(rect);
     let center = rect.center();
     painter.circle_filled(center, 6.0, color);
     painter.circle_stroke(center, 6.0, Stroke::new(1.0, color.gamma_multiply(0.5)));
-    painter.circle_stroke(center, 7.0, Stroke::new(1.5, color.gamma_multiply(0.2)));
+    painter.circle_stroke(center, 7.0, Stroke::new(1.2, color.gamma_multiply(0.3)));
     response.on_hover_text(label);
+    ui.label(
+        RichText::new(label)
+            .color(theme::COLOR_TEXT_PRIMARY)
+            .size(12.0),
+    );
 }
 
 struct ResourceRow {
@@ -89,8 +94,7 @@ struct ResourceRow {
 }
 
 enum StatusIndicator {
-    Led { color: Color32, label: String },
-    Text(RichText),
+    Led { color: Color32, status: String },
 }
 
 fn resource_rows(state: &AppState) -> Vec<ResourceRow> {
@@ -102,52 +106,117 @@ fn resource_rows(state: &AppState) -> Vec<ResourceRow> {
                 "Memoria límite {:.1} GB · Disco {:.1} GB",
                 state.resource_memory_limit_gb, state.resource_disk_limit_gb
             ),
-            indicator: status_indicator(None, "Operativo"),
+            indicator: StatusIndicator::Led {
+                color: theme::COLOR_SUCCESS,
+                status: "Operativo".to_string(),
+            },
         },
         ResourceRow {
             icon: ICON_JARVIS,
             name: "Jarvis",
             detail: format!("Ruta {}", state.jarvis_model_path),
-            indicator: status_indicator(state.jarvis_status.as_ref(), "Listo"),
+            indicator: jarvis_indicator(state),
         },
         ResourceRow {
             icon: ICON_OPENAI,
             name: "OpenAI",
             detail: format!("Modelo {}", state.openai_default_model),
-            indicator: status_indicator(state.openai_test_status.as_ref(), "Disponible"),
+            indicator: provider_indicator(
+                state.openai_test_status.as_ref(),
+                state.config.openai.api_key.as_ref().map(|s| s.as_str()),
+                "OpenAI",
+                "Pendiente de prueba",
+            ),
         },
         ResourceRow {
             icon: ICON_CLAUDE,
             name: "Claude",
             detail: format!("Modelo {}", state.claude_default_model),
-            indicator: status_indicator(state.anthropic_test_status.as_ref(), "Disponible"),
+            indicator: provider_indicator(
+                state.anthropic_test_status.as_ref(),
+                state.config.anthropic.api_key.as_ref().map(|s| s.as_str()),
+                "Anthropic",
+                "Pendiente de prueba",
+            ),
         },
         ResourceRow {
             icon: ICON_GROQ,
             name: "Groq",
             detail: format!("Modelo {}", state.groq_default_model),
-            indicator: status_indicator(state.groq_test_status.as_ref(), "Disponible"),
+            indicator: provider_indicator(
+                state.groq_test_status.as_ref(),
+                state.config.groq.api_key.as_ref().map(|s| s.as_str()),
+                "Groq",
+                "Pendiente de prueba",
+            ),
         },
     ]
 }
 
-fn status_indicator(message: Option<&String>, fallback: &str) -> StatusIndicator {
-    let label = message.cloned().unwrap_or_else(|| fallback.to_string());
-    let color = status_color(&label);
-    if label.to_lowercase().contains("disponible") {
-        StatusIndicator::Led { color, label }
+fn jarvis_indicator(state: &AppState) -> StatusIndicator {
+    if let Some(status) = &state.jarvis_status {
+        return led_from_message(status);
+    }
+
+    if state.installed_jarvis_models.is_empty() {
+        StatusIndicator::Led {
+            color: COLOR_WARNING,
+            status: "Sin modelos instalados".to_string(),
+        }
     } else {
-        StatusIndicator::Text(RichText::new(label).color(color))
+        StatusIndicator::Led {
+            color: theme::COLOR_SUCCESS,
+            status: format!("{} modelos listos", state.installed_jarvis_models.len()),
+        }
     }
 }
 
-fn status_color(label: &str) -> Color32 {
-    let lower = label.to_lowercase();
-    if lower.contains("error") || lower.contains("fail") {
-        theme::COLOR_DANGER
-    } else if lower.contains("index") || lower.contains("sync") {
-        theme::COLOR_PRIMARY
+fn provider_indicator(
+    status: Option<&String>,
+    api_key: Option<&str>,
+    provider: &str,
+    fallback: &str,
+) -> StatusIndicator {
+    if let Some(message) = status {
+        return led_from_message(message);
+    }
+
+    let has_key = api_key.is_some_and(|key| !key.trim().is_empty());
+    if has_key {
+        StatusIndicator::Led {
+            color: COLOR_WARNING,
+            status: fallback.to_string(),
+        }
     } else {
+        StatusIndicator::Led {
+            color: COLOR_WARNING,
+            status: format!("{} sin API key", provider),
+        }
+    }
+}
+
+fn led_from_message(message: &str) -> StatusIndicator {
+    let lower = message.to_lowercase();
+    let color = if lower.contains("error")
+        || lower.contains("fail")
+        || lower.contains("timeout")
+        || lower.contains("rechaz")
+    {
+        theme::COLOR_DANGER
+    } else if lower.contains("alcanzable")
+        || lower.contains("reachable")
+        || lower.contains("ok")
+        || lower.contains("complet")
+        || lower.contains("instal")
+        || lower.contains("disponible")
+    {
         theme::COLOR_SUCCESS
+    } else {
+        COLOR_WARNING
+    };
+
+    StatusIndicator::Led {
+        color,
+        status: message.to_string(),
     }
 }


### PR DESCRIPTION
## Summary
- Modernize the chat timeline with timestamped bubbles, quick actions, and a refreshed composer that anchors to the bottom and exposes @-mention shortcuts and code insertion.
- Extend HuggingFace support by consuming detailed model metadata, persisting structured results in state, and rendering a premium-aware gallery with install actions and metrics.
- Improve peripheral surfaces by rebuilding the resource sidebar LED indicators and expanding the activity log panel into a full-width striped table for clarity.

## Testing
- `cargo check`


------
https://chatgpt.com/codex/tasks/task_e_68d516e517ec8333971dd7c0d61b33fd