### PR TITLE
Allow Hugging Face text-generation pipelines

### DIFF
--- a/src/api/huggingface.rs
+++ b/src/api/huggingface.rs
@@ -63,15 +63,11 @@ fn huggingface_incompatibility(raw: &RawModelSummary) -> Option<String> {
                 | "text-embedding"
                 | "text-embeddings-inference"
                 | "embeddings"
+                | "text-generation"
+                | "text2text-generation"
         );
-        let compatible_by_tags = !supported
-            && has_embedding_hint
-            && matches!(
-                pipeline_lower.as_str(),
-                "text-generation" | "text2text-generation"
-            );
 
-        if !supported && !compatible_by_tags {
+        if !supported {
             return Some(format!(
                 "La pipeline declarada '{}' no es compatible con el runtime de incrustaciones de Jarvis.",
                 pipeline


### PR DESCRIPTION
## Summary
- allow Hugging Face models tagged with `text-generation` or `text2text-generation` pipelines to be treated as compatible with the Jarvis embeddings runtime

## Testing
- cargo check

------
https://chatgpt.com/codex/tasks/task_e_68d6cf4a257c8333b2ce90d25fb64471