### PR TITLE
Adjust chat panel and resource sidebar spacing

### DIFF
--- a/src/ui/chat.rs
+++ b/src/ui/chat.rs
@@ -110,39 +110,24 @@ fn draw_chat_history(ui: &mut egui::Ui, state: &mut AppState) {
         .rounding(egui::Rounding::same(16.0))
         .inner_margin(egui::Margin {
             left: 20.0,
-            right: 14.0,
+            right: 12.0,
             top: 20.0,
             bottom: 18.0,
         })
         .show(ui, |ui| {
             let available_height = ui.available_height();
-            let available_width = ui.available_width();
-            ui.set_width(available_width);
             ui.set_min_height(available_height);
+            ui.set_width(ui.available_width());
+
             egui::ScrollArea::vertical()
                 .stick_to_bottom(true)
                 .auto_shrink([false, false])
                 .show(ui, |ui| {
-                    let total_width = ui.available_width();
-                    let feed_width = total_width.min(820.0);
-                    let horizontal_padding = ((total_width - feed_width) / 2.0).max(0.0);
-
-                    ui.horizontal(|ui| {
-                        if horizontal_padding > 0.0 {
-                            ui.add_space(horizontal_padding);
-                        }
-
-                        ui.vertical(|ui| {
-                            ui.set_width(feed_width);
-                            for (index, message) in state.chat_messages.iter().enumerate() {
-                                draw_message_bubble(ui, message, index, &mut pending_actions);
-                            }
-                        });
-
-                        if horizontal_padding > 0.0 {
-                            ui.add_space(horizontal_padding);
-                        }
-                    });
+                    let feed_width = ui.available_width();
+                    ui.set_width(feed_width);
+                    for (index, message) in state.chat_messages.iter().enumerate() {
+                        draw_message_bubble(ui, message, index, &mut pending_actions);
+                    }
                 });
         });
 
@@ -191,12 +176,12 @@ fn draw_message_bubble(
     ui.with_layout(layout, |ui| {
         let available_width = ui.available_width();
         let mut bubble_width = if available_width > 32.0 {
-            (available_width - 16.0).min(680.0)
+            (available_width - 16.0).max(available_width * 0.6)
         } else {
             available_width
         };
         if available_width > 320.0 {
-            bubble_width = bubble_width.max(320.0);
+            bubble_width = bubble_width.clamp(320.0, available_width);
         }
         bubble_width = bubble_width.min(available_width);
 

--- a/src/ui/resource_sidebar.rs
+++ b/src/ui/resource_sidebar.rs
@@ -20,7 +20,12 @@ pub fn draw_resource_sidebar(ctx: &egui::Context, state: &AppState) {
             egui::Frame::none()
                 .fill(theme::COLOR_PANEL)
                 .stroke(theme::subtle_border())
-                .inner_margin(egui::Margin::symmetric(20.0, 18.0)),
+                .inner_margin(egui::Margin {
+                    left: 16.0,
+                    right: 18.0,
+                    top: 18.0,
+                    bottom: 18.0,
+                }),
         )
         .show(ctx, |ui| {
             let available_height = ui.available_height();
@@ -56,60 +61,73 @@ pub fn draw_resource_sidebar(ctx: &egui::Context, state: &AppState) {
 }
 
 fn draw_resource_row(ui: &mut egui::Ui, row: &ResourceRow) {
-    egui::Frame::none()
-        .fill(Color32::from_rgb(30, 32, 38))
-        .stroke(theme::subtle_border())
-        .rounding(egui::Rounding::same(12.0))
-        .inner_margin(Margin::symmetric(14.0, 12.0))
-        .show(ui, |ui| {
-            ui.set_width(ui.available_width());
-            let total_width = ui.available_width();
-            let status_width = (total_width * 0.32)
-                .max(110.0)
-                .min(total_width * 0.5)
-                .min(200.0);
+    let total_width = ui.available_width();
+    let row_width = (total_width - 8.0).max(total_width * 0.92);
 
-            ui.horizontal(|ui| {
-                ui.spacing_mut().item_spacing.x = 14.0;
+    ui.horizontal(|ui| {
+        ui.add_space(4.0);
+        ui.vertical(|ui| {
+            ui.set_width(row_width);
+            egui::Frame::none()
+                .fill(Color32::from_rgb(30, 32, 38))
+                .stroke(theme::subtle_border())
+                .rounding(egui::Rounding::same(12.0))
+                .inner_margin(Margin::symmetric(12.0, 10.0))
+                .show(ui, |ui| {
+                    ui.set_width(ui.available_width());
+                    let available = ui.available_width();
+                    let status_width = (available * 0.32)
+                        .max(110.0)
+                        .min(available * 0.5)
+                        .min(200.0);
 
-                ui.label(
-                    RichText::new(row.icon)
-                        .font(theme::icon_font(18.0))
-                        .color(theme::COLOR_PRIMARY),
-                );
+                    ui.horizontal(|ui| {
+                        ui.spacing_mut().item_spacing.x = 14.0;
 
-                let available_after_icon = ui.available_width();
-                let text_width = (available_after_icon - status_width)
-                    .max(120.0)
-                    .min(available_after_icon);
-
-                ui.allocate_ui_with_layout(
-                    egui::vec2(text_width, 0.0),
-                    egui::Layout::left_to_right(egui::Align::TOP),
-                    |ui| {
-                        ui.set_width(ui.available_width());
                         ui.label(
-                            RichText::new(row.name)
-                                .color(theme::COLOR_TEXT_PRIMARY)
-                                .strong(),
+                            RichText::new(row.icon)
+                                .font(theme::icon_font(18.0))
+                                .color(theme::COLOR_PRIMARY),
                         );
-                    },
-                );
 
-                ui.allocate_ui_with_layout(
-                    egui::vec2(status_width, 0.0),
-                    egui::Layout::right_to_left(egui::Align::Center),
-                    |ui| {
-                        let StatusIndicator::Led { color, status } = &row.indicator;
-                        draw_led(ui, *color, status);
-                    },
-                );
-            });
+                        let available_after_icon = ui.available_width();
+                        let text_width = (available_after_icon - status_width)
+                            .max(120.0)
+                            .min(available_after_icon);
 
-            ui.add_space(6.0);
-            ui.set_width(ui.available_width());
-            ui.add(Label::new(RichText::new(&row.detail).color(theme::COLOR_TEXT_WEAK)).wrap(true));
+                        ui.allocate_ui_with_layout(
+                            egui::vec2(text_width, 0.0),
+                            egui::Layout::left_to_right(egui::Align::TOP),
+                            |ui| {
+                                ui.set_width(ui.available_width());
+                                ui.label(
+                                    RichText::new(row.name)
+                                        .color(theme::COLOR_TEXT_PRIMARY)
+                                        .strong(),
+                                );
+                            },
+                        );
+
+                        ui.allocate_ui_with_layout(
+                            egui::vec2(status_width, 0.0),
+                            egui::Layout::right_to_left(egui::Align::Center),
+                            |ui| {
+                                let StatusIndicator::Led { color, status } = &row.indicator;
+                                draw_led(ui, *color, status);
+                            },
+                        );
+                    });
+
+                    ui.add_space(6.0);
+                    ui.set_width(ui.available_width());
+                    ui.add(
+                        Label::new(RichText::new(&row.detail).color(theme::COLOR_TEXT_WEAK))
+                            .wrap(true),
+                    );
+                });
         });
+        ui.add_space(4.0);
+    });
 }
 
 fn draw_led(ui: &mut egui::Ui, color: Color32, label: &str) {


### PR DESCRIPTION
## Summary
- expand the chat history container to consume the full central panel width so bubbles are no longer obscured by a right-side gap
- relax message bubble width clamping so content stretches closer to the sidebar while preserving sensible minimums
- tighten the resource sidebar frame margins and narrow each resource card so they sit fully inside the panel without appearing clipped

## Testing
- cargo check

------
https://chatgpt.com/codex/tasks/task_e_68d67c83f864833380547daed9144602