### PR TITLE
Refactor shell into reusable VSCode template

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3070,6 +3070,7 @@ dependencies = [
  "serde_json",
  "tokenizers",
  "tokio",
+ "vscode_shell",
 ]
 
 [[package]]
@@ -5380,6 +5381,13 @@ name = "version_check"
 version = "0.9.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
+
+[[package]]
+name = "vscode_shell"
+version = "0.1.0"
+dependencies = [
+ "eframe",
+]
 
 [[package]]
 name = "waker-fn"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,10 +3,15 @@ name = "multimodal-agent-rs"
 version = "0.1.0"
 edition = "2021"
 
+[workspace]
+members = ["templates/vscode_shell"]
+resolver = "2"
+
 [dependencies]
 # UI
 eframe = "0.27.2"
 egui_extras = { version = "0.27.2", features = ["image"] }
+vscode_shell = { path = "templates/vscode_shell" }
 
 # Async
 tokio = { version = "1", features = ["macros", "rt-multi-thread"] }

--- a/src/main.rs
+++ b/src/main.rs
@@ -4,45 +4,11 @@ mod local_providers;
 mod state;
 mod ui;
 
-use eframe::egui;
 use state::AppState;
 
 fn main() -> anyhow::Result<()> {
-    // Inicializa el logger, config, etc. aquí si es necesario
-
-    let options = eframe::NativeOptions {
-        viewport: egui::ViewportBuilder::default()
-            .with_inner_size(egui::vec2(1280.0, 800.0))
-            .with_maximized(true),
-        ..Default::default()
-    };
-
-    eframe::run_native(
-        "Multimodal Agent",
-        options,
-        Box::new(|cc| Box::new(MultimodalApp::new(cc))),
-    )
-    .map_err(|e| anyhow::anyhow!("Eframe error: {}", e))?;
+    vscode_shell::run(|| Box::new(AppState::default()))
+        .map_err(|e| anyhow::anyhow!("Eframe error: {}", e))?;
 
     Ok(())
-}
-
-struct MultimodalApp {
-    state: AppState,
-}
-
-impl MultimodalApp {
-    fn new(cc: &eframe::CreationContext<'_>) -> Self {
-        ui::theme::apply(&cc.egui_ctx);
-
-        Self {
-            state: AppState::default(),
-        }
-    }
-}
-
-impl eframe::App for MultimodalApp {
-    fn update(&mut self, ctx: &egui::Context, _frame: &mut eframe::Frame) {
-        ui::draw_ui(ctx, &mut self.state);
-    }
 }

--- a/src/state.rs
+++ b/src/state.rs
@@ -9,6 +9,7 @@ use std::collections::{BTreeMap, BTreeSet, HashMap};
 use std::fs;
 use std::path::{Path, PathBuf};
 use std::sync::mpsc::{self, Receiver, Sender};
+use vscode_shell::AppShell;
 
 /// Define metadatos reutilizables para paneles y recursos navegables.
 #[derive(Clone, Copy, Debug)]
@@ -5068,5 +5069,15 @@ impl ConditionValue {
                 }
             }
         }
+    }
+}
+
+impl AppShell for AppState {
+    fn init(&mut self, cc: &eframe::CreationContext<'_>) {
+        crate::ui::theme::apply(&cc.egui_ctx);
+    }
+
+    fn update(&mut self, ctx: &eframe::egui::Context) {
+        crate::ui::draw_ui(ctx, self);
     }
 }

--- a/templates/vscode_shell/Cargo.toml
+++ b/templates/vscode_shell/Cargo.toml
@@ -1,0 +1,7 @@
+[package]
+name = "vscode_shell"
+version = "0.1.0"
+edition = "2021"
+
+[dependencies]
+eframe = "0.27.2"

