### PR TITLE
Bloquea pipelines generativas incompatibles con Jarvis

### DIFF
--- a/src/api/huggingface.rs
+++ b/src/api/huggingface.rs
@@ -63,11 +63,16 @@ fn huggingface_incompatibility(raw: &RawModelSummary) -> Option<String> {
                 | "text-embedding"
                 | "text-embeddings-inference"
                 | "embeddings"
-                | "text-generation"
-                | "text2text-generation"
         );
 
         if !supported {
+            if pipeline_lower == "text-generation" || pipeline_lower == "text2text-generation" {
+                return Some(format!(
+                    "La pipeline '{}' corresponde a un modelo generativo. Jarvis solo puede cargar embeddings basados en BERT.",
+                    pipeline
+                ));
+            }
+
             return Some(format!(
                 "La pipeline declarada '{}' no es compatible con el runtime de incrustaciones de Jarvis.",
                 pipeline


### PR DESCRIPTION
## Summary
- evita que modelos de Hugging Face con pipeline de generación de texto se marquen como compatibles con Jarvis
- proporciona un mensaje específico indicando que Jarvis solo admite modelos de embeddings basados en BERT

## Testing
- cargo test

------
https://chatgpt.com/codex/tasks/task_e_68d6e08a2a0c833395b255dd21250390