### PR TITLE
Improve layout constraints and resizable logs table

### DIFF
--- a/src/ui/chat.rs
+++ b/src/ui/chat.rs
@@ -42,11 +42,23 @@ pub fn draw_main_content(ctx: &egui::Context, state: &mut AppState) {
 
 fn draw_chat_view(ui: &mut egui::Ui, state: &mut AppState) {
     let available = ui.available_size();
-    ui.set_min_size(available);
-    ui.with_layout(egui::Layout::bottom_up(egui::Align::LEFT), |ui| {
+    let (rect, _) = ui.allocate_exact_size(available, egui::Sense::hover());
+    let mut content_ui = ui.child_ui(rect, egui::Layout::top_down(egui::Align::LEFT));
+    content_ui.set_clip_rect(rect);
+
+    content_ui.with_layout(egui::Layout::bottom_up(egui::Align::LEFT), |ui| {
         draw_chat_input(ui, state);
         ui.add_space(16.0);
-        draw_chat_history(ui, state);
+
+        let history_height = ui.available_height().max(0.0);
+        let history_width = ui.available_width();
+        if history_height > 0.0 && history_width > 0.0 {
+            ui.allocate_ui(egui::vec2(history_width, history_height), |ui| {
+                draw_chat_history(ui, state);
+            });
+        } else {
+            draw_chat_history(ui, state);
+        }
     });
 }
 
@@ -75,7 +87,6 @@ fn draw_preferences_view(ui: &mut egui::Ui, state: &mut AppState) {
 }
 
 fn draw_chat_history(ui: &mut egui::Ui, state: &mut AppState) {
-    let available_height = ui.available_height().max(260.0);
     let mut pending_actions = Vec::new();
 
     egui::Frame::none()
@@ -84,6 +95,9 @@ fn draw_chat_history(ui: &mut egui::Ui, state: &mut AppState) {
         .rounding(egui::Rounding::same(16.0))
         .inner_margin(egui::Margin::symmetric(20.0, 18.0))
         .show(ui, |ui| {
+            let available_height = ui.available_height();
+            let available_width = ui.available_width();
+            ui.set_width(available_width);
             ui.set_min_height(available_height);
             egui::ScrollArea::vertical()
                 .stick_to_bottom(true)

--- a/src/ui/logs.rs
+++ b/src/ui/logs.rs
@@ -49,10 +49,11 @@ pub fn draw_logs_panel(ctx: &egui::Context, state: &mut AppState) {
                         TableBuilder::new(ui)
                             .striped(false)
                             .cell_layout(egui::Layout::left_to_right(egui::Align::Center))
-                            .column(Column::exact(48.0))
-                            .column(Column::exact(150.0))
-                            .column(Column::remainder())
-                            .column(Column::exact(120.0))
+                            .column(Column::initial(64.0).resizable(true))
+                            .column(Column::initial(160.0).resizable(true))
+                            .column(Column::remainder().resizable(true))
+                            .column(Column::initial(140.0).resizable(true))
+                            .resizable(true)
                             .header(28.0, |mut header| {
                                 header.col(|ui| {
                                     paint_header_cell(ui, header_bg);

--- a/src/ui/sidebar.rs
+++ b/src/ui/sidebar.rs
@@ -260,13 +260,17 @@ fn draw_nav_node(ui: &mut egui::Ui, state: &mut AppState, node: &NavNode, depth:
         painter.rect_filled(rect.shrink(1.0), 4.0, color);
     }
 
+    let content_rect = egui::Rect::from_min_max(
+        egui::pos2(rect.min.x + 12.0 + indent, rect.min.y),
+        egui::pos2(rect.max.x - 12.0, rect.max.y),
+    )
+    .intersect(rect);
+
     let mut content_ui = ui.child_ui(
-        egui::Rect::from_min_max(
-            egui::pos2(rect.min.x + 12.0 + indent, rect.min.y),
-            egui::pos2(rect.max.x - 12.0, rect.max.y),
-        ),
+        content_rect,
         egui::Layout::left_to_right(egui::Align::Center),
     );
+    content_ui.set_clip_rect(content_rect);
 
     if !node.children.is_empty() {
         let arrow = if is_expanded {


### PR DESCRIPTION
## Summary
- constrain the chat area to the visible viewport so the history and input remain inside the window
- clamp sidebar row content to the panel bounds to keep labels aligned
- allow resizing of the registry log table columns while using the full width

## Testing
- cargo fmt
- cargo check

------
https://chatgpt.com/codex/tasks/task_e_68d51d8209408333846d6a829d056c49