### PR TITLE
Ensure logs panel background covers underlying content

### DIFF
--- a/src/ui/logs.rs
+++ b/src/ui/logs.rs
@@ -43,7 +43,10 @@ pub fn draw_logs_panel(ctx: &egui::Context, state: &mut AppState) {
     }
 
     let panel_response = panel.show(ctx, |ui| {
-        ui.set_clip_rect(ui.max_rect());
+        let background_rect = ui.max_rect();
+        ui.painter()
+            .rect_filled(background_rect, 0.0, theme::COLOR_PANEL);
+        ui.set_clip_rect(background_rect);
         if state.logs_panel_expanded {
             draw_expanded_logs(ui, state);
         } else {


### PR DESCRIPTION
## Summary
- paint the logs panel background with the theme color so it fully obscures underlying panels when resized

## Testing
- cargo fmt
- cargo check

------
https://chatgpt.com/codex/tasks/task_e_68d68dd1c6a083339477e243c3079552