### PR TITLE
Move logs and tasks view into sidebar navigation

### DIFF
--- a/src/state.rs
+++ b/src/state.rs
@@ -140,6 +140,7 @@ impl Default for PreferenceSection {
 pub enum MainView {
     ChatMultimodal,
     Preferences,
+    Logs,
 }
 
 impl Default for MainView {
@@ -495,8 +496,6 @@ pub struct AppState {
     pub groq_test_status: Option<String>,
     /// Ramas expandidas del árbol de navegación.
     pub expanded_nav_nodes: BTreeSet<&'static str>,
-    /// Determina si el panel de logs inferior está visible.
-    pub logs_panel_expanded: bool,
     /// Controla si el panel lateral izquierdo está visible.
     pub left_panel_visible: bool,
     /// Controla si el panel lateral derecho está visible.
@@ -505,8 +504,6 @@ pub struct AppState {
     pub left_panel_width: f32,
     /// Ancho actual del panel lateral derecho.
     pub right_panel_width: f32,
-    /// Altura recordada del panel inferior de registros.
-    pub logs_panel_height: f32,
     /// Registros de actividad recientes.
     pub activity_logs: Vec<LogEntry>,
     /// Canal para recibir respuestas de proveedores remotos.
@@ -711,12 +708,10 @@ impl Default for AppState {
             },
             groq_test_status: None,
             expanded_nav_nodes,
-            logs_panel_expanded: true,
             left_panel_visible: true,
             right_panel_visible: true,
             left_panel_width: 280.0,
             right_panel_width: 320.0,
-            logs_panel_height: 200.0,
             activity_logs: default_logs(),
             provider_response_rx,
             provider_response_tx,

--- a/src/ui/chat.rs
+++ b/src/ui/chat.rs
@@ -90,14 +90,14 @@ pub fn draw_main_content(ctx: &egui::Context, state: &mut AppState) {
                     bottom: 14.0,
                 })
                 .show(&mut frame_ui, |ui| {
-                    logs::draw_logs_panel(ui, state);
+                    ui.set_width(ui.available_width());
+                    ui.set_min_height(ui.available_height());
 
-                    egui::CentralPanel::default()
-                        .frame(egui::Frame::none())
-                        .show_inside(ui, |ui| match state.active_main_view {
-                            MainView::ChatMultimodal => draw_chat_view(ui, state),
-                            MainView::Preferences => draw_preferences_view(ui, state),
-                        });
+                    match state.active_main_view {
+                        MainView::ChatMultimodal => draw_chat_view(ui, state),
+                        MainView::Preferences => draw_preferences_view(ui, state),
+                        MainView::Logs => logs::draw_logs_view(ui, state),
+                    }
                 });
         });
 }

--- a/src/ui/logs.rs
+++ b/src/ui/logs.rs
@@ -1,4 +1,4 @@
-use eframe::egui::{self, Color32, Frame, Label, Margin, RichText, Rounding};
+use eframe::egui::{self, Color32, RichText};
 use egui_extras::{Column, TableBuilder};
 
 use crate::state::{AppState, LogStatus};
@@ -6,138 +6,48 @@ use crate::state::{AppState, LogStatus};
 use super::theme;
 
 const ICON_LOGS: &str = "\u{f0f6}"; // file-lines
+const COLOR_WARNING: Color32 = Color32::from_rgb(255, 196, 0);
+const COLOR_RUNNING: Color32 = Color32::from_rgb(64, 172, 255);
 
