### PR TITLE
Prevent installing incompatible Hugging Face models

### DIFF
--- a/src/api/ollama.rs
+++ b/src/api/ollama.rs
@@ -94,6 +94,7 @@ pub fn search_models(query: &str, token: Option<&str>) -> Result<Vec<LocalModelC
                 downloads: None,
                 requires_token: false,
                 description: None,
+                incompatible_reason: None,
             }
         })
         .collect())

--- a/src/api/openrouter.rs
+++ b/src/api/openrouter.rs
@@ -103,6 +103,7 @@ pub fn search_models(query: &str) -> Result<Vec<LocalModelCard>> {
                 downloads: None,
                 requires_token: true,
                 description: model.description,
+                incompatible_reason: None,
             }
         })
         .take(50)

--- a/src/local_providers.rs
+++ b/src/local_providers.rs
@@ -100,6 +100,8 @@ pub struct LocalModelCard {
     pub downloads: Option<u64>,
     pub requires_token: bool,
     pub description: Option<String>,
+    #[serde(default)]
+    pub incompatible_reason: Option<String>,
 }
 
 impl LocalModelCard {
@@ -124,6 +126,7 @@ impl Default for LocalModelCard {
             downloads: None,
             requires_token: false,
             description: None,
+            incompatible_reason: None,
         }
     }
 }

--- a/src/state.rs
+++ b/src/state.rs
@@ -853,6 +853,7 @@ pub struct CommandDocumentation {
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub enum LogStatus {
     Ok,
+    Warning,
     Error,
     Running,
 }

--- a/src/ui/logs.rs
+++ b/src/ui/logs.rs
@@ -1,4 +1,4 @@
-use eframe::egui::{self, Frame, Label, Margin, RichText, Rounding};
+use eframe::egui::{self, Color32, Frame, Label, Margin, RichText, Rounding};
 use egui_extras::{Column, TableBuilder};
 
 use crate::state::{AppState, LogStatus};
@@ -263,6 +263,7 @@ fn collapsed_frame() -> egui::Frame {
 fn status_badge(status: LogStatus) -> RichText {
     match status {
         LogStatus::Ok => RichText::new("✔ OK").color(theme::COLOR_SUCCESS),
+        LogStatus::Warning => RichText::new("⚠ Advertencia").color(Color32::from_rgb(255, 196, 86)),
         LogStatus::Error => RichText::new("❌ Error").color(theme::COLOR_DANGER),
         LogStatus::Running => RichText::new("⏳ En curso").color(theme::COLOR_PRIMARY),
     }


### PR DESCRIPTION
## Summary
- detect GGUF/GGML weights and unsupported pipelines when searching Hugging Face and record an incompatibility reason for each card
- surface incompatibility in the gallery by highlighting cards, disabling installs, logging a warning, and showing the new warning status in the activity log
- expand provider helpers to populate the new card metadata field

## Testing
- cargo check

------
https://chatgpt.com/codex/tasks/task_e_68d6b76bda3083338df96a80d55d5256