### PR TITLE
Add OpenRouter and Ollama integrations for local models

### DIFF
--- a/src/api/mod.rs
+++ b/src/api/mod.rs
@@ -3,6 +3,8 @@ pub mod github;
 pub mod groq;
 pub mod huggingface;
 pub mod local;
+pub mod ollama;
 pub mod openai;
+pub mod openrouter;
 
 // Podrías definir un trait común `LLMClient` aquí para unificar las APIs.

--- a/src/api/ollama.rs
+++ b/src/api/ollama.rs
@@ -1,0 +1,129 @@
+use std::process::Command;
+use std::time::Duration;
+
+use anyhow::{anyhow, Context, Result};
+use reqwest::blocking::Client;
+use serde::Deserialize;
+
+use crate::local_providers::{LocalModelCard, LocalModelProvider};
+
+#[derive(Debug, Deserialize, Default)]
+struct OllamaTagsResponse {
+    #[serde(default)]
+    models: Vec<OllamaModel>,
+}
+
+#[derive(Debug, Deserialize, Default)]
+struct OllamaModel {
+    name: String,
+    #[serde(default)]
+    size: Option<String>,
+    #[serde(default)]
+    details: Option<OllamaDetails>,
+}
+
+#[derive(Debug, Deserialize, Default)]
+struct OllamaDetails {
+    #[serde(default)]
+    family: Option<String>,
+    #[serde(default, rename = "parameter_size")]
+    parameters: Option<String>,
+    #[serde(default, rename = "quantization_level")]
+    quantization: Option<String>,
+}
+
+fn resolve_host(token: Option<&str>) -> String {
+    let host = token.unwrap_or_default().trim();
+    if host.is_empty() {
+        "http://localhost:11434".to_string()
+    } else {
+        host.trim_end_matches('/').to_string()
+    }
+}
+
+/// Query the Ollama daemon for the list of available model tags.
+pub fn search_models(query: &str, token: Option<&str>) -> Result<Vec<LocalModelCard>> {
+    let host = resolve_host(token);
+
+    let client = Client::builder()
+        .timeout(Duration::from_secs(15))
+        .user_agent("JungleMonkAI/0.1")
+        .build()
+        .context("No se pudo crear el cliente HTTP para Ollama")?;
+
+    let url = format!("{}/api/tags", host);
+    let response: OllamaTagsResponse = client
+        .get(&url)
+        .send()
+        .context("No se pudo consultar la lista de modelos de Ollama")?
+        .error_for_status()
+        .context("Ollama devolvió un estado de error")?
+        .json()
+        .context("No se pudo interpretar la respuesta de Ollama")?;
+
+    let needle = query.to_lowercase();
+
+    Ok(response
+        .models
+        .into_iter()
+        .filter(|model| model.name.to_lowercase().contains(&needle))
+        .map(|model| {
+            let details = model.details.unwrap_or_default();
+
+            let mut tags = Vec::new();
+            if let Some(ref family) = details.family {
+                tags.push(family.clone());
+            }
+            if let Some(ref parameters) = details.parameters {
+                tags.push(parameters.clone());
+            }
+            if let Some(ref quantization) = details.quantization {
+                tags.push(quantization.clone());
+            }
+            if let Some(size) = model.size {
+                tags.push(size);
+            }
+
+            LocalModelCard {
+                provider: LocalModelProvider::Ollama,
+                id: model.name,
+                author: details.family,
+                pipeline_tag: Some("text-generation".to_string()),
+                tags,
+                likes: None,
+                downloads: None,
+                requires_token: false,
+                description: None,
+            }
+        })
+        .collect())
+}
+
+/// Attempt to pull a model using the local `ollama` binary.
+pub fn pull_model(model: &str, token: Option<&str>) -> Result<()> {
+    let host = resolve_host(token);
+
+    let mut command = Command::new("ollama");
+    command.arg("pull").arg(model);
+
+    if host != "http://localhost:11434" {
+        command.env("OLLAMA_HOST", &host);
+    }
+
+    let output = command
+        .output()
+        .context("No se pudo invocar al binario de Ollama")?;
+
+    if !output.status.success() {
+        let stdout = String::from_utf8_lossy(&output.stdout);
+        let stderr = String::from_utf8_lossy(&output.stderr);
+        return Err(anyhow!(
+            "ollama pull falló (salida: {} {}): {}",
+            stdout.trim(),
+            stderr.trim(),
+            output.status
+        ));
+    }
+
+    Ok(())
+}

