### PR TITLE
Expand chat feed height

### DIFF
--- a/src/ui/chat.rs
+++ b/src/ui/chat.rs
@@ -182,8 +182,9 @@ fn draw_chat_history(ui: &mut egui::Ui, state: &mut AppState) {
     let mut pending_actions = Vec::new();
 
     let max_width = ui.available_width().min(580.0);
+    let target_height = ui.available_height();
     ui.allocate_ui_with_layout(
-        egui::vec2(max_width, 0.0),
+        egui::vec2(max_width, target_height),
         egui::Layout::top_down(egui::Align::LEFT),
         |ui| {
             ui.set_width(max_width);


### PR DESCRIPTION
## Summary
- ensure the chat history container takes up the available vertical space so the feed stretches toward the input field

## Testing
- cargo fmt

------
https://chatgpt.com/codex/tasks/task_e_68d6fa7c59ac83339077f92365203882