### PR TITLE
Improve Jarvis status response messaging

### DIFF
--- a/src/api/local.rs
+++ b/src/api/local.rs
@@ -944,7 +944,7 @@ impl JarvisRuntime {
     }
 
     fn respond_status(&self, _prompt: &str, _score: f32) -> String {
-        let mut lines = vec![format!("Modelo activo: {}.", self.model_label())];
+        let mut lines = vec![self.runtime_overview()];
         if let Some(pipeline) = &self.pipeline_tag {
             lines.push(format!("Especialización del modelo: {}.", pipeline));
         }
@@ -952,6 +952,15 @@ impl JarvisRuntime {
             "Directorio de trabajo: {}",
             self.model_dir.display()
         ));
+        if self.encoder_ready {
+            lines.push(
+                "El runtime local está listo para generar respuestas semánticas basadas en embeddings.".to_string(),
+            );
+        } else {
+            lines.push(
+                "Por ahora responderé con metadatos hasta que descargues los pesos compatibles para el runtime local.".to_string(),
+            );
+        }
         lines.push(
             "Estoy listo para recibir instrucciones. Mencióname con el alias configurado y reacciono al instante.".to_string(),
         );


### PR DESCRIPTION
## Summary
- update the Jarvis status response to reuse the runtime overview messaging
- clarify whether the local encoder is ready or still returning metadata-only replies

## Testing
- cargo fmt
- cargo test

------
https://chatgpt.com/codex/tasks/task_e_68d6f6a93b2083339c329916d92f9625