### PR TITLE
Improve UI layout consistency and logs table

### DIFF
--- a/src/ui/logs.rs
+++ b/src/ui/logs.rs
@@ -150,44 +150,63 @@ fn draw_collapsed_logs(ui: &mut egui::Ui, state: &mut AppState) {
 }
 
 fn draw_logs_table(ui: &mut egui::Ui, state: &AppState) {
-    let header_bg = egui::Color32::from_rgb(40, 42, 48);
-    let row_even = egui::Color32::from_rgb(36, 38, 44);
-    let row_odd = egui::Color32::from_rgb(32, 34, 40);
+    let header_bg = egui::Color32::from_rgb(42, 44, 50);
+    let row_even = egui::Color32::from_rgb(34, 36, 42);
+    let row_odd = egui::Color32::from_rgb(30, 32, 38);
+
+    let min_height = ui.available_height().max(140.0);
 
     TableBuilder::new(ui)
-        .striped(false)
+        .striped(true)
         .cell_layout(egui::Layout::left_to_right(egui::Align::Center))
-        .column(Column::initial(64.0).resizable(true))
-        .column(Column::initial(160.0).resizable(true))
+        .column(Column::initial(72.0).at_least(64.0).resizable(true))
+        .column(Column::initial(160.0).at_least(120.0).resizable(true))
         .column(Column::remainder().resizable(true))
-        .column(Column::initial(140.0).resizable(true))
+        .column(Column::initial(150.0).at_least(120.0).resizable(true))
+        .min_scrolled_height(min_height)
         .resizable(true)
-        .header(36.0, |mut header| {
+        .header(30.0, |mut header| {
             header.col(|ui| {
                 header_cell(ui, header_bg, |ui| {
-                    ui.label(RichText::new("Estado").color(theme::COLOR_TEXT_WEAK));
+                    ui.label(
+                        RichText::new("Estado")
+                            .color(theme::COLOR_TEXT_WEAK)
+                            .monospace(),
+                    );
                 });
             });
             header.col(|ui| {
                 header_cell(ui, header_bg, |ui| {
-                    ui.label(RichText::new("Origen").color(theme::COLOR_TEXT_WEAK));
+                    ui.label(
+                        RichText::new("Origen")
+                            .color(theme::COLOR_TEXT_WEAK)
+                            .monospace(),
+                    );
                 });
             });
             header.col(|ui| {
                 header_cell(ui, header_bg, |ui| {
-                    ui.label(RichText::new("Detalle").color(theme::COLOR_TEXT_WEAK));
+                    ui.label(
+                        RichText::new("Detalle")
+                            .color(theme::COLOR_TEXT_WEAK)
+                            .monospace(),
+                    );
                 });
             });
             header.col(|ui| {
                 header_cell(ui, header_bg, |ui| {
-                    ui.label(RichText::new("Hora").color(theme::COLOR_TEXT_WEAK));
+                    ui.label(
+                        RichText::new("Hora")
+                            .color(theme::COLOR_TEXT_WEAK)
+                            .monospace(),
+                    );
                 });
             });
         })
         .body(|mut body| {
             for (index, entry) in state.activity_logs.iter().enumerate() {
                 let bg = if index % 2 == 0 { row_even } else { row_odd };
-                body.row(44.0, |mut row| {
+                body.row(32.0, |mut row| {
                     row.col(|ui| {
                         body_cell(ui, bg, |ui| {
                             ui.label(status_badge(entry.status));
@@ -198,28 +217,33 @@ fn draw_logs_table(ui: &mut egui::Ui, state: &AppState) {
                             ui.label(
                                 RichText::new(&entry.source)
                                     .color(theme::COLOR_TEXT_PRIMARY)
-                                    .strong(),
+                                    .monospace(),
                             );
                         });
                     });
                     row.col(|ui| {
                         body_cell(ui, bg, |ui| {
                             ui.scope(|ui| {
-                                ui.style_mut().wrap = Some(true);
-                                ui.add(
+                                ui.style_mut().wrap = Some(false);
+                                ui.add_sized(
+                                    [ui.available_width(), 0.0],
                                     Label::new(
                                         RichText::new(&entry.message)
-                                            .color(theme::COLOR_TEXT_PRIMARY),
+                                            .color(theme::COLOR_TEXT_PRIMARY)
+                                            .monospace(),
                                     )
-                                    .wrap(true)
-                                    .truncate(false),
+                                    .truncate(true),
                                 );
                             });
                         });
                     });
                     row.col(|ui| {
                         body_cell(ui, bg, |ui| {
-                            ui.label(RichText::new(&entry.timestamp).color(theme::COLOR_TEXT_WEAK));
+                            ui.label(
+                                RichText::new(&entry.timestamp)
+                                    .color(theme::COLOR_TEXT_WEAK)
+                                    .monospace(),
+                            );
                         });
                     });
                 });
@@ -257,8 +281,8 @@ fn status_badge(status: LogStatus) -> RichText {
 fn header_cell(ui: &mut egui::Ui, color: egui::Color32, add_contents: impl FnOnce(&mut egui::Ui)) {
     Frame::none()
         .fill(color)
-        .rounding(Rounding::same(8.0))
-        .inner_margin(Margin::symmetric(12.0, 6.0))
+        .rounding(Rounding::same(6.0))
+        .inner_margin(Margin::symmetric(10.0, 4.0))
         .show(ui, |ui| {
             ui.vertical_centered(|ui| {
                 add_contents(ui);
@@ -269,8 +293,8 @@ fn header_cell(ui: &mut egui::Ui, color: egui::Color32, add_contents: impl FnOnc
 fn body_cell(ui: &mut egui::Ui, color: egui::Color32, add_contents: impl FnOnce(&mut egui::Ui)) {
     Frame::none()
         .fill(color)
-        .rounding(Rounding::same(8.0))
-        .inner_margin(Margin::symmetric(14.0, 10.0))
+        .rounding(Rounding::same(4.0))
+        .inner_margin(Margin::symmetric(10.0, 6.0))
         .show(ui, |ui| {
             ui.vertical_centered(|ui| {
                 add_contents(ui);

--- a/src/ui/mod.rs
+++ b/src/ui/mod.rs
@@ -15,8 +15,9 @@ pub fn draw_ui(ctx: &egui::Context, state: &mut AppState) {
     }
     theme::apply(ctx);
     ctx.style_mut(|style| {
-        style.interaction.resize_grab_radius_side = 3.0;
-        style.interaction.resize_grab_radius_corner = 4.0;
+        style.interaction.resize_grab_radius_side = 6.0;
+        style.interaction.resize_grab_radius_corner = 8.0;
+        style.spacing.window_margin = egui::Margin::same(0.0);
     });
     header::draw_header(ctx, state);
     logs::draw_logs_panel(ctx, state);

--- a/src/ui/sidebar.rs
+++ b/src/ui/sidebar.rs
@@ -34,47 +34,36 @@ pub fn draw_sidebar(ctx: &egui::Context, state: &mut AppState) {
     let panel_response = egui::SidePanel::left("navigation_panel")
         .resizable(true)
         .default_width(state.left_panel_width)
-        .width_range(200.0..=400.0)
+        .width_range(200.0..=460.0)
         .frame(
             egui::Frame::none()
                 .fill(theme::COLOR_PANEL)
                 .stroke(theme::subtle_border())
-                .inner_margin(egui::Margin::same(16.0)),
+                .inner_margin(egui::Margin {
+                    left: 18.0,
+                    right: 18.0,
+                    top: 18.0,
+                    bottom: 18.0,
+                })
+                .rounding(egui::Rounding::same(14.0)),
         )
         .show(ctx, |ui| {
             ui.set_clip_rect(ui.max_rect());
             egui::ScrollArea::vertical()
                 .auto_shrink([false, false])
                 .show(ui, |ui| {
+                    ui.add_space(4.0);
                     for node in NAV_TREE {
                         draw_nav_node(ui, state, node, 0);
-                        ui.add_space(4.0);
+                        ui.add_space(6.0);
                     }
                 });
         });
 
-    let width = panel_response.response.rect.width().clamp(200.0, 400.0);
-    state.left_panel_width = width;
-
-    let separator_rect = egui::Rect::from_min_max(
-        egui::pos2(
-            panel_response.response.rect.right() - 2.0,
-            panel_response.response.rect.top(),
-        ),
-        egui::pos2(
-            panel_response.response.rect.right() + 2.0,
-            panel_response.response.rect.bottom(),
-        ),
-    );
-    let painter = ctx.layer_painter(egui::LayerId::new(
-        egui::Order::Foreground,
-        egui::Id::new("left_separator"),
-    ));
-    painter.rect_filled(
-        separator_rect,
-        0.0,
-        theme::COLOR_PRIMARY.gamma_multiply(0.25),
-    );
+    let width = panel_response.response.rect.width().clamp(200.0, 460.0);
+    if (width - state.left_panel_width).abs() > f32::EPSILON {
+        state.left_panel_width = width;
+    }
 }
 
 #[derive(Clone, Copy)]


### PR DESCRIPTION
## Summary
- center the chat and preferences surfaces with rounded containers so the main content keeps a consistent layout
- refresh resource sidebar cards with compact tag chips and persistent sidebar sizing to avoid overflow
- tighten the activity log table styling for a denser, log-centric presentation that adapts to the available space

## Testing
- `cargo fmt`
- `cargo check`


------
https://chatgpt.com/codex/tasks/task_e_68d6a203de288333b7a8f9af6c868fe1