### PR TITLE
Render markdown responses and handle async provider replies

### DIFF
--- a/src/ui/mod.rs
+++ b/src/ui/mod.rs
@@ -10,6 +10,9 @@ pub mod sidebar;
 pub mod theme;
 
 pub fn draw_ui(ctx: &egui::Context, state: &mut AppState) {
+    if state.update_async_tasks() {
+        ctx.request_repaint();
+    }
     theme::apply(ctx);
     header::draw_header(ctx, state);
     sidebar::draw_sidebar(ctx, state);


### PR DESCRIPTION
## Summary
- render chat responses with custom markdown formatting, including headings, lists, and highlighted code blocks with copy affordances
- add pending chat message state with spinner support and non-blocking remote provider calls
- poll asynchronous provider responses each frame so the UI stays responsive while awaiting replies

## Testing
- cargo check

------
https://chatgpt.com/codex/tasks/task_e_68d65be780888333bd1e2fd6f7f71cc4