-const COLLAPSED_HEIGHT: f32 = 28.0;
-const MIN_EXPANDED_HEIGHT: f32 = 100.0;
-const MAX_EXPANDED_HEIGHT: f32 = 360.0;
-
-pub fn draw_logs_panel(ui: &mut egui::Ui, state: &mut AppState) {
-    let ctx = ui.ctx().clone();
-
-    let mut panel = egui::TopBottomPanel::bottom("logs_panel")
-        .show_separator_line(false)
-        .frame(if state.logs_panel_expanded {
-            expanded_frame()
-        } else {
-            collapsed_frame()
-        });
-
-    if state.logs_panel_expanded {
-        let remembered = state
-            .logs_panel_height
-            .clamp(MIN_EXPANDED_HEIGHT, MAX_EXPANDED_HEIGHT);
-        panel = panel
-            .default_height(remembered)
-            .min_height(MIN_EXPANDED_HEIGHT)
-            .max_height(MAX_EXPANDED_HEIGHT)
-            .resizable(true);
-    } else {
-        panel = panel.exact_height(COLLAPSED_HEIGHT).resizable(false);
-    }
-
-    let panel_response = panel.show_inside(ui, |ui| {
-        let background_rect = ui.max_rect();
-        ui.painter()
-            .rect_filled(background_rect, 0.0, theme::COLOR_PANEL);
-        ui.set_clip_rect(background_rect);
-        if state.logs_panel_expanded {
-            draw_expanded_logs(ui, state);
-        } else {
-            draw_collapsed_logs(ui, state);
-        }
-    });
-
-    if state.logs_panel_expanded {
-        let measured_height = panel_response
-            .response
-            .rect
-            .height()
-            .clamp(MIN_EXPANDED_HEIGHT, MAX_EXPANDED_HEIGHT);
-        if (measured_height - state.logs_panel_height).abs() > f32::EPSILON {
-            state.logs_panel_height = measured_height;
-        }
-    }
-
-    let separator_rect = egui::Rect::from_min_max(
-        egui::pos2(
-            panel_response.response.rect.left(),
-            panel_response.response.rect.top() + 2.0,
-        ),
-        egui::pos2(
-            panel_response.response.rect.right(),
-            panel_response.response.rect.top() + 6.0,
-        ),
-    );
-    let painter = ctx.layer_painter(egui::LayerId::new(
-        egui::Order::Foreground,
-        egui::Id::new("logs_separator"),
-    ));
-    painter.rect_filled(
-        separator_rect,
-        0.0,
-        theme::COLOR_PRIMARY.gamma_multiply(0.25),
-    );
-}
-
-fn draw_expanded_logs(ui: &mut egui::Ui, state: &mut AppState) {
+pub fn draw_logs_view(ui: &mut egui::Ui, state: &AppState) {
     ui.set_width(ui.available_width());
     ui.set_min_height(ui.available_height());
 
-    ui.horizontal(|ui| {
-        ui.spacing_mut().item_spacing.x = 10.0;
-        ui.label(
-            RichText::new(ICON_LOGS)
-                .font(theme::icon_font(16.0))
-                .color(theme::COLOR_PRIMARY),
-        );
-        ui.heading(RichText::new("Registros & tareas").color(theme::COLOR_TEXT_PRIMARY));
-        ui.add_space(ui.available_width());
-        let hide_label = RichText::new("Ocultar panel").color(theme::COLOR_TEXT_PRIMARY);
-        if ui
-            .add_sized([130.0, 26.0], theme::secondary_button(hide_label))
-            .clicked()
-        {
-            state.logs_panel_expanded = false;
-        }
-    });
-    ui.add_space(6.0);
+    egui::Frame::none()
+        .fill(Color32::from_rgb(26, 28, 32))
+        .stroke(theme::subtle_border())
+        .rounding(egui::Rounding::same(18.0))
+        .inner_margin(egui::Margin {
+            left: 20.0,
+            right: 16.0,
+            top: 20.0,
+            bottom: 18.0,
+        })
+        .show(ui, |ui| {
+            ui.set_width(ui.available_width());
+            ui.set_min_height(ui.available_height());
 
-    let table_size = ui.available_size();
-    ui.allocate_ui(table_size, |ui| {
-        egui::ScrollArea::both()
-            .id_source("logs_table_scroll")
-            .auto_shrink([false, false])
-            .show(ui, |ui| {
-                ui.set_width(ui.available_width());
-                ui.set_min_height(table_size.y);
-                draw_logs_table(ui, state);
+            ui.horizontal(|ui| {
+                ui.spacing_mut().item_spacing.x = 10.0;
+                ui.label(
+                    RichText::new(ICON_LOGS)
+                        .font(theme::icon_font(18.0))
+                        .color(theme::COLOR_PRIMARY),
+                );
+                ui.heading(RichText::new("Registros & tareas").color(theme::COLOR_TEXT_PRIMARY));
             });
-    });
-    ui.add_space(12.0);
-}
 
-fn draw_collapsed_logs(ui: &mut egui::Ui, state: &mut AppState) {
-    ui.horizontal(|ui| {
-        ui.spacing_mut().item_spacing.x = 10.0;
-        ui.label(
-            RichText::new(ICON_LOGS)
-                .font(theme::icon_font(16.0))
-                .color(theme::COLOR_PRIMARY),
-        );
-        ui.label(
-            RichText::new("Registros & tareas")
-                .color(theme::COLOR_TEXT_PRIMARY)
-                .strong(),
-        );
-        ui.add_space(ui.available_width());
-        let show_label = RichText::new("Mostrar panel").color(theme::COLOR_TEXT_PRIMARY);
-        if ui
-            .add_sized([150.0, 26.0], theme::secondary_button(show_label))
-            .clicked()
-        {
-            state.logs_panel_expanded = true;
-        }
-    });
+            ui.add_space(12.0);
+
+            egui::ScrollArea::both()
+                .id_source("logs_view_scroll")
+                .auto_shrink([false, false])
+                .show(ui, |ui| {
+                    ui.set_width(ui.available_width());
+                    ui.set_min_height(ui.available_height());
+                    draw_logs_table(ui, state);
+                });
+        });
 }
 
 fn draw_logs_table(ui: &mut egui::Ui, state: &AppState) {
@@ -145,7 +55,7 @@ fn draw_logs_table(ui: &mut egui::Ui, state: &AppState) {
     let row_even = egui::Color32::from_rgb(34, 36, 42);
     let row_odd = egui::Color32::from_rgb(30, 32, 38);
 
-    let min_height = ui.available_height().max(140.0);
+    let min_height = ui.available_height().max(240.0);
 
     TableBuilder::new(ui)
         .striped(true)
@@ -199,12 +109,18 @@ fn draw_logs_table(ui: &mut egui::Ui, state: &AppState) {
                 let bg = if index % 2 == 0 { row_even } else { row_odd };
                 body.row(32.0, |mut row| {
                     row.col(|ui| {
-                        body_cell(ui, bg, |ui| {
-                            ui.label(status_badge(entry.status));
+                        row_cell(ui, bg, |ui| {
+                            let (text, color) = match entry.status {
+                                LogStatus::Ok => ("OK", theme::COLOR_SUCCESS),
+                                LogStatus::Warning => ("WARN", COLOR_WARNING),
+                                LogStatus::Error => ("ERR", theme::COLOR_DANGER),
+                                LogStatus::Running => ("RUN", COLOR_RUNNING),
+                            };
+                            ui.label(RichText::new(text).color(color).monospace());
                         });
                     });
                     row.col(|ui| {
-                        body_cell(ui, bg, |ui| {
+                        row_cell(ui, bg, |ui| {
                             ui.label(
                                 RichText::new(&entry.source)
                                     .color(theme::COLOR_TEXT_PRIMARY)
@@ -213,23 +129,12 @@ fn draw_logs_table(ui: &mut egui::Ui, state: &AppState) {
                         });
                     });
                     row.col(|ui| {
-                        body_cell(ui, bg, |ui| {
-                            ui.scope(|ui| {
-                                ui.style_mut().wrap = Some(false);
-                                ui.add_sized(
-                                    [ui.available_width(), 0.0],
-                                    Label::new(
-                                        RichText::new(&entry.message)
-                                            .color(theme::COLOR_TEXT_PRIMARY)
-                                            .monospace(),
-                                    )
-                                    .truncate(true),
-                                );
-                            });
+                        row_cell(ui, bg, |ui| {
+                            ui.label(RichText::new(&entry.message).color(theme::COLOR_TEXT_WEAK));
                         });
                     });
                     row.col(|ui| {
-                        body_cell(ui, bg, |ui| {
+                        row_cell(ui, bg, |ui| {
                             ui.label(
                                 RichText::new(&entry.timestamp)
                                     .color(theme::COLOR_TEXT_WEAK)
@@ -242,54 +147,30 @@ fn draw_logs_table(ui: &mut egui::Ui, state: &AppState) {
         });
 }
 
-fn expanded_frame() -> egui::Frame {
-    egui::Frame::none()
-        .fill(theme::COLOR_PANEL)
-        .stroke(theme::subtle_border())
-        .inner_margin(egui::Margin::symmetric(14.0, 10.0))
+fn header_cell(ui: &mut egui::Ui, bg: Color32, add_contents: impl FnOnce(&mut egui::Ui)) {
+    ui.allocate_ui_with_layout(
+        egui::vec2(ui.available_width(), 28.0),
+        egui::Layout::left_to_right(egui::Align::Center),
+        |ui| {
+            let rect = ui.max_rect();
+            ui.painter().rect_filled(rect, 4.0, bg);
+            ui.set_clip_rect(rect);
+            ui.add_space(12.0);
+            add_contents(ui);
+        },
+    );
 }
 
-fn collapsed_frame() -> egui::Frame {
-    egui::Frame::none()
-        .fill(theme::COLOR_PANEL)
-        .stroke(theme::subtle_border())
-        .inner_margin(egui::Margin {
-            left: 16.0,
-            right: 16.0,
-            top: 4.0,
-            bottom: 4.0,
-        })
-}
-
-fn status_badge(status: LogStatus) -> RichText {
-    match status {
-        LogStatus::Ok => RichText::new("✔ OK").color(theme::COLOR_SUCCESS),
-        LogStatus::Warning => RichText::new("⚠ Advertencia").color(Color32::from_rgb(255, 196, 86)),
-        LogStatus::Error => RichText::new("❌ Error").color(theme::COLOR_DANGER),
-        LogStatus::Running => RichText::new("⏳ En curso").color(theme::COLOR_PRIMARY),
-    }
-}
-
-fn header_cell(ui: &mut egui::Ui, color: egui::Color32, add_contents: impl FnOnce(&mut egui::Ui)) {
-    Frame::none()
-        .fill(color)
-        .rounding(Rounding::same(6.0))
-        .inner_margin(Margin::symmetric(10.0, 4.0))
-        .show(ui, |ui| {
-            ui.vertical_centered(|ui| {
-                add_contents(ui);
-            });
-        });
-}
-
-fn body_cell(ui: &mut egui::Ui, color: egui::Color32, add_contents: impl FnOnce(&mut egui::Ui)) {
-    Frame::none()
-        .fill(color)
-        .rounding(Rounding::same(4.0))
-        .inner_margin(Margin::symmetric(10.0, 6.0))
-        .show(ui, |ui| {
-            ui.vertical_centered(|ui| {
-                add_contents(ui);
-            });
-        });
+fn row_cell(ui: &mut egui::Ui, bg: Color32, add_contents: impl FnOnce(&mut egui::Ui)) {
+    ui.allocate_ui_with_layout(
+        egui::vec2(ui.available_width(), 28.0),
+        egui::Layout::left_to_right(egui::Align::Center),
+        |ui| {
+            let rect = ui.max_rect();
+            ui.painter().rect_filled(rect, 4.0, bg);
+            ui.set_clip_rect(rect);
+            ui.add_space(12.0);
+            add_contents(ui);
+        },
+    );
 }

--- a/src/ui/sidebar.rs
+++ b/src/ui/sidebar.rs
@@ -4,6 +4,7 @@ use eframe::egui::{self, Color32, RichText};
 use super::theme;
 
 const ICON_CHAT: &str = "\u{f086}"; // comments
+const ICON_LOGS: &str = "\u{f0f6}"; // file-lines
 const ICON_RESOURCES: &str = "\u{f1b3}"; // cubes
 const ICON_SYSTEM: &str = "\u{f2db}"; // microchip
 const ICON_PROVIDERS: &str = "\u{f6ff}"; // network-wired
@@ -136,6 +137,14 @@ const NAV_TREE: &[NavNode] = &[
         label: "Chat Multimodal",
         icon: ICON_CHAT,
         view: Some(MainView::ChatMultimodal),
+        section: None,
+        children: &[],
+    },
+    NavNode {
+        id: "logs",
+        label: "Registros & tareas",
+        icon: ICON_LOGS,
+        view: Some(MainView::Logs),
         section: None,
         children: &[],
     },


### PR DESCRIPTION
## Summary
- add a dedicated "Registros & tareas" entry in the sidebar that activates a new logs main view
- remove the collapsible bottom panel state and render the logs table in the central content area

## Testing
- cargo test

------
https://chatgpt.com/codex/tasks/task_e_68d6fc755a60833397dc0a734f244e0f