### PR TITLE
Ajustes de layout para chat y panel de logs

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -10,7 +10,9 @@ fn main() -> anyhow::Result<()> {
     // Inicializa el logger, config, etc. aquí si es necesario
 
     let options = eframe::NativeOptions {
-        viewport: egui::ViewportBuilder::default().with_inner_size(egui::vec2(1280.0, 800.0)),
+        viewport: egui::ViewportBuilder::default()
+            .with_inner_size(egui::vec2(1280.0, 800.0))
+            .with_maximized(true),
         ..Default::default()
     };
 

--- a/src/ui/chat.rs
+++ b/src/ui/chat.rs
@@ -2,7 +2,7 @@ use crate::api::github;
 use crate::state::{AppState, ChatMessage, MainView, PreferenceSection, AVAILABLE_CUSTOM_ACTIONS};
 use eframe::egui::{self, Color32, RichText};
 
-use super::theme;
+use super::{logs, theme};
 
 const ICON_USER: &str = "\u{f007}"; // user
 const ICON_SYSTEM: &str = "\u{f085}"; // cogs
@@ -34,9 +34,13 @@ pub fn draw_main_content(ctx: &egui::Context, state: &mut AppState) {
                 .stroke(theme::subtle_border())
                 .inner_margin(egui::Margin::symmetric(20.0, 16.0)),
         )
-        .show(ctx, |ui| match state.active_main_view {
-            MainView::ChatMultimodal => draw_chat_view(ui, state),
-            MainView::Preferences => draw_preferences_view(ui, state),
+        .show(ctx, |ui| {
+            logs::draw_logs_panel(ui, state);
+
+            match state.active_main_view {
+                MainView::ChatMultimodal => draw_chat_view(ui, state),
+                MainView::Preferences => draw_preferences_view(ui, state),
+            }
         });
 }
 
@@ -44,6 +48,8 @@ fn draw_chat_view(ui: &mut egui::Ui, state: &mut AppState) {
     let available = ui.available_size();
     let (rect, _) = ui.allocate_exact_size(available, egui::Sense::hover());
     let mut content_ui = ui.child_ui(rect, egui::Layout::top_down(egui::Align::LEFT));
+    content_ui.set_min_width(available.x);
+    content_ui.set_min_height(available.y);
     content_ui.set_clip_rect(rect);
 
     content_ui.with_layout(egui::Layout::bottom_up(egui::Align::LEFT), |ui| {

--- a/src/ui/logs.rs
+++ b/src/ui/logs.rs
@@ -7,138 +7,147 @@ use super::theme;
 
 const ICON_LOGS: &str = "\u{f0f6}"; // file-lines
 
-pub fn draw_logs_panel(ctx: &egui::Context, state: &mut AppState) {
+pub fn draw_logs_panel(ui: &mut egui::Ui, state: &mut AppState) {
+    let mut panel = egui::TopBottomPanel::bottom("logs_panel");
     if state.logs_panel_expanded {
-        egui::TopBottomPanel::bottom("logs_panel")
+        panel = panel
             .frame(expanded_frame())
             .min_height(160.0)
             .max_height(360.0)
-            .resizable(true)
-            .show(ctx, |ui| {
-                ui.horizontal(|ui| {
-                    ui.spacing_mut().item_spacing.x = 10.0;
-                    ui.label(
-                        RichText::new(ICON_LOGS)
-                            .font(theme::icon_font(16.0))
-                            .color(theme::COLOR_PRIMARY),
-                    );
-                    ui.heading(
-                        RichText::new("Registros & tareas").color(theme::COLOR_TEXT_PRIMARY),
-                    );
-                    ui.add_space(ui.available_width());
-                    let hide_label =
-                        RichText::new("Ocultar panel").color(theme::COLOR_TEXT_PRIMARY);
-                    if ui
-                        .add_sized([130.0, 26.0], theme::secondary_button(hide_label))
-                        .clicked()
-                    {
-                        state.logs_panel_expanded = false;
-                    }
-                });
-                ui.add_space(6.0);
-
-                egui::ScrollArea::both()
-                    .auto_shrink([false, false])
-                    .show(ui, |ui| {
-                        let header_bg = egui::Color32::from_rgb(40, 42, 48);
-                        let row_even = egui::Color32::from_rgb(36, 38, 44);
-                        let row_odd = egui::Color32::from_rgb(32, 34, 40);
-
-                        ui.set_width(ui.available_width());
-
-                        TableBuilder::new(ui)
-                            .striped(false)
-                            .cell_layout(egui::Layout::left_to_right(egui::Align::Center))
-                            .column(Column::initial(64.0).resizable(true))
-                            .column(Column::initial(160.0).resizable(true))
-                            .column(Column::remainder().resizable(true))
-                            .column(Column::initial(140.0).resizable(true))
-                            .resizable(true)
-                            .header(28.0, |mut header| {
-                                header.col(|ui| {
-                                    paint_header_cell(ui, header_bg);
-                                    ui.label(RichText::new("Estado").color(theme::COLOR_TEXT_WEAK));
-                                });
-                                header.col(|ui| {
-                                    paint_header_cell(ui, header_bg);
-                                    ui.label(RichText::new("Origen").color(theme::COLOR_TEXT_WEAK));
-                                });
-                                header.col(|ui| {
-                                    paint_header_cell(ui, header_bg);
-                                    ui.label(
-                                        RichText::new("Detalle").color(theme::COLOR_TEXT_WEAK),
-                                    );
-                                });
-                                header.col(|ui| {
-                                    paint_header_cell(ui, header_bg);
-                                    ui.label(RichText::new("Hora").color(theme::COLOR_TEXT_WEAK));
-                                });
-                            })
-                            .body(|mut body| {
-                                for (index, entry) in state.activity_logs.iter().enumerate() {
-                                    let bg = if index % 2 == 0 { row_even } else { row_odd };
-                                    body.row(28.0, |mut row| {
-                                        row.col(|ui| {
-                                            paint_cell(ui, bg);
-                                            ui.label(status_badge(entry.status));
-                                        });
-                                        row.col(|ui| {
-                                            paint_cell(ui, bg);
-                                            ui.label(
-                                                RichText::new(&entry.source)
-                                                    .color(theme::COLOR_TEXT_PRIMARY)
-                                                    .strong(),
-                                            );
-                                        });
-                                        row.col(|ui| {
-                                            paint_cell(ui, bg);
-                                            ui.label(
-                                                RichText::new(&entry.message)
-                                                    .color(theme::COLOR_TEXT_PRIMARY),
-                                            );
-                                        });
-                                        row.col(|ui| {
-                                            paint_cell(ui, bg);
-                                            ui.label(
-                                                RichText::new(&entry.timestamp)
-                                                    .color(theme::COLOR_TEXT_WEAK),
-                                            );
-                                        });
-                                    });
-                                }
-                            });
-                    });
-            });
+            .resizable(true);
     } else {
-        egui::TopBottomPanel::bottom("logs_panel")
+        panel = panel
             .frame(collapsed_frame())
             .exact_height(38.0)
-            .resizable(false)
-            .show(ctx, |ui| {
-                ui.horizontal(|ui| {
-                    ui.spacing_mut().item_spacing.x = 10.0;
-                    ui.label(
-                        RichText::new(ICON_LOGS)
-                            .font(theme::icon_font(16.0))
-                            .color(theme::COLOR_PRIMARY),
-                    );
-                    ui.label(
-                        RichText::new("Registros & tareas")
-                            .color(theme::COLOR_TEXT_PRIMARY)
-                            .strong(),
-                    );
-                    ui.add_space(ui.available_width());
-                    let show_label =
-                        RichText::new("Mostrar panel").color(theme::COLOR_TEXT_PRIMARY);
-                    if ui
-                        .add_sized([150.0, 26.0], theme::secondary_button(show_label))
-                        .clicked()
-                    {
-                        state.logs_panel_expanded = true;
-                    }
-                });
-            });
+            .resizable(false);
     }
+
+    panel.show_inside(ui, |ui| {
+        if state.logs_panel_expanded {
+            draw_expanded_logs(ui, state);
+        } else {
+            draw_collapsed_logs(ui, state);
+        }
+    });
+}
+
+fn draw_expanded_logs(ui: &mut egui::Ui, state: &mut AppState) {
+    ui.set_width(ui.available_width());
+    ui.set_min_height(ui.available_height());
+
+    ui.horizontal(|ui| {
+        ui.spacing_mut().item_spacing.x = 10.0;
+        ui.label(
+            RichText::new(ICON_LOGS)
+                .font(theme::icon_font(16.0))
+                .color(theme::COLOR_PRIMARY),
+        );
+        ui.heading(RichText::new("Registros & tareas").color(theme::COLOR_TEXT_PRIMARY));
+        ui.add_space(ui.available_width());
+        let hide_label = RichText::new("Ocultar panel").color(theme::COLOR_TEXT_PRIMARY);
+        if ui
+            .add_sized([130.0, 26.0], theme::secondary_button(hide_label))
+            .clicked()
+        {
+            state.logs_panel_expanded = false;
+        }
+    });
+    ui.add_space(6.0);
+
+    let table_size = ui.available_size();
+    ui.allocate_ui(table_size, |ui| {
+        egui::ScrollArea::both()
+            .auto_shrink([false, false])
+            .show(ui, |ui| {
+                ui.set_width(ui.available_width());
+                ui.set_min_height(table_size.y);
+                draw_logs_table(ui, state);
+            });
+    });
+}
+
+fn draw_collapsed_logs(ui: &mut egui::Ui, state: &mut AppState) {
+    ui.horizontal(|ui| {
+        ui.spacing_mut().item_spacing.x = 10.0;
+        ui.label(
+            RichText::new(ICON_LOGS)
+                .font(theme::icon_font(16.0))
+                .color(theme::COLOR_PRIMARY),
+        );
+        ui.label(
+            RichText::new("Registros & tareas")
+                .color(theme::COLOR_TEXT_PRIMARY)
+                .strong(),
+        );
+        ui.add_space(ui.available_width());
+        let show_label = RichText::new("Mostrar panel").color(theme::COLOR_TEXT_PRIMARY);
+        if ui
+            .add_sized([150.0, 26.0], theme::secondary_button(show_label))
+            .clicked()
+        {
+            state.logs_panel_expanded = true;
+        }
+    });
+}
+
+fn draw_logs_table(ui: &mut egui::Ui, state: &AppState) {
+    let header_bg = egui::Color32::from_rgb(40, 42, 48);
+    let row_even = egui::Color32::from_rgb(36, 38, 44);
+    let row_odd = egui::Color32::from_rgb(32, 34, 40);
+
+    TableBuilder::new(ui)
+        .striped(false)
+        .cell_layout(egui::Layout::left_to_right(egui::Align::Center))
+        .column(Column::initial(64.0).resizable(true))
+        .column(Column::initial(160.0).resizable(true))
+        .column(Column::remainder().resizable(true))
+        .column(Column::initial(140.0).resizable(true))
+        .resizable(true)
+        .header(28.0, |mut header| {
+            header.col(|ui| {
+                paint_header_cell(ui, header_bg);
+                ui.label(RichText::new("Estado").color(theme::COLOR_TEXT_WEAK));
+            });
+            header.col(|ui| {
+                paint_header_cell(ui, header_bg);
+                ui.label(RichText::new("Origen").color(theme::COLOR_TEXT_WEAK));
+            });
+            header.col(|ui| {
+                paint_header_cell(ui, header_bg);
+                ui.label(RichText::new("Detalle").color(theme::COLOR_TEXT_WEAK));
+            });
+            header.col(|ui| {
+                paint_header_cell(ui, header_bg);
+                ui.label(RichText::new("Hora").color(theme::COLOR_TEXT_WEAK));
+            });
+        })
+        .body(|mut body| {
+            for (index, entry) in state.activity_logs.iter().enumerate() {
+                let bg = if index % 2 == 0 { row_even } else { row_odd };
+                body.row(28.0, |mut row| {
+                    row.col(|ui| {
+                        paint_cell(ui, bg);
+                        ui.label(status_badge(entry.status));
+                    });
+                    row.col(|ui| {
+                        paint_cell(ui, bg);
+                        ui.label(
+                            RichText::new(&entry.source)
+                                .color(theme::COLOR_TEXT_PRIMARY)
+                                .strong(),
+                        );
+                    });
+                    row.col(|ui| {
+                        paint_cell(ui, bg);
+                        ui.label(RichText::new(&entry.message).color(theme::COLOR_TEXT_PRIMARY));
+                    });
+                    row.col(|ui| {
+                        paint_cell(ui, bg);
+                        ui.label(RichText::new(&entry.timestamp).color(theme::COLOR_TEXT_WEAK));
+                    });
+                });
+            }
+        });
 }
 
 fn expanded_frame() -> egui::Frame {

--- a/src/ui/mod.rs
+++ b/src/ui/mod.rs
@@ -14,7 +14,6 @@ pub fn draw_ui(ctx: &egui::Context, state: &mut AppState) {
     header::draw_header(ctx, state);
     sidebar::draw_sidebar(ctx, state);
     resource_sidebar::draw_resource_sidebar(ctx, state);
-    logs::draw_logs_panel(ctx, state);
     chat::draw_main_content(ctx, state);
 
     modals::draw_settings_modal(ctx, state);


### PR DESCRIPTION
## Summary
- integrar el panel inferior de registros dentro del panel central para que quede entre las barras laterales
- ajustar el layout del chat multimodal para que use todo el alto disponible y respete el área reservada para los registros
- abrir la ventana nativa maximizada por defecto

## Testing
- cargo fmt
- cargo check

------
https://chatgpt.com/codex/tasks/task_e_68d521f1a06c83338d18f7dfab63f1bc