### PR TITLE
Refine layout structure with resizable panels

### DIFF
--- a/src/state.rs
+++ b/src/state.rs
@@ -442,6 +442,12 @@ pub struct AppState {
     pub expanded_nav_nodes: BTreeSet<&'static str>,
     /// Determina si el panel de logs inferior está visible.
     pub logs_panel_expanded: bool,
+    /// Ancho actual del panel lateral izquierdo.
+    pub left_panel_width: f32,
+    /// Ancho actual del panel lateral derecho.
+    pub right_panel_width: f32,
+    /// Altura recordada del panel inferior de registros.
+    pub logs_panel_height: f32,
     /// Registros de actividad recientes.
     pub activity_logs: Vec<LogEntry>,
     /// Canal para recibir respuestas de proveedores remotos.
@@ -634,6 +640,9 @@ impl Default for AppState {
             groq_test_status: None,
             expanded_nav_nodes,
             logs_panel_expanded: true,
+            left_panel_width: 250.0,
+            right_panel_width: 250.0,
+            logs_panel_height: 200.0,
             activity_logs: default_logs(),
             provider_response_rx,
             provider_response_tx,

--- a/src/ui/chat.rs
+++ b/src/ui/chat.rs
@@ -4,7 +4,7 @@ use crate::state::{AppState, ChatMessage, MainView, PreferenceSection, AVAILABLE
 use anyhow::Result;
 use eframe::egui::{self, Color32, RichText, Spinner};
 
-use super::{logs, theme};
+use super::theme;
 
 const ICON_USER: &str = "\u{f007}"; // user
 const ICON_SYSTEM: &str = "\u{f085}"; // cogs
@@ -41,13 +41,9 @@ pub fn draw_main_content(ctx: &egui::Context, state: &mut AppState) {
                     bottom: 14.0,
                 }),
         )
-        .show(ctx, |ui| {
-            logs::draw_logs_panel(ui, state);
-
-            match state.active_main_view {
-                MainView::ChatMultimodal => draw_chat_view(ui, state),
-                MainView::Preferences => draw_preferences_view(ui, state),
-            }
+        .show(ctx, |ui| match state.active_main_view {
+            MainView::ChatMultimodal => draw_chat_view(ui, state),
+            MainView::Preferences => draw_preferences_view(ui, state),
         });
 }
 

--- a/src/ui/header.rs
+++ b/src/ui/header.rs
@@ -6,7 +6,7 @@ use super::theme;
 
 pub fn draw_header(ctx: &egui::Context, state: &mut AppState) {
     egui::TopBottomPanel::top("global_header")
-        .exact_height(44.0)
+        .exact_height(56.0)
         .frame(
             egui::Frame::none()
                 .fill(theme::COLOR_HEADER)
@@ -14,7 +14,7 @@ pub fn draw_header(ctx: &egui::Context, state: &mut AppState) {
                 .inner_margin(egui::Margin::symmetric(12.0, 6.0)),
         )
         .show(ctx, |ui| {
-            ui.set_height(32.0);
+            ui.set_height(44.0);
             ui.horizontal(|ui| {
                 ui.spacing_mut().item_spacing.x = 10.0;
 

--- a/src/ui/mod.rs
+++ b/src/ui/mod.rs
@@ -14,7 +14,12 @@ pub fn draw_ui(ctx: &egui::Context, state: &mut AppState) {
         ctx.request_repaint();
     }
     theme::apply(ctx);
+    ctx.style_mut(|style| {
+        style.interaction.resize_grab_radius_side = 3.0;
+        style.interaction.resize_grab_radius_corner = 4.0;
+    });
     header::draw_header(ctx, state);
+    logs::draw_logs_panel(ctx, state);
     sidebar::draw_sidebar(ctx, state);
     resource_sidebar::draw_resource_sidebar(ctx, state);
     chat::draw_main_content(ctx, state);

--- a/src/ui/resource_sidebar.rs
+++ b/src/ui/resource_sidebar.rs
@@ -11,11 +11,11 @@ const ICON_CLAUDE: &str = "\u{e2ca}"; // wand-magic-sparkles
 const ICON_GROQ: &str = "\u{f0e7}"; // bolt
 const COLOR_WARNING: Color32 = Color32::from_rgb(255, 196, 0);
 
-pub fn draw_resource_sidebar(ctx: &egui::Context, state: &AppState) {
-    egui::SidePanel::right("resource_panel")
+pub fn draw_resource_sidebar(ctx: &egui::Context, state: &mut AppState) {
+    let panel_response = egui::SidePanel::right("resource_panel")
         .resizable(true)
-        .default_width(280.0)
-        .width_range(220.0..=420.0)
+        .default_width(state.right_panel_width)
+        .width_range(200.0..=400.0)
         .frame(
             egui::Frame::none()
                 .fill(theme::COLOR_PANEL)
@@ -28,6 +28,7 @@ pub fn draw_resource_sidebar(ctx: &egui::Context, state: &AppState) {
                 }),
         )
         .show(ctx, |ui| {
+            ui.set_clip_rect(ui.max_rect());
             let available_height = ui.available_height();
             ui.set_min_height(available_height);
             ui.set_width(ui.available_width());
@@ -58,6 +59,29 @@ pub fn draw_resource_sidebar(ctx: &egui::Context, state: &AppState) {
                     });
             });
         });
+
+    let width = panel_response.response.rect.width().clamp(200.0, 400.0);
+    state.right_panel_width = width;
+
+    let separator_rect = egui::Rect::from_min_max(
+        egui::pos2(
+            panel_response.response.rect.left() - 2.0,
+            panel_response.response.rect.top(),
+        ),
+        egui::pos2(
+            panel_response.response.rect.left() + 2.0,
+            panel_response.response.rect.bottom(),
+        ),
+    );
+    let painter = ctx.layer_painter(egui::LayerId::new(
+        egui::Order::Foreground,
+        egui::Id::new("right_separator"),
+    ));
+    painter.rect_filled(
+        separator_rect,
+        0.0,
+        theme::COLOR_PRIMARY.gamma_multiply(0.25),
+    );
 }
 
 fn draw_resource_row(ui: &mut egui::Ui, row: &ResourceRow) {

--- a/src/ui/sidebar.rs
+++ b/src/ui/sidebar.rs
@@ -31,10 +31,10 @@ const ICON_BRANCH_COLLAPSED: &str = "\u{f054}"; // chevron-right
 const ICON_BRANCH_EXPANDED: &str = "\u{f078}"; // chevron-down
 
 pub fn draw_sidebar(ctx: &egui::Context, state: &mut AppState) {
-    egui::SidePanel::left("navigation_panel")
+    let panel_response = egui::SidePanel::left("navigation_panel")
         .resizable(true)
-        .default_width(280.0)
-        .width_range(220.0..=420.0)
+        .default_width(state.left_panel_width)
+        .width_range(200.0..=400.0)
         .frame(
             egui::Frame::none()
                 .fill(theme::COLOR_PANEL)
@@ -42,6 +42,7 @@ pub fn draw_sidebar(ctx: &egui::Context, state: &mut AppState) {
                 .inner_margin(egui::Margin::same(16.0)),
         )
         .show(ctx, |ui| {
+            ui.set_clip_rect(ui.max_rect());
             egui::ScrollArea::vertical()
                 .auto_shrink([false, false])
                 .show(ui, |ui| {
@@ -51,6 +52,29 @@ pub fn draw_sidebar(ctx: &egui::Context, state: &mut AppState) {
                     }
                 });
         });
+
+    let width = panel_response.response.rect.width().clamp(200.0, 400.0);
+    state.left_panel_width = width;
+
+    let separator_rect = egui::Rect::from_min_max(
+        egui::pos2(
+            panel_response.response.rect.right() - 2.0,
+            panel_response.response.rect.top(),
+        ),
+        egui::pos2(
+            panel_response.response.rect.right() + 2.0,
+            panel_response.response.rect.bottom(),
+        ),
+    );
+    let painter = ctx.layer_painter(egui::LayerId::new(
+        egui::Order::Foreground,
+        egui::Id::new("left_separator"),
+    ));
+    painter.rect_filled(
+        separator_rect,
+        0.0,
+        theme::COLOR_PRIMARY.gamma_multiply(0.25),
+    );
 }
 
 #[derive(Clone, Copy)]


### PR DESCRIPTION
## Summary
- enforce the requested application shell by locking the header height, adding global resizable sidebars, and drawing visible drag handles
- persist sidebar widths and bottom log panel height in state so user adjustments stick during the session
- rework the log panel into an animated, retractable bottom bar with internal scrolling while keeping existing colors

## Testing
- cargo check

------
https://chatgpt.com/codex/tasks/task_e_68d688c009a08333939350f73499f527