### PR TITLE
Improve layout spacing and wrapping

### DIFF
--- a/src/ui/header.rs
+++ b/src/ui/header.rs
@@ -1,4 +1,4 @@
-use eframe::egui::{self, Color32, RichText};
+use eframe::egui::{self, Color32, Frame, Margin, RichText, Rounding};
 
 use crate::state::AppState;
 
@@ -6,16 +6,21 @@ use super::theme;
 
 pub fn draw_header(ctx: &egui::Context, state: &mut AppState) {
     egui::TopBottomPanel::top("global_header")
-        .exact_height(56.0)
+        .exact_height(64.0)
         .frame(
             egui::Frame::none()
                 .fill(theme::COLOR_HEADER)
                 .stroke(theme::subtle_border())
-                .inner_margin(egui::Margin::symmetric(12.0, 6.0)),
+                .inner_margin(egui::Margin {
+                    left: 18.0,
+                    right: 18.0,
+                    top: 10.0,
+                    bottom: 10.0,
+                }),
         )
         .show(ctx, |ui| {
             ui.set_height(44.0);
-            ui.horizontal(|ui| {
+            ui.with_layout(egui::Layout::left_to_right(egui::Align::Center), |ui| {
                 ui.spacing_mut().item_spacing.x = 10.0;
 
                 draw_logo(ui);
@@ -26,10 +31,24 @@ pub fn draw_header(ctx: &egui::Context, state: &mut AppState) {
                         .strong(),
                 );
 
+                ui.add_space(12.0);
                 ui.separator();
-                ui.add_space(4.0);
-                draw_search(ui, state);
-                ui.add_space(ui.available_width());
+                ui.add_space(16.0);
+
+                let available = ui.available_width();
+                let search_width = available.clamp(240.0, 420.0);
+                if available > search_width {
+                    ui.add_space(available - search_width);
+                }
+
+                ui.allocate_ui_with_layout(
+                    egui::vec2(search_width, 0.0),
+                    egui::Layout::left_to_right(egui::Align::Center),
+                    |ui| {
+                        ui.set_width(search_width);
+                        draw_search(ui, state);
+                    },
+                );
             });
         });
 }
@@ -64,12 +83,24 @@ fn draw_logo(ui: &mut egui::Ui) {
 }
 
 fn draw_search(ui: &mut egui::Ui, state: &mut AppState) {
-    ui.horizontal(|ui| {
-        ui.spacing_mut().item_spacing.x = 4.0;
-        ui.label(RichText::new("🔍").color(theme::COLOR_TEXT_WEAK));
-        ui.add_sized(
-            [200.0, 26.0],
-            egui::TextEdit::singleline(&mut state.search_buffer).hint_text("Buscar recursos..."),
-        );
-    });
+    Frame::none()
+        .fill(Color32::from_rgb(44, 46, 52))
+        .stroke(theme::subtle_border())
+        .rounding(Rounding::same(12.0))
+        .inner_margin(Margin::symmetric(14.0, 10.0))
+        .show(ui, |ui| {
+            ui.set_width(ui.available_width());
+            ui.set_height(36.0);
+            ui.horizontal(|ui| {
+                ui.spacing_mut().item_spacing.x = 8.0;
+                ui.label(RichText::new("🔍").color(theme::COLOR_TEXT_WEAK));
+                let input_width = ui.available_width().max(160.0);
+                ui.add_sized(
+                    [input_width, 28.0],
+                    egui::TextEdit::singleline(&mut state.search_buffer)
+                        .hint_text("Buscar recursos...")
+                        .frame(false),
+                );
+            });
+        });
 }

--- a/src/ui/logs.rs
+++ b/src/ui/logs.rs
@@ -1,4 +1,4 @@
-use eframe::egui::{self, RichText};
+use eframe::egui::{self, Frame, Label, Margin, RichText, Rounding};
 use egui_extras::{Column, TableBuilder};
 
 use crate::state::{AppState, LogStatus};
@@ -122,6 +122,7 @@ fn draw_expanded_logs(ui: &mut egui::Ui, state: &mut AppState) {
                 draw_logs_table(ui, state);
             });
     });