--- a/templates/vscode_shell/README.md
+++ b/templates/vscode_shell/README.md
@@ -1,0 +1,71 @@
+# Plantilla VSCode Shell
+
+Esta plantilla encapsula el arranque de una aplicación basada en `eframe` y
+expone un `run` reutilizable que ejecuta cualquier estado que implemente el
+rasgo [`AppShell`](src/lib.rs).
+
+## Uso básico
+
+```rust
+use vscode_shell::run;
+use vscode_shell::AppShell;
+
+struct MyShell;
+
+impl AppShell for MyShell {
+    fn init(&mut self, _cc: &eframe::CreationContext<'_>) {}
+
+    fn update(&mut self, _ctx: &egui::Context) {}
+}
+
+fn main() {
+    run(|| Box::new(MyShell)).unwrap();
+}
+```
+
+## Inyectar vistas personalizadas mediante _closures_
+
+Puedes combinar un estado propio con _closures_ que reciban `&Context` y un
+estado mutable para construir vistas especializadas. Por ejemplo:
+
+```rust
+use eframe::egui::Context;
+use vscode_shell::AppShell;
+
+struct CustomViewShell<State, View>
+where
+    View: FnMut(&Context, &mut State) + 'static,
+    State: 'static,
+{
+    state: State,
+    view: View,
+}
+
+impl<State, View> CustomViewShell<State, View>
+where
+    View: FnMut(&Context, &mut State) + 'static,
+    State: 'static,
+{
+    fn new(state: State, view: View) -> Self {
+        Self { state, view }
+    }
+}
+
+impl<State, View> AppShell for CustomViewShell<State, View>
+where
+    View: FnMut(&Context, &mut State) + 'static,
+    State: 'static,
+{
+    fn init(&mut self, _cc: &eframe::CreationContext<'_>) {
+        // Configura el estado o el tema inicial si es necesario.
+    }
+
+    fn update(&mut self, ctx: &Context) {
+        (self.view)(ctx, &mut self.state);
+    }
+}
+```
+
+Con este patrón puedes inyectar cualquier vista declarativa sin modificar la
+plantilla: basta con encapsular el estado y la _closure_ dentro de un tipo que
+implemente `AppShell` y pasarlo a `run`.

--- a/templates/vscode_shell/src/lib.rs
+++ b/templates/vscode_shell/src/lib.rs
@@ -1,0 +1,56 @@
+use eframe::egui;
+use eframe::{App, CreationContext, Frame, NativeOptions};
+
+/// Trait que abstrae el estado y comportamiento de una shell basada en egui.
+pub trait AppShell: 'static {
+    /// Inicializa el estado con el contexto de creación de eframe.
+    fn init(&mut self, cc: &CreationContext<'_>);
+
+    /// Renderiza la shell en cada frame con acceso al contexto global de egui.
+    fn update(&mut self, ctx: &egui::Context);
+}
+
+struct MultimodalApp {
+    shell: Box<dyn AppShell>,
+}
+
+impl MultimodalApp {
+    fn new(mut shell: Box<dyn AppShell>, cc: &CreationContext<'_>) -> Self {
+        shell.init(cc);
+        Self { shell }
+    }
+}
+
+impl App for MultimodalApp {
+    fn update(&mut self, ctx: &egui::Context, _frame: &mut Frame) {
+        self.shell.update(ctx);
+    }
+}
+
+/// Ejecuta una aplicación shell reutilizable basada en egui.
+///
+/// El `app_builder` se invoca una única vez para crear el estado concreto que
+/// implementa [`AppShell`]. Este estado será inicializado con el
+/// [`CreationContext`] y posteriormente recibirá llamadas a [`AppShell::update`]
+/// en cada frame.
+pub fn run(app_builder: impl FnOnce() -> Box<dyn AppShell> + 'static) -> Result<(), eframe::Error> {
+    let options = NativeOptions {
+        viewport: egui::ViewportBuilder::default()
+            .with_inner_size(egui::vec2(1280.0, 800.0))
+            .with_maximized(true),
+        ..Default::default()
+    };
+
+    let mut builder = Some(app_builder);
+
+    eframe::run_native(
+        "Multimodal Agent",
+        options,
+        Box::new(move |cc| {
+            let shell = builder
+                .take()
+                .expect("app_builder solo puede ejecutarse una vez")();
+            Box::new(MultimodalApp::new(shell, cc))
+        }),
+    )
+}


### PR DESCRIPTION
## Summary
- add a reusable `vscode_shell` crate with an `AppShell` trait and `run` helper
- update the main binary to build shells through the trait implementation on `AppState`
- document how to wire custom views into the shell template via closures

## Testing
- cargo check

------
https://chatgpt.com/codex/tasks/task_e_68da3c1ecea48333afee43dcba6f8f6e