### PR TITLE
Gracefully degrade Jarvis runtime when local model is missing

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3062,6 +3062,7 @@ dependencies = [
  "eframe",
  "egui_extras",
  "hf-hub",
+ "log",
  "octocrab",
  "once_cell",
  "reqwest",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,3 +31,4 @@ tokenizers = { version = "0.22", features = ["http"] }
 anyhow = "1.0"
 dirs = "5.0"
 once_cell = "1.19"
+log = "0.4"


### PR DESCRIPTION
## Summary
- add a placeholder encoder so Jarvis can respond when local weights are absent and log degraded conditions
- load metadata defensively, track whether the runtime is ready, and adjust generated replies to fall back gracefully
- include the `log` crate to surface runtime warnings about missing assets

## Testing
- cargo test
- cargo clippy -- -W clippy::all

------
https://chatgpt.com/codex/tasks/task_e_68d6f0b239a08333957f25c49c9e7a07