--- a/src/api/openrouter.rs
+++ b/src/api/openrouter.rs
@@ -1,0 +1,110 @@
+use std::time::Duration;
+
+use anyhow::{Context, Result};
+use reqwest::blocking::Client;
+use serde::Deserialize;
+
+use crate::local_providers::{LocalModelCard, LocalModelProvider};
+
+#[derive(Debug, Deserialize)]
+struct OpenRouterResponse {
+    #[serde(default)]
+    data: Vec<OpenRouterModel>,
+}
+
+#[derive(Debug, Deserialize)]
+struct OpenRouterModel {
+    id: String,
+    #[serde(default)]
+    name: Option<String>,
+    #[serde(default)]
+    description: Option<String>,
+    #[serde(default)]
+    architecture: Option<OpenRouterArchitecture>,
+}
+
+#[derive(Debug, Deserialize, Default)]
+struct OpenRouterArchitecture {
+    #[serde(default)]
+    modality: Option<String>,
+    #[serde(default)]
+    input_modalities: Vec<String>,
+    #[serde(default)]
+    output_modalities: Vec<String>,
+}
+
+/// Fetches the public OpenRouter catalog and filters it using the provided query.
+pub fn search_models(query: &str) -> Result<Vec<LocalModelCard>> {
+    let client = Client::builder()
+        .timeout(Duration::from_secs(30))
+        .user_agent("JungleMonkAI/0.1")
+        .build()
+        .context("No se pudo crear el cliente HTTP para OpenRouter")?;
+
+    let response: OpenRouterResponse = client
+        .get("https://openrouter.ai/api/v1/models")
+        .send()
+        .context("No se pudo enviar la petición a OpenRouter")?
+        .error_for_status()
+        .context("OpenRouter devolvió un estado de error")?
+        .json()
+        .context("No se pudo interpretar la respuesta de OpenRouter")?;
+
+    let needle = query.to_lowercase();
+
+    Ok(response
+        .data
+        .into_iter()
+        .filter(|model| {
+            model.id.to_lowercase().contains(&needle)
+                || model
+                    .name
+                    .as_ref()
+                    .map(|value| value.to_lowercase().contains(&needle))
+                    .unwrap_or(false)
+                || model
+                    .description
+                    .as_ref()
+                    .map(|value| value.to_lowercase().contains(&needle))
+                    .unwrap_or(false)
+        })
+        .map(|model| {
+            let mut tags = Vec::new();
+            if let Some(arch) = model.architecture.as_ref() {
+                if let Some(modality) = arch.modality.as_ref() {
+                    tags.push(modality.to_string());
+                }
+                tags.extend(
+                    arch.input_modalities
+                        .iter()
+                        .map(|value| format!("input:{}", value.to_lowercase())),
+                );
+                tags.extend(
+                    arch.output_modalities
+                        .iter()
+                        .map(|value| format!("output:{}", value.to_lowercase())),
+                );
+            }
+
+            let author = model
+                .name
+                .as_ref()
+                .and_then(|name| name.split(':').next())
+                .map(|value| value.trim().to_string())
+                .filter(|value| !value.is_empty());
+
+            LocalModelCard {
+                provider: LocalModelProvider::OpenRouter,
+                id: model.id,
+                author,
+                pipeline_tag: None,
+                tags,
+                likes: None,
+                downloads: None,
+                requires_token: true,
+                description: model.description,
+            }
+        })
+        .take(50)
+        .collect())
+}

--- a/src/config.rs
+++ b/src/config.rs
@@ -30,6 +30,7 @@ pub struct JarvisConfig {
     pub model_path: String,
     pub install_dir: String,
     pub auto_start: bool,
+    /// Modelos instalados codificados como `proveedor::identificador`.
     pub installed_models: Vec<String>,
     #[serde(default)]
     pub active_model: Option<String>,
@@ -59,9 +60,9 @@ impl JarvisConfig {
     }
 }
 
-/// Preferencias relacionadas con Hugging Face.
+/// Preferencias relacionadas con catálogos de modelos descargables.
 #[derive(Debug, Clone, Serialize, Deserialize, Default)]