+    ui.add_space(12.0);
 }
 
 fn draw_collapsed_logs(ui: &mut egui::Ui, state: &mut AppState) {
@@ -161,47 +162,65 @@ fn draw_logs_table(ui: &mut egui::Ui, state: &AppState) {
         .column(Column::remainder().resizable(true))
         .column(Column::initial(140.0).resizable(true))
         .resizable(true)
-        .header(28.0, |mut header| {
+        .header(36.0, |mut header| {
             header.col(|ui| {
-                paint_header_cell(ui, header_bg);
-                ui.label(RichText::new("Estado").color(theme::COLOR_TEXT_WEAK));
+                header_cell(ui, header_bg, |ui| {
+                    ui.label(RichText::new("Estado").color(theme::COLOR_TEXT_WEAK));
+                });
             });
             header.col(|ui| {
-                paint_header_cell(ui, header_bg);
-                ui.label(RichText::new("Origen").color(theme::COLOR_TEXT_WEAK));
+                header_cell(ui, header_bg, |ui| {
+                    ui.label(RichText::new("Origen").color(theme::COLOR_TEXT_WEAK));
+                });
             });
             header.col(|ui| {
-                paint_header_cell(ui, header_bg);
-                ui.label(RichText::new("Detalle").color(theme::COLOR_TEXT_WEAK));
+                header_cell(ui, header_bg, |ui| {
+                    ui.label(RichText::new("Detalle").color(theme::COLOR_TEXT_WEAK));
+                });
             });
             header.col(|ui| {
-                paint_header_cell(ui, header_bg);
-                ui.label(RichText::new("Hora").color(theme::COLOR_TEXT_WEAK));
+                header_cell(ui, header_bg, |ui| {
+                    ui.label(RichText::new("Hora").color(theme::COLOR_TEXT_WEAK));
+                });
             });
         })
         .body(|mut body| {
             for (index, entry) in state.activity_logs.iter().enumerate() {
                 let bg = if index % 2 == 0 { row_even } else { row_odd };
-                body.row(28.0, |mut row| {
+                body.row(44.0, |mut row| {
                     row.col(|ui| {
-                        paint_cell(ui, bg);
-                        ui.label(status_badge(entry.status));
+                        body_cell(ui, bg, |ui| {
+                            ui.label(status_badge(entry.status));
+                        });
                     });
                     row.col(|ui| {
-                        paint_cell(ui, bg);
-                        ui.label(
-                            RichText::new(&entry.source)
-                                .color(theme::COLOR_TEXT_PRIMARY)
-                                .strong(),
-                        );
+                        body_cell(ui, bg, |ui| {
+                            ui.label(
+                                RichText::new(&entry.source)
+                                    .color(theme::COLOR_TEXT_PRIMARY)
+                                    .strong(),
+                            );
+                        });
                     });
                     row.col(|ui| {
-                        paint_cell(ui, bg);
-                        ui.label(RichText::new(&entry.message).color(theme::COLOR_TEXT_PRIMARY));
+                        body_cell(ui, bg, |ui| {
+                            ui.scope(|ui| {
+                                ui.style_mut().wrap = Some(true);
+                                ui.add(
+                                    Label::new(
+                                        RichText::new(&entry.message)
+                                            .color(theme::COLOR_TEXT_PRIMARY),
+                                    )
+                                    .wrap(true)
+                                    .truncate(false),
+                                );
+                            });
+                        });
                     });
                     row.col(|ui| {
-                        paint_cell(ui, bg);
-                        ui.label(RichText::new(&entry.timestamp).color(theme::COLOR_TEXT_WEAK));
+                        body_cell(ui, bg, |ui| {
+                            ui.label(RichText::new(&entry.timestamp).color(theme::COLOR_TEXT_WEAK));
+                        });
                     });
                 });
             }
@@ -235,14 +254,26 @@ fn status_badge(status: LogStatus) -> RichText {
     }
 }
 
-fn paint_header_cell(ui: &mut egui::Ui, color: egui::Color32) {
-    let rect = ui.max_rect();
-    ui.painter()
-        .rect_filled(rect, egui::Rounding::same(6.0), color);
+fn header_cell(ui: &mut egui::Ui, color: egui::Color32, add_contents: impl FnOnce(&mut egui::Ui)) {
+    Frame::none()
+        .fill(color)
+        .rounding(Rounding::same(8.0))
+        .inner_margin(Margin::symmetric(12.0, 6.0))
+        .show(ui, |ui| {
+            ui.vertical_centered(|ui| {
+                add_contents(ui);
+            });
+        });
 }
 
-fn paint_cell(ui: &mut egui::Ui, color: egui::Color32) {
-    let rect = ui.max_rect();
-    ui.painter()
-        .rect_filled(rect, egui::Rounding::same(4.0), color);
+fn body_cell(ui: &mut egui::Ui, color: egui::Color32, add_contents: impl FnOnce(&mut egui::Ui)) {
+    Frame::none()
+        .fill(color)
+        .rounding(Rounding::same(8.0))
+        .inner_margin(Margin::symmetric(14.0, 10.0))
+        .show(ui, |ui| {
+            ui.vertical_centered(|ui| {
+                add_contents(ui);
+            });
+        });
 }

--- a/src/ui/resource_sidebar.rs
+++ b/src/ui/resource_sidebar.rs
@@ -116,12 +116,12 @@ fn draw_resource_row(ui: &mut egui::Ui, row: &ResourceRow) {
 
                         let available_after_icon = ui.available_width();
                         let text_width = (available_after_icon - status_width)
-                            .max(120.0)
+                            .max(160.0)
                             .min(available_after_icon);
 
                         ui.allocate_ui_with_layout(
                             egui::vec2(text_width, 0.0),
-                            egui::Layout::left_to_right(egui::Align::TOP),
+                            egui::Layout::top_down(egui::Align::LEFT),
                             |ui| {
                                 ui.set_width(ui.available_width());
                                 ui.label(
@@ -134,20 +134,33 @@ fn draw_resource_row(ui: &mut egui::Ui, row: &ResourceRow) {
 
                         ui.allocate_ui_with_layout(
                             egui::vec2(status_width, 0.0),
-                            egui::Layout::right_to_left(egui::Align::Center),
+                            egui::Layout::top_down(egui::Align::RIGHT),
                             |ui| {
-                                let StatusIndicator::Led { color, status } = &row.indicator;
-                                draw_led(ui, *color, status);
+                                ui.set_width(status_width);
+                                ui.vertical_centered(|ui| {
+                                    ui.with_layout(
+                                        egui::Layout::left_to_right(egui::Align::Center),
+                                        |ui| {
+                                            let StatusIndicator::Led { color, status } =
+                                                &row.indicator;
+                                            draw_led(ui, *color, status);
+                                        },
+                                    );
+                                });
                             },
                         );
                     });
 
-                    ui.add_space(6.0);
+                    ui.add_space(8.0);
                     ui.set_width(ui.available_width());
-                    ui.add(
-                        Label::new(RichText::new(&row.detail).color(theme::COLOR_TEXT_WEAK))
-                            .wrap(true),
-                    );
+                    ui.scope(|ui| {
+                        ui.style_mut().wrap = Some(true);
+                        ui.add(
+                            Label::new(RichText::new(&row.detail).color(theme::COLOR_TEXT_WEAK))
+                                .wrap(true)
+                                .truncate(false),
+                        );
+                    });
                 });
         });
         ui.add_space(4.0);
@@ -163,11 +176,14 @@ fn draw_led(ui: &mut egui::Ui, color: Color32, label: &str) {
     painter.circle_stroke(center, 6.0, Stroke::new(1.0, color.gamma_multiply(0.5)));
     painter.circle_stroke(center, 7.0, Stroke::new(1.2, color.gamma_multiply(0.3)));
     response.on_hover_text(label);
-    ui.label(
+    let label_width = ui.available_width().max(0.0);
+    let label_widget = Label::new(
         RichText::new(label)
             .color(theme::COLOR_TEXT_PRIMARY)
             .size(12.0),
-    );
+    )
+    .wrap(true);
+    ui.add_sized([label_width, 0.0], label_widget);
 }
 
 struct ResourceRow {


### PR DESCRIPTION
## Summary
- increase header padding and wrap the search box in a pill-style container for clearer separation
- align resource status badges and enable full text wrapping inside the right panel cards
- restyle the activity log table with padded cells and consistent vertical alignment

## Testing
- cargo check

------
https://chatgpt.com/codex/tasks/task_e_68d69deebde8833399797d1de317a36b