### PR TITLE
Narrow chat feed and sidebar layouts

### DIFF
--- a/src/ui/chat.rs
+++ b/src/ui/chat.rs
@@ -36,7 +36,7 @@ pub fn draw_main_content(ctx: &egui::Context, state: &mut AppState) {
                 .stroke(theme::subtle_border())
                 .inner_margin(egui::Margin {
                     left: 18.0,
-                    right: 0.0,
+                    right: 18.0,
                     top: 18.0,
                     bottom: 14.0,
                 }),
@@ -123,10 +123,26 @@ fn draw_chat_history(ui: &mut egui::Ui, state: &mut AppState) {
                 .stick_to_bottom(true)
                 .auto_shrink([false, false])
                 .show(ui, |ui| {
-                    ui.set_width(ui.available_width());
-                    for (index, message) in state.chat_messages.iter().enumerate() {
-                        draw_message_bubble(ui, message, index, &mut pending_actions);
-                    }
+                    let total_width = ui.available_width();
+                    let feed_width = total_width.min(820.0);
+                    let horizontal_padding = ((total_width - feed_width) / 2.0).max(0.0);
+
+                    ui.horizontal(|ui| {
+                        if horizontal_padding > 0.0 {
+                            ui.add_space(horizontal_padding);
+                        }
+
+                        ui.vertical(|ui| {
+                            ui.set_width(feed_width);
+                            for (index, message) in state.chat_messages.iter().enumerate() {
+                                draw_message_bubble(ui, message, index, &mut pending_actions);
+                            }
+                        });
+
+                        if horizontal_padding > 0.0 {
+                            ui.add_space(horizontal_padding);
+                        }
+                    });
                 });
         });
 
@@ -174,8 +190,17 @@ fn draw_message_bubble(
 
     ui.with_layout(layout, |ui| {
         let available_width = ui.available_width();
-        let mut bubble_width = (available_width - 8.0).max(260.0);
+        let mut bubble_width = if available_width > 32.0 {
+            (available_width - 16.0).min(680.0)
+        } else {
+            available_width
+        };
+        if available_width > 320.0 {
+            bubble_width = bubble_width.max(320.0);
+        }
         bubble_width = bubble_width.min(available_width);
+
+        ui.add_space(8.0);
         let frame = egui::Frame::none()
             .fill(background)
             .stroke(egui::Stroke::new(1.4, border))

--- a/src/ui/resource_sidebar.rs
+++ b/src/ui/resource_sidebar.rs
@@ -23,28 +23,44 @@ pub fn draw_resource_sidebar(ctx: &egui::Context, state: &AppState) {
                 .inner_margin(egui::Margin::symmetric(20.0, 18.0)),
         )
         .show(ctx, |ui| {
-            ui.set_width(ui.available_width());
-            ui.heading(
-                RichText::new("Resumen de recursos")
-                    .color(theme::COLOR_TEXT_PRIMARY)
-                    .strong(),
-            );
-            ui.label(RichText::new("Actualizado ahora").color(theme::COLOR_TEXT_WEAK));
-            ui.add_space(12.0);
+            let total_width = ui.available_width();
+            let content_width = total_width.min(360.0);
+            let horizontal_padding = ((total_width - content_width) / 2.0).max(0.0);
 
-            let rows = resource_rows(state);
-            egui::ScrollArea::vertical()
-                .auto_shrink([false, false])
-                .show(ui, |ui| {
-                    for (index, row) in rows.iter().enumerate() {
-                        draw_resource_row(ui, row);
-                        if index + 1 != rows.len() {
-                            ui.add_space(10.0);
-                            ui.separator();
-                            ui.add_space(10.0);
-                        }
-                    }
+            ui.horizontal(|ui| {
+                if horizontal_padding > 0.0 {
+                    ui.add_space(horizontal_padding);
+                }
+
+                ui.vertical(|ui| {
+                    ui.set_width(content_width);
+                    ui.heading(
+                        RichText::new("Resumen de recursos")
+                            .color(theme::COLOR_TEXT_PRIMARY)
+                            .strong(),
+                    );
+                    ui.label(RichText::new("Actualizado ahora").color(theme::COLOR_TEXT_WEAK));
+                    ui.add_space(12.0);
+
+                    let rows = resource_rows(state);
+                    egui::ScrollArea::vertical()
+                        .auto_shrink([false, false])
+                        .show(ui, |ui| {
+                            for (index, row) in rows.iter().enumerate() {
+                                draw_resource_row(ui, row);
+                                if index + 1 != rows.len() {
+                                    ui.add_space(10.0);
+                                    ui.separator();
+                                    ui.add_space(10.0);
+                                }
+                            }
+                        });
                 });
+
+                if horizontal_padding > 0.0 {
+                    ui.add_space(horizontal_padding);
+                }
+            });
         });
 }
 


### PR DESCRIPTION
## Summary
- center the chat history feed and cap its width so message bubbles stay within the available space between sidebars
- constrain individual message bubbles with consistent margins to avoid horizontal overflow
- wrap the resource sidebar content in a centered column so cards no longer overlap the resizer handle

## Testing
- cargo fmt
- cargo check

------
https://chatgpt.com/codex/tasks/task_e_68d6753f88b88333b025d8d983893fe3