-pub struct HuggingFaceConfig {
+pub struct ModelProviderConfig {
     pub access_token: Option<String>,
     pub last_search_query: String,
 }
@@ -87,7 +88,17 @@ pub struct AppConfig {
     pub projects: Vec<String>,
     pub selected_project: Option<usize>,
     pub jarvis: JarvisConfig,
-    pub huggingface: HuggingFaceConfig,
+    pub huggingface: ModelProviderConfig,
+    #[serde(default)]
+    pub github_models: ModelProviderConfig,
+    #[serde(default)]
+    pub replicate: ModelProviderConfig,
+    #[serde(default)]
+    pub ollama: ModelProviderConfig,
+    #[serde(default)]
+    pub openrouter: ModelProviderConfig,
+    #[serde(default)]
+    pub modelscope: ModelProviderConfig,
 }
 
 impl Default for AppConfig {
@@ -127,7 +138,12 @@ impl Default for AppConfig {
             projects: vec!["Autonomous Agent".to_string(), "RAG Pipeline".to_string()],
             selected_project: Some(0),
             jarvis: JarvisConfig::default(),
-            huggingface: HuggingFaceConfig::default(),
+            huggingface: ModelProviderConfig::default(),
+            github_models: ModelProviderConfig::default(),
+            replicate: ModelProviderConfig::default(),
+            ollama: ModelProviderConfig::default(),
+            openrouter: ModelProviderConfig::default(),
+            modelscope: ModelProviderConfig::default(),
         }
     }
 }

--- a/src/local_providers.rs
+++ b/src/local_providers.rs
@@ -1,0 +1,169 @@
+use std::fmt;
+
+/// Proveedores soportados para instalar modelos locales en Jarvis.
+#[derive(Clone, Copy, Debug, PartialEq, Eq, PartialOrd, Ord, Hash)]
+pub enum LocalModelProvider {
+    HuggingFace,
+    GithubModels,
+    Replicate,
+    Ollama,
+    OpenRouter,
+    Modelscope,
+}
+
+impl LocalModelProvider {
+    pub const ALL: [LocalModelProvider; 6] = [
+        LocalModelProvider::HuggingFace,
+        LocalModelProvider::GithubModels,
+        LocalModelProvider::Replicate,
+        LocalModelProvider::Ollama,
+        LocalModelProvider::OpenRouter,
+        LocalModelProvider::Modelscope,
+    ];
+
+    /// Identificador estable utilizado para serializar el proveedor.
+    pub fn key(self) -> &'static str {
+        match self {
+            LocalModelProvider::HuggingFace => "huggingface",
+            LocalModelProvider::GithubModels => "github_models",
+            LocalModelProvider::Replicate => "replicate",
+            LocalModelProvider::Ollama => "ollama",
+            LocalModelProvider::OpenRouter => "openrouter",
+            LocalModelProvider::Modelscope => "modelscope",
+        }
+    }
+
+    /// Nombre amigable mostrado en la interfaz.
+    pub fn display_name(self) -> &'static str {
+        match self {
+            LocalModelProvider::HuggingFace => "Hugging Face",
+            LocalModelProvider::GithubModels => "GitHub Models",
+            LocalModelProvider::Replicate => "Replicate",
+            LocalModelProvider::Ollama => "Ollama",
+            LocalModelProvider::OpenRouter => "OpenRouter",
+            LocalModelProvider::Modelscope => "ModelScope",
+        }
+    }
+
+    /// Etiqueta del campo para configurar tokens o credenciales.
+    pub fn token_label(self) -> &'static str {
+        match self {
+            LocalModelProvider::HuggingFace => "Token de acceso (opcional)",
+            LocalModelProvider::GithubModels => "GitHub token (modelo)",
+            LocalModelProvider::Replicate => "Replicate API token",
+            LocalModelProvider::Ollama => "Host / token de Ollama",
+            LocalModelProvider::OpenRouter => "OpenRouter API token",
+            LocalModelProvider::Modelscope => "ModelScope access key",
+        }
+    }
+
+    /// Mensaje de ayuda para el campo de búsqueda del catálogo.
+    pub fn search_hint(self) -> &'static str {
+        match self {
+            LocalModelProvider::HuggingFace => "Busca modelos, ej. whisper, mistral, diffusion",
+            LocalModelProvider::GithubModels => "Busca modelos alojados por GitHub",
+            LocalModelProvider::Replicate => "Busca modelos públicos de Replicate",
+            LocalModelProvider::Ollama => "Busca modelos disponibles en tu servidor Ollama",
+            LocalModelProvider::OpenRouter => "Busca modelos disponibles en OpenRouter",
+            LocalModelProvider::Modelscope => "Busca modelos publicados en ModelScope",
+        }
+    }
+
+    /// Algunos proveedores requieren token para listar modelos incluso de forma pública.
+    pub fn requires_token(self) -> bool {
+        matches!(
+            self,
+            LocalModelProvider::GithubModels
+                | LocalModelProvider::Replicate
+                | LocalModelProvider::OpenRouter
+                | LocalModelProvider::Modelscope
+        )
+    }
+}
+
+impl fmt::Display for LocalModelProvider {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str(self.display_name())
+    }
+}
+
+/// Representa una tarjeta dentro de la galería de modelos.
+#[derive(Clone, Debug)]
+pub struct LocalModelCard {
+    pub provider: LocalModelProvider,
+    pub id: String,
+    pub author: Option<String>,
+    pub pipeline_tag: Option<String>,
+    pub tags: Vec<String>,
+    pub likes: Option<u64>,
+    pub downloads: Option<u64>,
+    pub requires_token: bool,
+    pub description: Option<String>,
+}
+
+impl LocalModelCard {
+    pub fn placeholder(provider: LocalModelProvider, id: impl Into<String>) -> Self {
+        Self {
+            provider,
+            id: id.into(),
+            ..Default::default()
+        }
+    }
+}
+
+impl Default for LocalModelCard {
+    fn default() -> Self {
+        Self {
+            provider: LocalModelProvider::HuggingFace,
+            id: String::new(),
+            author: None,
+            pipeline_tag: None,
+            tags: Vec::new(),
+            likes: None,
+            downloads: None,
+            requires_token: false,
+            description: None,
+        }
+    }
+}
+
+/// Identificador serializable de un modelo local instalado.
+#[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Hash)]
+pub struct LocalModelIdentifier {
+    pub provider: LocalModelProvider,
+    pub model_id: String,
+}
+
+impl LocalModelIdentifier {
+    pub fn new(provider: LocalModelProvider, model_id: impl Into<String>) -> Self {
+        Self {
+            provider,
+            model_id: model_id.into(),
+        }
+    }
+
+    pub fn parse(value: &str) -> Self {
+        if let Some((provider, model)) = value.split_once("::") {
+            let provider = LocalModelProvider::ALL
+                .into_iter()
+                .find(|p| p.key() == provider)
+                .unwrap_or(LocalModelProvider::HuggingFace);
+            Self::new(provider, model.trim())
+        } else {
+            Self::new(LocalModelProvider::HuggingFace, value.trim())
+        }
+    }
+
+    pub fn serialize(&self) -> String {
+        format!("{}::{}", self.provider.key(), self.model_id)
+    }
+
+    pub fn display_label(&self) -> String {
+        format!("{} · {}", self.provider.display_name(), self.model_id)
+    }
+
+    pub fn sanitized_dir_name(&self) -> String {
+        let sanitized = self.model_id.replace('/', "_").replace(' ', "_");
+        format!("{}__{}", self.provider.key(), sanitized)
+    }
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,5 +1,6 @@
 mod api;
 mod config;
+mod local_providers;
 mod state;
 mod ui;
 

--- a/src/ui/resource_sidebar.rs
+++ b/src/ui/resource_sidebar.rs
@@ -186,7 +186,7 @@ fn jarvis_indicator(state: &AppState) -> StatusIndicator {
         return led_from_message(status);
     }
 
-    if state.installed_jarvis_models.is_empty() {
+    if state.installed_local_models.is_empty() {
         StatusIndicator::Led {
             color: COLOR_WARNING,
             status: "Sin modelos instalados".to_string(),
@@ -194,16 +194,16 @@ fn jarvis_indicator(state: &AppState) -> StatusIndicator {
     } else {
         StatusIndicator::Led {
             color: theme::COLOR_SUCCESS,
-            status: format!("{} modelos listos", state.installed_jarvis_models.len()),
+            status: format!("{} modelos listos", state.installed_local_models.len()),
         }
     }
 }
 
 fn jarvis_detail(state: &AppState) -> String {
-    if let Some(model_id) = &state.jarvis_active_model {
+    if let Some(model) = &state.jarvis_active_model {
         let trimmed_path = state.jarvis_model_path.trim();
         if trimmed_path.is_empty() {
-            return format!("Modelo {} · ruta sin configurar", model_id);
+            return format!("{} · ruta sin configurar", model.display_label());
         }
 
         let path = Path::new(trimmed_path);
@@ -213,7 +213,7 @@ fn jarvis_detail(state: &AppState) -> String {
             .map(|name| name.to_string())
             .unwrap_or_else(|| trimmed_path.to_string());
 
-        format!("Modelo {} · {}", model_id, display)
+        format!("{} · {}", model.display_label(), display)
     } else if state.jarvis_model_path.trim().is_empty() {
         "Sin modelo seleccionado".to_string()
     } else {

--- a/src/ui/sidebar.rs
+++ b/src/ui/sidebar.rs
@@ -16,6 +16,11 @@ const ICON_PROVIDER_ANTHROPIC: &str = "\u{f544}"; // robot
 const ICON_PROVIDER_OPENAI: &str = "\u{e2ca}"; // wand-magic-sparkles
 const ICON_PROVIDER_GROQ: &str = "\u{f0e7}"; // bolt
 const ICON_LOCAL_HF: &str = "\u{f49e}"; // box-open
+const ICON_LOCAL_GITHUB: &str = "\u{f09b}"; // github
+const ICON_LOCAL_REPLICATE: &str = "\u{f1e0}"; // share-alt
+const ICON_LOCAL_OLLAMA: &str = "\u{f233}"; // server
+const ICON_LOCAL_OPENROUTER: &str = "\u{f6ff}"; // route
+const ICON_LOCAL_MODELSCOPE: &str = "\u{f0c3}"; // flask
 const ICON_LOCAL_SETTINGS: &str = "\u{f1de}"; // sliders
 const ICON_CUSTOMIZATION: &str = "\u{f1de}"; // sliders
 const ICON_COMMANDS: &str = "\u{f120}"; // terminal
@@ -181,6 +186,46 @@ const LOCAL_DETAILS: &[NavNode] = &[
         icon: ICON_LOCAL_HF,
         view: Some(MainView::Preferences),
         section: Some(PreferenceSection::ModelsLocalHuggingFace),
+        children: &[],
+    },
+    NavNode {
+        id: "local_github_models",
+        label: "GitHub Models",
+        icon: ICON_LOCAL_GITHUB,
+        view: Some(MainView::Preferences),
+        section: Some(PreferenceSection::ModelsLocalGithub),
+        children: &[],
+    },
+    NavNode {
+        id: "local_replicate",
+        label: "Replicate",
+        icon: ICON_LOCAL_REPLICATE,
+        view: Some(MainView::Preferences),
+        section: Some(PreferenceSection::ModelsLocalReplicate),
+        children: &[],
+    },
+    NavNode {
+        id: "local_ollama",
+        label: "Ollama",
+        icon: ICON_LOCAL_OLLAMA,
+        view: Some(MainView::Preferences),
+        section: Some(PreferenceSection::ModelsLocalOllama),
+        children: &[],
+    },
+    NavNode {
+        id: "local_openrouter",
+        label: "OpenRouter",
+        icon: ICON_LOCAL_OPENROUTER,
+        view: Some(MainView::Preferences),
+        section: Some(PreferenceSection::ModelsLocalOpenRouter),
+        children: &[],
+    },
+    NavNode {
+        id: "local_modelscope",
+        label: "ModelScope",
+        icon: ICON_LOCAL_MODELSCOPE,
+        view: Some(MainView::Preferences),
+        section: Some(PreferenceSection::ModelsLocalModelscope),
         children: &[],
     },
     NavNode {


### PR DESCRIPTION
## Summary
- implement OpenRouter catalog fetching so the local gallery shows live search results
- add Ollama discovery and pulling through the daemon/CLI and wire it into the installer flow
- route the UI search/install handlers through the new provider APIs

## Testing
- cargo fmt
- cargo check

------
https://chatgpt.com/codex/tasks/task_e_68d553bb7bc083338b517ea442086b47