### PR TITLE
Refactor shell layout into reusable components

### DIFF
--- a/src/state.rs
+++ b/src/state.rs
@@ -10,7 +10,7 @@ use std::collections::{BTreeMap, BTreeSet, HashMap};
 use std::fs;
 use std::path::{Path, PathBuf};
 use std::sync::mpsc::{self, Receiver, Sender};
-use vscode_shell::AppShell;
+use vscode_shell::{layout::LayoutConfig, AppShell};
 
 /// Define metadatos reutilizables para paneles y recursos navegables.
 #[derive(Clone, Copy, Debug)]
@@ -2300,12 +2300,10 @@ pub struct AppState {
     pub personalization_feedback: Option<String>,
     /// Preferencias de enrutamiento por hilo en el chat.
     pub chat_routing: ChatRoutingState,
-    /// Ancho actual del panel lateral izquierdo.
-    pub left_panel_width: f32,
-    /// Controla si el panel lateral derecho está visible.
-    pub right_panel_visible: bool,
-    /// Ancho actual del panel lateral derecho.
-    pub right_panel_width: f32,
+    /// Configuración de layout para los paneles del shell.
+    pub layout: LayoutConfig,
+    /// Solicitud diferida para copiar la conversación actual.
+    pub pending_copy_conversation: bool,
     /// Registros de actividad recientes.
     pub activity_logs: Vec<LogEntry>,
     /// Tablero con tareas programadas y filtros activos.
@@ -2537,9 +2535,8 @@ impl Default for AppState {
             personalization_resources,
             personalization_feedback: None,
             chat_routing,
-            left_panel_width: 280.0,
-            right_panel_visible: true,
-            right_panel_width: 280.0,
+            layout: LayoutConfig::default(),
+            pending_copy_conversation: false,
             activity_logs: default_logs(),
             cron_board: CronBoardState::with_tasks(default_scheduled_tasks()),
             automation_workflows,

--- a/src/ui/header.rs
+++ b/src/ui/header.rs
@@ -1,206 +1,133 @@
-use eframe::egui::{self, Area, Color32, Frame, Id, Margin, Order, RichText, Rounding};
+use eframe::egui;
+use vscode_shell::components::{
+    self, HeaderAction, HeaderModel, HeaderProps, SearchGroup, SearchResult,
+};
 
-use crate::state::AppState;
-use crate::ui::theme::ThemeTokens;
-
-use super::theme;
+use crate::state::{AppState, MainView};
+use crate::ui::layout_bridge::shell_theme;
 
 pub fn draw_header(ctx: &egui::Context, state: &mut AppState) {
-    let tokens = state.theme.clone();
-    egui::TopBottomPanel::top("global_header")
-        .exact_height(64.0)
-        .frame(
-            egui::Frame::none()
-                .fill(theme::color_header())
-                .stroke(theme::subtle_border(&tokens))
-                .inner_margin(egui::Margin {
-                    left: 18.0,
-                    right: 18.0,
-                    top: 10.0,
-                    bottom: 10.0,
-                }),
+    let layout = state.layout.clone();
+    let mut model = AppHeader { state };
+    components::draw_header(ctx, &layout, &mut model);
+}
+
+struct AppHeader<'a> {
+    state: &'a mut AppState,
+}
+
+impl AppHeader<'_> {
+    fn active_view_subtitle(&self) -> Option<String> {
+        Some(
+            match self.state.active_main_view {
+                MainView::ChatMultimodal => "Conversación multimodal",
+                MainView::CronScheduler => "Planificador de tareas",
+                MainView::ActivityFeed => "Actividad reciente",
+                MainView::DebugConsole => "Consola de depuración",
+                MainView::Preferences => "Preferencias avanzadas",
+                MainView::ResourceBrowser => "Explorador de recursos",
+            }
+            .to_string(),
         )
-        .show(ctx, |ui| {
-            ui.set_height(44.0);
-            ui.with_layout(egui::Layout::left_to_right(egui::Align::Center), |ui| {
-                ui.spacing_mut().item_spacing.x = 10.0;
-
-                draw_logo(ui);
-                ui.label(
-                    RichText::new("Jungle MonkAI")
-                        .size(18.0)
-                        .color(theme::color_text_primary())
-                        .strong(),
-                );
-
-                ui.add_space(12.0);
-                ui.separator();
-                ui.add_space(16.0);
-
-                let available = ui.available_width();
-                let search_width = available.clamp(240.0, 420.0);
-                if available > search_width {
-                    ui.add_space(available - search_width);
-                }
-
-                ui.allocate_ui_with_layout(
-                    egui::vec2(search_width, 0.0),
-                    egui::Layout::left_to_right(egui::Align::Center),
-                    |ui| {
-                        ui.set_width(search_width);
-                        draw_search(ui, state, &tokens);
-                    },
-                );
-            });
-        });
-}
-
-fn draw_logo(ui: &mut egui::Ui) {
-    let (rect, _) = ui.allocate_exact_size(egui::vec2(30.0, 30.0), egui::Sense::hover());
-    let painter = ui.painter_at(rect);
-
-    let outer = rect.expand2(egui::vec2(0.0, 0.0));
-    painter.rect(
-        outer,
-        egui::Rounding::same(4.0),
-        Color32::from_rgb(0, 204, 102),
-        egui::Stroke::new(1.5, Color32::from_rgb(10, 70, 40)),
-    );
-
-    let inner_rect = egui::Rect::from_center_size(outer.center(), egui::vec2(22.0, 22.0));
-    painter.circle(
-        inner_rect.center(),
-        inner_rect.width() * 0.35,
-        theme::color_header(),
-        egui::Stroke::new(1.2, Color32::from_rgb(0, 204, 102)),
-    );
-
-    painter.text(
-        inner_rect.center(),
-        egui::Align2::CENTER_CENTER,
-        "JM",
-        egui::FontId::proportional(12.0),
-        Color32::from_rgb(12, 18, 16),
-    );
-}
-
-fn draw_search(ui: &mut egui::Ui, state: &mut AppState, tokens: &ThemeTokens) {
-    let ctx = ui.ctx().clone();
-    let mut search_rect = egui::Rect::NOTHING;
-    let mut has_focus = false;
-
-    Frame::none()
-        .fill(Color32::from_rgb(44, 46, 52))
-        .stroke(theme::subtle_border(tokens))
-        .rounding(Rounding::same(12.0))
-        .inner_margin(Margin::symmetric(14.0, 10.0))
-        .show(ui, |ui| {
-            ui.set_width(ui.available_width());
-            ui.set_height(36.0);
-            ui.horizontal(|ui| {
-                ui.spacing_mut().item_spacing.x = 8.0;
-                ui.label(RichText::new("🔍").color(theme::color_text_weak()));
-                let input_width = ui.available_width().max(160.0);
-                let response = ui.add_sized(
-                    [input_width, 28.0],
-                    egui::TextEdit::singleline(&mut state.search_buffer)
-                        .hint_text("Cmd/Ctrl+K · Buscar modelos, conversaciones y documentos")
-                        .frame(false),
-                );
-                has_focus = response.has_focus();
-                search_rect = response.rect;
-            });
-        });
-
-    let show_palette = has_focus || !state.search_buffer.trim().is_empty();
-    if !show_palette {
-        return;
     }
 
-    let palette_width = search_rect.width().max(320.0);
-    let palette_pos = egui::pos2(search_rect.left(), search_rect.bottom() + 6.0);
-    let groups = state.global_search_groups();
+    fn parse_result_id(id: &str) -> Option<(usize, usize)> {
+        let (group, row) = id.split_once(':')?;
+        let g = group.strip_prefix('g')?.parse().ok()?;
+        let r = row.strip_prefix('r')?.parse().ok()?;
+        Some((g, r))
+    }
+}
 
-    Area::new(Id::new("global_search_palette"))
-        .order(Order::Foreground)
-        .fixed_pos(palette_pos)
-        .show(&ctx, |ui| {
-            egui::Frame::none()
-                .fill(Color32::from_rgb(28, 30, 36))
-                .stroke(theme::subtle_border(tokens))
-                .rounding(Rounding::same(14.0))
-                .inner_margin(Margin::symmetric(16.0, 14.0))
-                .show(ui, |ui| {
-                    ui.set_width(palette_width);
-                    ui.vertical(|ui| {
-                        ui.horizontal(|ui| {
-                            ui.label(
-                                RichText::new("⌘K / Ctrl+K")
-                                    .color(theme::color_text_weak())
-                                    .monospace()
-                                    .size(11.0),
-                            );
-                            ui.add_space(ui.available_width());
-                            ui.label(
-                                RichText::new("Enter para abrir")
-                                    .color(theme::color_text_weak())
-                                    .size(11.0),
-                            );
-                        });
+impl HeaderModel for AppHeader<'_> {
+    fn theme(&self) -> vscode_shell::layout::ShellTheme {
+        shell_theme(&self.state.theme)
+    }
 
-                        ui.add_space(6.0);
+    fn props(&self) -> HeaderProps {
+        HeaderProps {
+            title: "Jungle MonkAI".into(),
+            subtitle: self.active_view_subtitle(),
+            search_placeholder: Some(
+                "Cmd/Ctrl+K · Buscar modelos, conversaciones y documentos".into(),
+            ),
+            actions: vec![
+                HeaderAction {
+                    id: "open_settings".into(),
+                    label: "Preferencias".into(),
+                    icon: Some("⚙️".into()),
+                    shortcut: Some("Ctrl+,".into()),
+                    enabled: true,
+                },
+                HeaderAction {
+                    id: "open_functions".into(),
+                    label: "Funciones".into(),
+                    icon: Some("🧰".into()),
+                    shortcut: Some("Ctrl+Shift+F".into()),
+                    enabled: true,
+                },
+            ],
+            logo_acronym: Some("JM".into()),
+        }
+    }
 
-                        if groups.is_empty() {
-                            ui.colored_label(
-                                theme::color_text_weak(),
-                                "Sin resultados para la búsqueda actual.",
-                            );
-                            return;
-                        }
+    fn search_value(&self) -> String {
+        self.state.search_buffer.clone()
+    }
 
-                        egui::ScrollArea::vertical()
-                            .max_height(260.0)
-                            .show(ui, |ui| {
-                                for group in groups {
-                                    ui.label(
-                                        RichText::new(group.title)
-                                            .color(theme::color_text_primary())
-                                            .strong()
-                                            .size(12.0),
-                                    );
-                                    ui.add_space(4.0);
-                                    for result in group.results {
-                                        egui::Frame::none()
-                                            .fill(Color32::from_rgb(34, 36, 42))
-                                            .stroke(theme::subtle_border(tokens))
-                                            .rounding(Rounding::same(10.0))
-                                            .inner_margin(Margin::symmetric(12.0, 10.0))
-                                            .show(ui, |ui| {
-                                                ui.vertical(|ui| {
-                                                    ui.label(
-                                                        RichText::new(&result.title)
-                                                            .color(theme::color_text_primary())
-                                                            .strong()
-                                                            .size(12.0),
-                                                    );
-                                                    ui.label(
-                                                        RichText::new(&result.subtitle)
-                                                            .color(theme::color_text_weak())
-                                                            .size(11.0),
-                                                    );
-                                                    ui.label(
-                                                        RichText::new(&result.action_hint)
-                                                            .color(theme::color_text_weak())
-                                                            .size(10.0)
-                                                            .italics(),
-                                                    );
-                                                });
-                                            });
-                                        ui.add_space(6.0);
-                                    }
-                                }
-                            });
-                    });
-                });
-        });
+    fn set_search_value(&mut self, value: String) {
+        self.state.search_buffer = value;
+    }
+
+    fn search_palette(&self) -> Vec<SearchGroup> {
+        self.state
+            .global_search_groups()
+            .into_iter()
+            .enumerate()
+            .map(|(group_index, group)| SearchGroup {
+                id: format!("g{}", group_index),
+                title: group.title,
+                results: group
+                    .results
+                    .into_iter()
+                    .enumerate()
+                    .map(|(result_index, result)| SearchResult {
+                        id: format!("g{}:r{}", group_index, result_index),
+                        title: result.title,
+                        subtitle: result.subtitle,
+                        action_hint: Some(result.action_hint),
+                    })
+                    .collect(),
+            })
+            .collect()
+    }
+
+    fn on_search_result(&mut self, result_id: &str) {
+        if let Some((group_index, result_index)) = Self::parse_result_id(result_id) {
+            if let Some(group) = self.state.global_search_groups().get(group_index) {
+                if let Some(result) = group.results.get(result_index) {
+                    self.state.search_buffer = result.title.clone();
+                    if !self
+                        .state
+                        .global_search_recent
+                        .iter()
+                        .any(|entry| entry == &result.title)
+                    {
+                        self.state
+                            .global_search_recent
+                            .insert(0, result.title.clone());
+                        self.state.global_search_recent.truncate(10);
+                    }
+                }
+            }
+        }
+    }
+
+    fn on_action(&mut self, action_id: &str) {
+        match action_id {
+            "open_settings" => self.state.show_settings_modal = true,
+            "open_functions" => self.state.show_functions_modal = true,
+            _ => {}
+        }
+    }
 }

--- a/src/ui/layout_bridge.rs
+++ b/src/ui/layout_bridge.rs
@@ -1,0 +1,16 @@
+use vscode_shell::layout::ShellTheme;
+
+use crate::ui::theme::ThemeTokens;
+
+pub fn shell_theme(tokens: &ThemeTokens) -> ShellTheme {
+    ShellTheme {
+        root_background: tokens.palette.root_background,
+        surface_background: tokens.palette.panel_background,
+        header_background: tokens.palette.header_background,
+        border: tokens.palette.border,
+        text_primary: tokens.palette.text_primary,
+        text_muted: tokens.palette.text_weak,
+        accent: tokens.palette.primary,
+        accent_soft: tokens.palette.hover_background,
+    }
+}

--- a/src/ui/mod.rs
+++ b/src/ui/mod.rs
@@ -3,6 +3,7 @@ use eframe::egui;
 
 pub mod chat;
 pub mod header;
+pub mod layout_bridge;
 pub mod logs;
 pub mod modals;
 pub mod resource_sidebar;
@@ -25,6 +26,12 @@ pub fn draw_ui(ctx: &egui::Context, state: &mut AppState) {
     sidebar::draw_sidebar(ctx, state);
     resource_sidebar::draw_resource_sidebar(ctx, state);
     chat::draw_main_content(ctx, state);
+
+    if state.layout.take_navigation_signal().is_some()
+        || state.layout.take_resource_signal().is_some()
+    {
+        ctx.request_repaint();
+    }
 
     modals::draw_settings_modal(ctx, state);
     modals::draw_functions_modal(ctx, state);

--- a/src/ui/resource_sidebar.rs
+++ b/src/ui/resource_sidebar.rs
@@ -1,500 +1,197 @@
-use crate::state::{AppState, ChatMessage};
-use eframe::egui::{self, Color32, Frame, Margin, RichText, Stroke};
+use eframe::egui;
+use vscode_shell::components::{
+    self, ResourceItem, ResourcePanelModel, ResourcePanelProps, ResourceSectionProps,
+};
 
-use super::theme;
-use std::path::Path;
-
-const ICON_JARVIS: &str = "\u{f0a0}"; // hard-drive
-const COLOR_WARNING: Color32 = Color32::from_rgb(255, 196, 0);
-const ICON_COLLAPSE_RIGHT: &str = "\u{f054}"; // chevron-right
-const ICON_EXPAND_LEFT: &str = "\u{f053}"; // chevron-left
-
-const RIGHT_PANEL_WIDTH: f32 = 280.0;
-const COLLAPSED_HANDLE_WIDTH: f32 = 28.0;
+use crate::state::{
+    AppState, ChatMessage, MainView, RemoteProviderKind, ResourceSection, AVAILABLE_CUSTOM_ACTIONS,
+};
+use crate::ui::layout_bridge::shell_theme;
 
 pub fn draw_resource_sidebar(ctx: &egui::Context, state: &mut AppState) {
-    state.right_panel_width = RIGHT_PANEL_WIDTH;
+    let mut layout = state.layout.clone();
+    {
+        let mut model = AppResourcePanel { state };
+        components::draw_resource_panel(ctx, &mut layout, &mut model);
+    }
+    state.layout = layout;
 
-    if !state.right_panel_visible {
-        egui::SidePanel::right("resource_panel_collapsed")
-            .resizable(false)
-            .exact_width(COLLAPSED_HANDLE_WIDTH)
-            .frame(
-                egui::Frame::none()
-                    .fill(theme::color_panel())
-                    .stroke(theme::subtle_border(&state.theme))
-                    .inner_margin(egui::Margin::same(8.0))
-                    .rounding(egui::Rounding::same(14.0)),
-            )
-            .show(ctx, |ui| {
-                ui.vertical_centered(|ui| {
-                    ui.add_space(12.0);
-                    let button = egui::Button::new(
-                        RichText::new(ICON_EXPAND_LEFT)
-                            .font(theme::icon_font(16.0))
-                            .color(theme::color_text_primary()),
-                    )
-                    .frame(false);
-                    if ui.add_sized([20.0, 24.0], button).clicked() {
-                        state.right_panel_visible = true;
-                    }
-                });
+    if state.pending_copy_conversation {
+        copy_conversation_to_clipboard(ctx, &state.chat_messages);
+        state.pending_copy_conversation = false;
+    }
+}
+
+struct AppResourcePanel<'a> {
+    state: &'a mut AppState,
+}
+
+impl AppResourcePanel<'_> {
+    fn status_sections(&self) -> Vec<ResourceSectionProps> {
+        let jarvis_status = self
+            .state
+            .jarvis_status
+            .clone()
+            .unwrap_or_else(|| "Jarvis listo para iniciar".to_string());
+        let active_model = self
+            .state
+            .jarvis_active_model
+            .as_ref()
+            .map(|model| model.display_label())
+            .unwrap_or_else(|| "Sin modelo seleccionado".to_string());
+
+        vec![ResourceSectionProps {
+            id: "status".into(),
+            title: "Jarvis runtime".into(),
+            description: Some("Resumen del entorno local".into()),
+            items: vec![
+                ResourceItem {
+                    id: "status:jarvis".into(),
+                    title: jarvis_status,
+                    subtitle: Some(format!(
+                        "Inicio automático: {}",
+                        if self.state.jarvis_auto_start {
+                            "activado"
+                        } else {
+                            "manual"
+                        }
+                    )),
+                    selected: false,
+                },
+                ResourceItem {
+                    id: "status:model".into(),
+                    title: format!("Modelo configurado: {}", active_model),
+                    subtitle: Some(format!("Alias: {}", self.state.jarvis_alias)),
+                    selected: false,
+                },
+            ],
+        }]
+    }
+
+    fn quick_actions(&self) -> ResourceSectionProps {
+        let mut items = vec![
+            ResourceItem {
+                id: "action:open_settings".into(),
+                title: "Abrir preferencias".into(),
+                subtitle: Some("Configura proveedores y automatizaciones".into()),
+                selected: false,
+            },
+            ResourceItem {
+                id: "action:open_functions".into(),
+                title: "Explorar funciones".into(),
+                subtitle: Some(format!(
+                    "{} funciones personalizables",
+                    AVAILABLE_CUSTOM_ACTIONS.len()
+                )),
+                selected: false,
+            },
+        ];
+
+        if !self.state.chat_messages.is_empty() {
+            items.push(ResourceItem {
+                id: "action:copy_conversation".into(),
+                title: "Copiar conversación".into(),
+                subtitle: Some("Guarda el historial actual en el portapapeles".into()),
+                selected: false,
             });
+        }
+
+        ResourceSectionProps {
+            id: "quick-actions".into(),
+            title: "Acciones rápidas".into(),
+            description: Some("Atajos frecuentes durante la sesión".into()),
+            items,
+        }
+    }
+
+    fn resource_navigation(&self) -> ResourceSectionProps {
+        let mut items = Vec::new();
+        for provider in [
+            RemoteProviderKind::Anthropic,
+            RemoteProviderKind::OpenAi,
+            RemoteProviderKind::Groq,
+        ] {
+            let section = ResourceSection::RemoteCatalog(provider);
+            let metadata = section.metadata();
+            items.push(ResourceItem {
+                id: super::sidebar::resource_id(&section),
+                title: metadata
+                    .breadcrumb
+                    .last()
+                    .copied()
+                    .unwrap_or(metadata.title)
+                    .to_string(),
+                subtitle: Some(metadata.description.to_string()),
+                selected: self
+                    .state
+                    .selected_resource
+                    .map(|current| current == section)
+                    .unwrap_or(false)
+                    && self.state.active_main_view == MainView::ResourceBrowser,
+            });
+        }
+        ResourceSectionProps {
+            id: "resource-nav".into(),
+            title: "Catálogos destacados".into(),
+            description: Some("Explora proveedores conectados".into()),
+            items,
+        }
+    }
+}
+
+fn copy_conversation_to_clipboard(ctx: &egui::Context, messages: &[ChatMessage]) {
+    if messages.is_empty() {
         return;
     }
 
-    egui::SidePanel::right("resource_panel")
-        .resizable(false)
-        .exact_width(state.right_panel_width)
-        .frame(
-            egui::Frame::none()
-                .fill(theme::color_panel())
-                .stroke(theme::subtle_border(&state.theme))
-                .inner_margin(egui::Margin {
-                    left: 18.0,
-                    right: 18.0,
-                    top: 18.0,
-                    bottom: 18.0,
-                })
-                .rounding(egui::Rounding::same(14.0)),
-        )
-        .show(ctx, |ui| {
-            let available_height = ui.available_height();
-            let clip_rect = ui.max_rect();
-            ui.set_clip_rect(clip_rect);
-            ui.set_min_height(available_height);
-            ui.set_width(clip_rect.width());
-
-            ui.with_layout(egui::Layout::top_down(egui::Align::LEFT), |ui| {
-                ui.set_width(ui.available_width());
-                ui.horizontal(|ui| {
-                    let button = egui::Button::new(
-                        RichText::new(ICON_COLLAPSE_RIGHT)
-                            .font(theme::icon_font(15.0))
-                            .color(theme::color_text_primary()),
-                    )
-                    .frame(false);
-                    if ui.add_sized([26.0, 24.0], button).clicked() {
-                        state.right_panel_visible = false;
-                    }
-                    ui.heading(
-                        RichText::new("Resumen de recursos")
-                            .color(theme::color_text_primary())
-                            .strong(),
-                    );
-                });
-                ui.label(RichText::new("Actualizado ahora").color(theme::color_text_weak()));
-                ui.add_space(12.0);
-
-                egui::ScrollArea::vertical()
-                    .id_source("resource_summary_scroll")
-                    .auto_shrink([false, false])
-                    .show(ui, |ui| {
-                        ui.set_width(ui.available_width());
-                        draw_jarvis_card(ui, state);
-                        ui.add_space(12.0);
-                        draw_models_card(ui, state);
-                        ui.add_space(12.0);
-                        draw_actions_section(ui, state);
-                    });
-            });
-        });
-}
-
-fn draw_led(ui: &mut egui::Ui, color: Color32, tooltip: &str) {
-    let (rect, response) = ui.allocate_exact_size(egui::vec2(18.0, 18.0), egui::Sense::hover());
-    let painter = ui.painter_at(rect);
-    let center = rect.center();
-    painter.circle_filled(center, 6.0, color);
-    painter.circle_stroke(center, 6.0, Stroke::new(1.0, color.gamma_multiply(0.5)));
-    painter.circle_stroke(center, 7.0, Stroke::new(1.2, color.gamma_multiply(0.3)));
-    if !tooltip.trim().is_empty() {
-        response.on_hover_text(tooltip);
-    }
-}
-
-fn draw_actions_section(ui: &mut egui::Ui, state: &AppState) {
-    ui.label(
-        RichText::new("Acciones")
-            .color(theme::color_text_primary())
-            .strong(),
-    );
-    ui.label(
-        RichText::new("Herramientas rápidas para tu sesión actual")
-            .color(theme::color_text_weak())
-            .size(12.0),
-    );
-    ui.add_space(8.0);
-
-    Frame::none()
-        .fill(Color32::from_rgb(28, 30, 36))
-        .stroke(theme::subtle_border(&state.theme))
-        .rounding(egui::Rounding::same(14.0))
-        .inner_margin(Margin::symmetric(16.0, 14.0))
-        .show(ui, |ui| {
-            ui.set_width(ui.available_width());
-
-            let button = theme::secondary_button(
-                RichText::new("Copiar conversación")
-                    .color(theme::color_text_primary())
-                    .strong(),
-                &state.theme,
-            );
-
-            if ui.add_sized([ui.available_width(), 32.0], button).clicked() {
-                let transcript = build_conversation_transcript(&state.chat_messages);
-                ui.output_mut(|out| out.copied_text = transcript);
-                ui.colored_label(
-                    theme::color_text_weak(),
-                    "Conversación copiada al portapapeles",
-                );
-            }
-        });
-}
-
-fn build_conversation_transcript(messages: &[ChatMessage]) -> String {
     let mut transcript = String::new();
-
     for (index, message) in messages.iter().enumerate() {
         if index > 0 {
             transcript.push_str("\n\n");
         }
-
         let status = if message.is_pending() {
             " (pendiente)"
         } else {
             ""
         };
-
         transcript.push_str(&format!(
             "[{}] {}{}:\n{}",
             message.timestamp, message.sender, status, message.text
         ));
     }
 
-    transcript
+    ctx.output_mut(|out| out.copied_text = transcript);
 }
 
-enum StatusIndicator {
-    Led { color: Color32, status: String },
-}
+impl ResourcePanelModel for AppResourcePanel<'_> {
+    fn theme(&self) -> vscode_shell::layout::ShellTheme {
+        shell_theme(&self.state.theme)
+    }
 
-struct ResourceDetail {
-    label: Option<String>,
-    value: String,
-}
+    fn props(&self) -> ResourcePanelProps {
+        let mut sections = self.status_sections();
+        sections.push(self.quick_actions());
+        sections.push(self.resource_navigation());
 
-impl ResourceDetail {
-    fn value(value: impl Into<String>) -> Self {
-        Self {
-            label: None,
-            value: value.into(),
+        ResourcePanelProps {
+            title: Some("Recursos".into()),
+            sections,
+            collapse_button_tooltip: Some("Ocultar panel de recursos".into()),
         }
     }
 
-    fn labeled(label: impl Into<String>, value: impl Into<String>) -> Self {
-        Self {
-            label: Some(label.into()),
-            value: value.into(),
-        }
-    }
-}
-
-struct ModelOverview {
-    handle: &'static str,
-    detail: String,
-    indicator: StatusIndicator,
-}
-
-fn draw_jarvis_card(ui: &mut egui::Ui, state: &AppState) {
-    Frame::none()
-        .fill(Color32::from_rgb(28, 30, 36))
-        .stroke(theme::subtle_border(&state.theme))
-        .rounding(egui::Rounding::same(14.0))
-        .inner_margin(Margin::symmetric(16.0, 14.0))
-        .show(ui, |ui| {
-            ui.set_width(ui.available_width());
-
-            let indicator = jarvis_indicator(state);
-            ui.horizontal(|ui| {
-                ui.spacing_mut().item_spacing.x = 12.0;
-                ui.label(
-                    RichText::new(ICON_JARVIS)
-                        .font(theme::icon_font(22.0))
-                        .color(theme::color_primary()),
-                );
-                ui.vertical(|ui| {
-                    ui.label(
-                        RichText::new("Jarvis")
-                            .color(theme::color_text_primary())
-                            .strong(),
-                    );
-                    ui.label(
-                        RichText::new("Runtime de incrustaciones")
-                            .color(theme::color_text_weak())
-                            .size(12.0),
-                    );
-                });
-                ui.with_layout(egui::Layout::right_to_left(egui::Align::Center), |ui| {
-                    draw_status_led(ui, &indicator);
-                });
-            });
-
-            let details = jarvis_details(state);
-            if !details.is_empty() {
-                ui.add_space(10.0);
-                ui.spacing_mut().item_spacing.y = 6.0;
-                for detail in &details {
-                    if let Some(label) = &detail.label {
-                        ui.label(
-                            RichText::new(label)
-                                .color(theme::color_text_weak())
-                                .size(12.0),
-                        );
-                    }
-                    ui.label(
-                        RichText::new(&detail.value)
-                            .color(theme::color_text_primary())
-                            .size(13.0),
-                    );
+    fn on_item_selected(&mut self, item_id: &str) {
+        match item_id {
+            "action:open_settings" => self.state.show_settings_modal = true,
+            "action:open_functions" => self.state.show_functions_modal = true,
+            "action:copy_conversation" => self.state.pending_copy_conversation = true,
+            _ => {
+                if let Some(section) = super::sidebar::parse_resource_id(item_id) {
+                    self.state.selected_resource = Some(section);
+                    self.state.active_main_view = MainView::ResourceBrowser;
+                    self.state.sync_active_tab_from_view();
                 }
             }
-        });
-}
-
-fn draw_models_card(ui: &mut egui::Ui, state: &AppState) {
-    let entries = vec![
-        ModelOverview {
-            handle: "@gpt",
-            detail: provider_model_caption(&state.openai_default_model),
-            indicator: provider_indicator(
-                state.openai_test_status.as_ref(),
-                state.config.openai.api_key.as_deref(),
-                "OpenAI",
-                "Pendiente de prueba",
-            ),
-        },
-        ModelOverview {
-            handle: "@claude",
-            detail: provider_model_caption(&state.claude_default_model),
-            indicator: provider_indicator(
-                state.anthropic_test_status.as_ref(),
-                state.config.anthropic.api_key.as_deref(),
-                "Anthropic",
-                "Pendiente de prueba",
-            ),
-        },
-        ModelOverview {
-            handle: "@groq",
-            detail: provider_model_caption(&state.groq_default_model),
-            indicator: provider_indicator(
-                state.groq_test_status.as_ref(),
-                state.config.groq.api_key.as_deref(),
-                "Groq",
-                "Pendiente de prueba",
-            ),
-        },
-    ];
-
-    Frame::none()
-        .fill(Color32::from_rgb(28, 30, 36))
-        .stroke(theme::subtle_border(&state.theme))
-        .rounding(egui::Rounding::same(14.0))
-        .inner_margin(Margin::symmetric(16.0, 14.0))
-        .show(ui, |ui| {
-            ui.set_width(ui.available_width());
-            ui.label(
-                RichText::new("Modelos conectados")
-                    .color(theme::color_text_primary())
-                    .strong(),
-            );
-
-            for (index, entry) in entries.iter().enumerate() {
-                if index > 0 {
-                    ui.add_space(10.0);
-                    ui.separator();
-                    ui.add_space(10.0);
-                } else {
-                    ui.add_space(8.0);
-                }
-
-                ui.horizontal(|ui| {
-                    ui.spacing_mut().item_spacing.x = 10.0;
-                    ui.label(
-                        RichText::new(entry.handle)
-                            .color(theme::color_text_primary())
-                            .strong(),
-                    );
-                    ui.with_layout(egui::Layout::right_to_left(egui::Align::Center), |ui| {
-                        draw_status_led(ui, &entry.indicator);
-                    });
-                });
-
-                ui.add_space(4.0);
-                ui.label(
-                    RichText::new(&entry.detail)
-                        .color(theme::color_text_weak())
-                        .size(12.0),
-                );
-            }
-        });
-}
-
-fn draw_status_led(ui: &mut egui::Ui, indicator: &StatusIndicator) {
-    let StatusIndicator::Led { color, status } = indicator;
-    draw_led(ui, *color, status);
-}
-
-fn provider_model_caption(model: &str) -> String {
-    let trimmed = model.trim();
-    if trimmed.is_empty() {
-        "[sin modelo configurado]".to_string()
-    } else {
-        format!("[{}]", trimmed)
-    }
-}
-
-fn jarvis_indicator(state: &AppState) -> StatusIndicator {
-    if let Some(status) = &state.jarvis_status {
-        return led_from_message(status);
-    }
-
-    if state.installed_local_models.is_empty() {
-        StatusIndicator::Led {
-            color: COLOR_WARNING,
-            status: "Sin modelos instalados".to_string(),
         }
-    } else {
-        StatusIndicator::Led {
-            color: theme::color_success(),
-            status: format!("{} modelos listos", state.installed_local_models.len()),
-        }
-    }
-}
-
-fn jarvis_details(state: &AppState) -> Vec<ResourceDetail> {
-    if let Some(model) = &state.jarvis_active_model {
-        let trimmed_path = state.jarvis_model_path.trim();
-        let mut details = vec![ResourceDetail::labeled("Modelo", model.display_label())];
-
-        if let Some(record) = state.installed_model(model) {
-            let size = format_sidebar_bytes(record.size_bytes);
-            details.push(ResourceDetail::labeled("Tamaño", size));
-            let timestamp = format_sidebar_timestamp(record.installed_at);
-            details.push(ResourceDetail::labeled("Instalado", timestamp));
-
-            let effective_path = if record.install_path.trim().is_empty() {
-                trimmed_path
-            } else {
-                record.install_path.as_str()
-            };
-
-            let display = Path::new(effective_path)
-                .file_name()
-                .and_then(|name| name.to_str())
-                .map(|name| name.to_string())
-                .unwrap_or_else(|| effective_path.to_string());
-            details.push(ResourceDetail::labeled("Ruta", display));
-            return details;
-        }
-
-        if trimmed_path.is_empty() {
-            details.push(ResourceDetail::labeled("Ruta", "Sin configurar"));
-        } else {
-            let path = Path::new(trimmed_path);
-            let display = path
-                .file_name()
-                .and_then(|name| name.to_str())
-                .map(|name| name.to_string())
-                .unwrap_or_else(|| trimmed_path.to_string());
-            details.push(ResourceDetail::labeled("Ruta", display));
-        }
-
-        details
-    } else if state.jarvis_model_path.trim().is_empty() {
-        vec![
-            ResourceDetail::value("Sin modelo"),
-            ResourceDetail::labeled("Ruta", "Configurar"),
-        ]
-    } else {
-        vec![ResourceDetail::labeled(
-            "Ruta",
-            state.jarvis_model_path.trim().to_string(),
-        )]
-    }
-}
-
-fn format_sidebar_bytes(bytes: u64) -> String {
-    if bytes == 0 {
-        return "—".to_string();
-    }
-
-    const UNITS: [&str; 4] = ["B", "KB", "MB", "GB"];
-    let mut value = bytes as f64;
-    let mut unit = 0usize;
-    while value >= 1024.0 && unit < UNITS.len() - 1 {
-        value /= 1024.0;
-        unit += 1;
-    }
-
-    if unit == 0 {
-        format!("{} {}", bytes, UNITS[unit])
-    } else {
-        format!("{:.1} {}", value, UNITS[unit])
-    }
-}
-
-fn format_sidebar_timestamp(timestamp: chrono::DateTime<chrono::Utc>) -> String {
-    let local: chrono::DateTime<chrono::Local> = chrono::DateTime::from(timestamp);
-    local.format("%d %b %Y").to_string()
-}
-
-fn provider_indicator(
-    status: Option<&String>,
-    api_key: Option<&str>,
-    provider: &str,
-    fallback: &str,
-) -> StatusIndicator {
-    if let Some(message) = status {
-        return led_from_message(message);
-    }
-
-    let has_key = api_key.is_some_and(|key| !key.trim().is_empty());
-    if has_key {
-        StatusIndicator::Led {
-            color: COLOR_WARNING,
-            status: fallback.to_string(),
-        }
-    } else {
-        StatusIndicator::Led {
-            color: COLOR_WARNING,
-            status: format!("{} sin API key", provider),
-        }
-    }
-}
-
-fn led_from_message(message: &str) -> StatusIndicator {
-    let lower = message.to_lowercase();
-    let color = if lower.contains("error")
-        || lower.contains("fail")
-        || lower.contains("timeout")
-        || lower.contains("rechaz")
-    {
-        theme::color_danger()
-    } else if lower.contains("alcanzable")
-        || lower.contains("reachable")
-        || lower.contains("ok")
-        || lower.contains("complet")
-        || lower.contains("instal")
-        || lower.contains("disponible")
-    {
-        theme::color_success()
-    } else {
-        COLOR_WARNING
-    };
-
-    StatusIndicator::Led {
-        color,
-        status: message.to_string(),
     }
 }

--- a/src/ui/theme.rs
+++ b/src/ui/theme.rs
@@ -328,10 +328,12 @@ pub fn color_primary() -> Color32 {
     theme_tokens().read().unwrap().palette.primary
 }
 
+#[allow(dead_code)]
 pub fn color_panel() -> Color32 {
     theme_tokens().read().unwrap().palette.root_background
 }
 
+#[allow(dead_code)]
 pub fn color_header() -> Color32 {
     theme_tokens().read().unwrap().palette.header_background
 }

--- a/templates/vscode_shell/src/components/header.rs
+++ b/templates/vscode_shell/src/components/header.rs
@@ -1,0 +1,274 @@
+use eframe::egui::{self, Align, Color32, Id, Layout, Margin, Order, RichText, Rounding, Sense};
+
+use crate::layout::{LayoutConfig, ShellTheme};
+
+#[derive(Clone, Debug)]
+pub struct HeaderProps {
+    pub title: String,
+    pub subtitle: Option<String>,
+    pub search_placeholder: Option<String>,
+    pub actions: Vec<HeaderAction>,
+    pub logo_acronym: Option<String>,
+}
+
+impl Default for HeaderProps {
+    fn default() -> Self {
+        Self {
+            title: "Shell".to_string(),
+            subtitle: None,
+            search_placeholder: None,
+            actions: Vec::new(),
+            logo_acronym: Some("VS".to_string()),
+        }
+    }
+}
+
+#[derive(Clone, Debug)]
+pub struct HeaderAction {
+    pub id: String,
+    pub label: String,
+    pub icon: Option<String>,
+    pub shortcut: Option<String>,
+    pub enabled: bool,
+}
+
+impl HeaderAction {
+    pub fn new(id: impl Into<String>, label: impl Into<String>) -> Self {
+        Self {
+            id: id.into(),
+            label: label.into(),
+            icon: None,
+            shortcut: None,
+            enabled: true,
+        }
+    }
+}
+
+#[derive(Clone, Debug)]
+pub struct SearchGroup {
+    pub id: String,
+    pub title: String,
+    pub results: Vec<SearchResult>,
+}
+
+#[derive(Clone, Debug)]
+pub struct SearchResult {
+    pub id: String,
+    pub title: String,
+    pub subtitle: String,
+    pub action_hint: Option<String>,
+}
+
+pub trait HeaderModel {
+    fn theme(&self) -> ShellTheme;
+    fn props(&self) -> HeaderProps;
+    fn search_value(&self) -> String;
+    fn set_search_value(&mut self, value: String);
+    fn search_palette(&self) -> Vec<SearchGroup>;
+    fn on_search_result(&mut self, result_id: &str);
+    fn on_action(&mut self, action_id: &str);
+}
+
+pub fn draw_header(ctx: &egui::Context, layout: &LayoutConfig, model: &mut dyn HeaderModel) {
+    if !layout.show_header {
+        return;
+    }
+
+    let theme = model.theme();
+    let props = model.props();
+
+    egui::TopBottomPanel::top("shell_header")
+        .exact_height(64.0)
+        .frame(
+            egui::Frame::none()
+                .fill(theme.header_background)
+                .stroke(egui::Stroke::new(1.0, theme.border))
+                .inner_margin(Margin {
+                    left: 16.0,
+                    right: 16.0,
+                    top: 10.0,
+                    bottom: 10.0,
+                }),
+        )
+        .show(ctx, |ui| {
+            ui.set_height(44.0);
+            ui.with_layout(Layout::left_to_right(Align::Center), |ui| {
+                ui.spacing_mut().item_spacing.x = 10.0;
+                draw_logo(ui, &theme, props.logo_acronym.as_deref().unwrap_or("VS"));
+
+                ui.vertical(|ui| {
+                    ui.strong(
+                        RichText::new(&props.title)
+                            .color(theme.text_primary)
+                            .size(18.0),
+                    );
+                    if let Some(subtitle) = props.subtitle.as_ref() {
+                        ui.small(RichText::new(subtitle).color(theme.text_muted));
+                    }
+                });
+
+                ui.add_space(12.0);
+                ui.separator();
+                ui.add_space(16.0);
+
+                if let Some(search_placeholder) = props.search_placeholder {
+                    draw_search(ui, model, &theme, &search_placeholder);
+                }
+
+                ui.add_space(ui.available_width());
+                for action in props.actions.iter() {
+                    let mut button = egui::Button::new(
+                        match &action.icon {
+                            Some(icon) => RichText::new(format!("{} {}", icon, action.label)),
+                            None => RichText::new(action.label.clone()),
+                        }
+                        .color(theme.text_primary),
+                    );
+                    button = button.min_size(egui::vec2(0.0, 32.0));
+                    if !action.enabled {
+                        button = button.sense(Sense::hover());
+                    }
+                    let mut response = ui.add(button);
+                    if let Some(shortcut) = &action.shortcut {
+                        response = response.on_hover_text(shortcut);
+                    }
+                    if action.enabled && response.clicked() {
+                        model.on_action(&action.id);
+                    }
+                }
+            });
+        });
+}
+
+fn draw_logo(ui: &mut egui::Ui, theme: &ShellTheme, acronym: &str) {
+    let (rect, _) = ui.allocate_exact_size(egui::vec2(32.0, 32.0), Sense::hover());
+    let painter = ui.painter_at(rect);
+
+    painter.rect(
+        rect,
+        Rounding::same(6.0),
+        theme.accent_soft,
+        egui::Stroke::new(1.5, theme.accent),
+    );
+
+    painter.text(
+        rect.center(),
+        egui::Align2::CENTER_CENTER,
+        acronym,
+        egui::FontId::proportional(14.0),
+        theme.text_primary,
+    );
+}
+
+fn draw_search(
+    ui: &mut egui::Ui,
+    model: &mut dyn HeaderModel,
+    theme: &ShellTheme,
+    placeholder: &str,
+) {
+    let mut query = model.search_value();
+    let mut search_rect = egui::Rect::NOTHING;
+
+    egui::Frame::none()
+        .fill(theme.surface_background)
+        .stroke(egui::Stroke::new(1.0, theme.border))
+        .rounding(Rounding::same(12.0))
+        .inner_margin(Margin::symmetric(14.0, 10.0))
+        .show(ui, |ui| {
+            ui.set_width(ui.available_width().max(260.0));
+            ui.set_height(36.0);
+            ui.horizontal(|ui| {
+                ui.spacing_mut().item_spacing.x = 8.0;
+                ui.label(RichText::new("🔍").color(theme.text_muted));
+                let response = ui.add_sized(
+                    [ui.available_width().max(160.0), 24.0],
+                    egui::TextEdit::singleline(&mut query)
+                        .hint_text(placeholder)
+                        .frame(false),
+                );
+                if response.changed() {
+                    model.set_search_value(query.clone());
+                }
+                search_rect = response.rect;
+            });
+        });
+
+    let groups = model.search_palette();
+    if groups.is_empty() {
+        return;
+    }
+
+    let palette_width = search_rect.width().max(320.0);
+    let palette_pos = egui::pos2(search_rect.left(), search_rect.bottom() + 6.0);
+    let ctx = ui.ctx().clone();
+
+    egui::Area::new(Id::new("shell_header_palette"))
+        .order(Order::Foreground)
+        .fixed_pos(palette_pos)
+        .show(&ctx, |ui| {
+            egui::Frame::none()
+                .fill(theme.surface_background)
+                .stroke(egui::Stroke::new(1.0, theme.border))
+                .rounding(Rounding::same(10.0))
+                .inner_margin(Margin::symmetric(16.0, 12.0))
+                .show(ui, |ui| {
+                    ui.set_width(palette_width);
+                    egui::ScrollArea::vertical()
+                        .max_height(260.0)
+                        .show(ui, |ui| {
+                            for group in groups {
+                                ui.label(
+                                    RichText::new(&group.title)
+                                        .color(theme.text_primary)
+                                        .strong()
+                                        .size(12.0),
+                                );
+                                ui.add_space(6.0);
+                                for result in group.results {
+                                    let response = egui::Frame::none()
+                                        .fill(Color32::from_rgba_unmultiplied(255, 255, 255, 6))
+                                        .stroke(egui::Stroke::new(1.0, theme.border))
+                                        .rounding(Rounding::same(8.0))
+                                        .inner_margin(Margin::symmetric(12.0, 8.0))
+                                        .show(ui, |ui| {
+                                            ui.vertical(|ui| {
+                                                ui.label(
+                                                    RichText::new(&result.title)
+                                                        .color(theme.text_primary)
+                                                        .strong(),
+                                                );
+                                                ui.label(
+                                                    RichText::new(&result.subtitle)
+                                                        .color(theme.text_muted)
+                                                        .size(11.0),
+                                                );
+                                                if let Some(hint) = result.action_hint.as_ref() {
+                                                    ui.small(
+                                                        RichText::new(hint)
+                                                            .color(theme.text_muted)
+                                                            .italics(),
+                                                    );
+                                                }
+                                            });
+                                        })
+                                        .response;
+
+                                    let mut response =
+                                        ui.interact(response.rect, response.id, Sense::click());
+                                    response = response.on_hover_text("Enter para abrir");
+                                    if response.clicked() {
+                                        model.on_search_result(&result.id);
+                                    }
+                                    response.context_menu(|ui| {
+                                        if ui.button("Seleccionar").clicked() {
+                                            model.on_search_result(&result.id);
+                                            ui.close_menu();
+                                        }
+                                    });
+                                }
+                                ui.add_space(10.0);
+                            }
+                        });
+                });
+        });
+}

--- a/templates/vscode_shell/src/components/main_content.rs
+++ b/templates/vscode_shell/src/components/main_content.rs
@@ -1,0 +1,166 @@
+use eframe::egui::{self, Align, Layout, Margin, RichText, Sense};
+
+use crate::layout::{main_surface_frame, LayoutConfig, ShellTheme};
+
+#[derive(Clone, Debug)]
+pub struct MainContentProps {
+    pub title: Option<String>,
+    pub subtitle: Option<String>,
+    pub actions: Vec<MainContentAction>,
+    pub tabs: Vec<MainContentTab>,
+    pub active_tab: Option<String>,
+}
+
+impl Default for MainContentProps {
+    fn default() -> Self {
+        Self {
+            title: None,
+            subtitle: None,
+            actions: Vec::new(),
+            tabs: Vec::new(),
+            active_tab: None,
+        }
+    }
+}
+
+#[derive(Clone, Debug)]
+pub struct MainContentAction {
+    pub id: String,
+    pub label: String,
+    pub icon: Option<String>,
+    pub enabled: bool,
+}
+
+impl MainContentAction {
+    pub fn new(id: impl Into<String>, label: impl Into<String>) -> Self {
+        Self {
+            id: id.into(),
+            label: label.into(),
+            icon: None,
+            enabled: true,
+        }
+    }
+}
+
+#[derive(Clone, Debug)]
+pub struct MainContentTab {
+    pub id: String,
+    pub label: String,
+    pub icon: Option<String>,
+}
+
+pub trait MainContentModel {
+    fn theme(&self) -> ShellTheme;
+    fn props(&self) -> MainContentProps;
+    fn on_action(&mut self, action_id: &str);
+    fn on_tab_selected(&mut self, tab_id: &str);
+    fn show_content(&mut self, ui: &mut egui::Ui);
+}
+
+pub fn draw_main_content(
+    ctx: &egui::Context,
+    layout: &LayoutConfig,
+    model: &mut dyn MainContentModel,
+) {
+    let _ = layout;
+    let theme = model.theme();
+    let props = model.props();
+
+    egui::CentralPanel::default()
+        .frame(egui::Frame::none().fill(theme.root_background))
+        .show(ctx, |ui| {
+            egui::TopBottomPanel::top("main_toolbar")
+                .resizable(false)
+                .frame(egui::Frame::none().fill(theme.root_background))
+                .show_separator_line(false)
+                .show_inside(ui, |ui| {
+                    ui.set_height(52.0);
+                    ui.with_layout(Layout::left_to_right(Align::Center), |ui| {
+                        if let Some(title) = props.title.as_ref() {
+                            ui.strong(RichText::new(title).color(theme.text_primary).size(18.0));
+                        }
+                        if let Some(subtitle) = props.subtitle.as_ref() {
+                            ui.add_space(12.0);
+                            ui.label(RichText::new(subtitle).color(theme.text_muted));
+                        }
+                        ui.add_space(ui.available_width());
+                        for action in props.actions.iter() {
+                            let mut button = egui::Button::new(match &action.icon {
+                                Some(icon) => RichText::new(format!("{} {}", icon, action.label))
+                                    .color(theme.text_primary),
+                                None => {
+                                    RichText::new(action.label.clone()).color(theme.text_primary)
+                                }
+                            })
+                            .min_size(egui::vec2(0.0, 30.0));
+                            if !action.enabled {
+                                button = button.sense(Sense::hover());
+                            }
+                            if ui.add(button).clicked() && action.enabled {
+                                model.on_action(&action.id);
+                            }
+                        }
+                    });
+                });
+
+            if !props.tabs.is_empty() {
+                egui::TopBottomPanel::top("main_tabs")
+                    .resizable(false)
+                    .frame(
+                        egui::Frame::none()
+                            .fill(theme.root_background)
+                            .inner_margin(Margin::symmetric(0.0, 6.0)),
+                    )
+                    .show_separator_line(false)
+                    .show_inside(ui, |ui| {
+                        ui.horizontal(|ui| {
+                            for tab in props.tabs.iter() {
+                                let is_active = props
+                                    .active_tab
+                                    .as_ref()
+                                    .map(|id| id == &tab.id)
+                                    .unwrap_or(false);
+                                let button = egui::Button::new(match &tab.icon {
+                                    Some(icon) => {
+                                        let text = if is_active {
+                                            RichText::new(format!("{} {}", icon, tab.label.clone()))
+                                                .color(theme.text_primary)
+                                                .strong()
+                                        } else {
+                                            RichText::new(format!("{} {}", icon, tab.label.clone()))
+                                                .color(theme.text_primary)
+                                        };
+                                        text
+                                    }
+                                    None => {
+                                        let mut text = RichText::new(tab.label.clone())
+                                            .color(theme.text_primary);
+                                        if is_active {
+                                            text = text.strong();
+                                        }
+                                        text
+                                    }
+                                })
+                                .fill(if is_active {
+                                    theme.accent_soft
+                                } else {
+                                    theme.root_background
+                                })
+                                .min_size(egui::vec2(0.0, 28.0));
+                                if ui.add(button).clicked() {
+                                    model.on_tab_selected(&tab.id);
+                                }
+                            }
+                        });
+                    });
+            }
+
+            egui::CentralPanel::default()
+                .frame(main_surface_frame(&theme))
+                .show_inside(ui, |ui| {
+                    ui.set_width(ui.available_width());
+                    ui.set_min_height(ui.available_height());
+                    model.show_content(ui);
+                });
+        });
+}

--- a/templates/vscode_shell/src/components/mod.rs
+++ b/templates/vscode_shell/src/components/mod.rs
@@ -1,0 +1,13 @@
+pub mod header;
+pub mod main_content;
+pub mod resource_panel;
+pub mod sidebar;
+
+pub use header::{draw_header, HeaderAction, HeaderModel, HeaderProps, SearchGroup, SearchResult};
+pub use main_content::{
+    draw_main_content, MainContentAction, MainContentModel, MainContentProps, MainContentTab,
+};
+pub use resource_panel::{
+    draw_resource_panel, ResourceItem, ResourcePanelModel, ResourcePanelProps, ResourceSectionProps,
+};
+pub use sidebar::{draw_sidebar, NavigationModel, SidebarItem, SidebarProps, SidebarSection};

--- a/templates/vscode_shell/src/components/resource_panel.rs
+++ b/templates/vscode_shell/src/components/resource_panel.rs
@@ -1,0 +1,159 @@
+use eframe::egui::{self, Color32, Frame, Margin, RichText, Rounding, Sense, Stroke};
+
+use crate::layout::{LayoutConfig, ShellTheme};
+
+#[derive(Clone, Debug)]
+pub struct ResourcePanelProps {
+    pub title: Option<String>,
+    pub sections: Vec<ResourceSectionProps>,
+    pub collapse_button_tooltip: Option<String>,
+}
+
+impl Default for ResourcePanelProps {
+    fn default() -> Self {
+        Self {
+            title: None,
+            sections: Vec::new(),
+            collapse_button_tooltip: None,
+        }
+    }
+}
+
+#[derive(Clone, Debug)]
+pub struct ResourceSectionProps {
+    pub id: String,
+    pub title: String,
+    pub description: Option<String>,
+    pub items: Vec<ResourceItem>,
+}
+
+#[derive(Clone, Debug)]
+pub struct ResourceItem {
+    pub id: String,
+    pub title: String,
+    pub subtitle: Option<String>,
+    pub selected: bool,
+}
+
+pub trait ResourcePanelModel {
+    fn theme(&self) -> ShellTheme;
+    fn props(&self) -> ResourcePanelProps;
+    fn on_item_selected(&mut self, item_id: &str);
+}
+
+pub fn draw_resource_panel(
+    ctx: &egui::Context,
+    layout: &mut LayoutConfig,
+    model: &mut dyn ResourcePanelModel,
+) {
+    if !layout.show_resource_panel {
+        return;
+    }
+
+    let theme = model.theme();
+    let props = model.props();
+
+    if layout.resource_collapsed() {
+        egui::SidePanel::right("resource_panel_collapsed")
+            .resizable(false)
+            .exact_width(36.0)
+            .frame(
+                Frame::none()
+                    .fill(theme.surface_background)
+                    .stroke(Stroke::new(1.0, theme.border))
+                    .inner_margin(Margin::same(6.0)),
+            )
+            .show(ctx, |ui| {
+                if ui.button("◀").on_hover_text("Expandir recursos").clicked() {
+                    layout.emit_resource_signal(false);
+                }
+            });
+        return;
+    }
+
+    egui::SidePanel::right("resource_panel")
+        .resizable(false)
+        .exact_width(layout.resource_width)
+        .frame(
+            Frame::none()
+                .fill(theme.surface_background)
+                .stroke(Stroke::new(1.0, theme.border))
+                .inner_margin(Margin {
+                    left: 16.0,
+                    right: 16.0,
+                    top: 18.0,
+                    bottom: 18.0,
+                })
+                .rounding(Rounding::same(12.0)),
+        )
+        .show(ctx, |ui| {
+            ui.set_width(ui.available_width());
+            ui.horizontal(|ui| {
+                if let Some(title) = props.title.as_ref() {
+                    ui.strong(RichText::new(title).color(theme.text_primary));
+                }
+                ui.add_space(ui.available_width());
+                let button = egui::Button::new("▶").min_size(egui::vec2(24.0, 24.0));
+                let mut response = ui.add(button);
+                if let Some(tooltip) = props.collapse_button_tooltip.as_ref() {
+                    response = response.on_hover_text(tooltip);
+                }
+                if response.clicked() {
+                    layout.emit_resource_signal(true);
+                }
+            });
+
+            ui.add_space(12.0);
+            egui::ScrollArea::vertical()
+                .id_source("shell_resource_panel_scroll")
+                .auto_shrink([false, false])
+                .show(ui, |ui| {
+                    for section in props.sections {
+                        ui.label(
+                            RichText::new(section.title)
+                                .color(theme.text_muted)
+                                .size(12.0),
+                        );
+                        if let Some(description) = section.description.as_ref() {
+                            ui.small(RichText::new(description).color(theme.text_muted));
+                        }
+                        ui.add_space(6.0);
+                        for item in section.items {
+                            let response = resource_entry(ui, &theme, &item);
+                            if response.clicked() {
+                                model.on_item_selected(&item.id);
+                            }
+                        }
+                        ui.add_space(16.0);
+                    }
+                });
+        });
+}
+
+fn resource_entry(ui: &mut egui::Ui, theme: &ShellTheme, item: &ResourceItem) -> egui::Response {
+    let frame = Frame::none()
+        .fill(if item.selected {
+            theme.accent_soft
+        } else {
+            Color32::from_rgba_unmultiplied(0, 0, 0, 0)
+        })
+        .stroke(Stroke::new(1.0, theme.border))
+        .rounding(Rounding::same(10.0))
+        .inner_margin(Margin::symmetric(12.0, 8.0));
+
+    let response = frame.show(ui, |ui| {
+        ui.vertical(|ui| {
+            ui.label(
+                RichText::new(&item.title)
+                    .color(theme.text_primary)
+                    .strong(),
+            );
+            if let Some(subtitle) = item.subtitle.as_ref() {
+                ui.small(RichText::new(subtitle).color(theme.text_muted));
+            }
+        });
+    });
+
+    let response = ui.interact(response.response.rect, response.response.id, Sense::click());
+    response
+}

--- a/templates/vscode_shell/src/components/sidebar.rs
+++ b/templates/vscode_shell/src/components/sidebar.rs
@@ -1,0 +1,157 @@
+use eframe::egui::{self, Margin, RichText, Rounding};
+
+use crate::layout::{LayoutConfig, ShellTheme};
+
+#[derive(Clone, Debug)]
+pub struct SidebarProps {
+    pub title: Option<String>,
+    pub sections: Vec<SidebarSection>,
+    pub collapse_button_tooltip: Option<String>,
+}
+
+impl Default for SidebarProps {
+    fn default() -> Self {
+        Self {
+            title: None,
+            sections: Vec::new(),
+            collapse_button_tooltip: None,
+        }
+    }
+}
+
+#[derive(Clone, Debug)]
+pub struct SidebarSection {
+    pub id: String,
+    pub title: String,
+    pub items: Vec<SidebarItem>,
+}
+
+#[derive(Clone, Debug)]
+pub struct SidebarItem {
+    pub id: String,
+    pub label: String,
+    pub description: Option<String>,
+    pub icon: Option<String>,
+    pub badge: Option<String>,
+    pub selected: bool,
+}
+
+pub trait NavigationModel {
+    fn theme(&self) -> ShellTheme;
+    fn props(&self) -> SidebarProps;
+    fn on_item_selected(&mut self, item_id: &str);
+}
+
+pub fn draw_sidebar(
+    ctx: &egui::Context,
+    layout: &mut LayoutConfig,
+    model: &mut dyn NavigationModel,
+) {
+    if !layout.show_navigation {
+        return;
+    }
+
+    let theme = model.theme();
+    let props = model.props();
+
+    if layout.navigation_collapsed() {
+        egui::SidePanel::left("navigation_panel_collapsed")
+            .resizable(false)
+            .exact_width(36.0)
+            .frame(
+                egui::Frame::none()
+                    .fill(theme.surface_background)
+                    .stroke(egui::Stroke::new(1.0, theme.border))
+                    .inner_margin(Margin::same(6.0)),
+            )
+            .show(ctx, |ui| {
+                if ui.button("▶").on_hover_text("Expandir panel").clicked() {
+                    layout.emit_navigation_signal(false);
+                }
+            });
+        return;
+    }
+
+    egui::SidePanel::left("navigation_panel")
+        .resizable(false)
+        .exact_width(layout.navigation_width)
+        .frame(
+            egui::Frame::none()
+                .fill(theme.surface_background)
+                .stroke(egui::Stroke::new(1.0, theme.border))
+                .inner_margin(Margin {
+                    left: 16.0,
+                    right: 16.0,
+                    top: 18.0,
+                    bottom: 18.0,
+                })
+                .rounding(Rounding::same(12.0)),
+        )
+        .show(ctx, |ui| {
+            ui.set_width(ui.available_width());
+
+            ui.horizontal(|ui| {
+                if let Some(title) = props.title.as_ref() {
+                    ui.strong(RichText::new(title).color(theme.text_primary));
+                }
+                ui.add_space(ui.available_width());
+                let button = egui::Button::new("◀").min_size(egui::vec2(24.0, 24.0));
+                let mut response = ui.add(button);
+                if let Some(tooltip) = props.collapse_button_tooltip.as_ref() {
+                    response = response.on_hover_text(tooltip);
+                }
+                if response.clicked() {
+                    layout.emit_navigation_signal(true);
+                }
+            });
+
+            ui.add_space(12.0);
+            egui::ScrollArea::vertical()
+                .id_source("shell_sidebar_scroll")
+                .auto_shrink([false, false])
+                .show(ui, |ui| {
+                    for section in props.sections {
+                        ui.label(
+                            RichText::new(section.title)
+                                .color(theme.text_muted)
+                                .size(12.0),
+                        );
+                        ui.add_space(6.0);
+                        for item in section.items {
+                            let response = nav_entry(ui, &theme, &item);
+                            if response.clicked() {
+                                model.on_item_selected(&item.id);
+                            }
+                        }
+                        ui.add_space(14.0);
+                    }
+                });
+        });
+}
+
+fn nav_entry(ui: &mut egui::Ui, theme: &ShellTheme, item: &SidebarItem) -> egui::Response {
+    let mut text = RichText::new(item.label.clone()).color(theme.text_primary);
+    if item.selected {
+        text = text.strong();
+    }
+
+    let button = egui::Button::new(match &item.icon {
+        Some(icon) => RichText::new(format!("{} {}", icon, text.text())).color(theme.text_primary),
+        None => text,
+    })
+    .fill(if item.selected {
+        theme.accent_soft
+    } else {
+        theme.surface_background
+    })
+    .min_size(egui::vec2(0.0, 32.0));
+
+    let mut response = ui.add(button);
+    if let Some(description) = &item.description {
+        response = response.on_hover_text(description);
+    }
+    if let Some(badge) = &item.badge {
+        response = response.on_hover_text(format!("{}", badge));
+    }
+    response
+}

--- a/templates/vscode_shell/src/examples.rs
+++ b/templates/vscode_shell/src/examples.rs
@@ -1,0 +1,155 @@
+//! Ejemplos de integración del shell reutilizable.
+//!
+//! ```no_run
+//! use eframe::egui;
+//! use vscode_shell::{
+//!     components::{
+//!         draw_header, draw_main_content, draw_resource_panel, draw_sidebar, HeaderAction,
+//!         HeaderModel, HeaderProps, MainContentAction, MainContentModel, MainContentProps,
+//!         MainContentTab, NavigationModel, ResourcePanelModel, ResourcePanelProps,
+//!         ResourceSectionProps, SearchGroup, SearchResult, SidebarItem, SidebarProps,
+//!         SidebarSection,
+//!     },
+//!     layout::{LayoutConfig, ShellTheme},
+//!     AppShell,
+//! };
+//!
+//! struct DemoShell {
+//!     layout: LayoutConfig,
+//! }
+//!
+//! impl DemoShell {
+//!     fn new() -> Self {
+//!         Self {
+//!             layout: LayoutConfig::default(),
+//!         }
+//!     }
+//! }
+//!
+//! impl HeaderModel for DemoShell {
+//!     fn theme(&self) -> ShellTheme {
+//!         ShellTheme::default()
+//!     }
+//!
+//!     fn props(&self) -> HeaderProps {
+//!         HeaderProps {
+//!             title: "Demo".into(),
+//!             subtitle: Some("Shell mínimo".into()),
+//!             search_placeholder: Some("Buscar".into()),
+//!             actions: vec![HeaderAction::new("settings", "Ajustes")],
+//!             logo_acronym: Some("DM".into()),
+//!         }
+//!     }
+//!
+//!     fn search_value(&self) -> String {
+//!         String::new()
+//!     }
+//!
+//!     fn set_search_value(&mut self, _value: String) {}
+//!
+//!     fn search_palette(&self) -> Vec<SearchGroup> {
+//!         vec![SearchGroup {
+//!             id: "welcome".into(),
+//!             title: "Recientes".into(),
+//!             results: vec![SearchResult {
+//!                 id: "first".into(),
+//!                 title: "Abrir panel principal".into(),
+//!                 subtitle: "Demostración".into(),
+//!                 action_hint: Some("Enter para abrir".into()),
+//!             }],
+//!         }]
+//!     }
+//!
+//!     fn on_search_result(&mut self, _result_id: &str) {}
+//!
+//!     fn on_action(&mut self, _action_id: &str) {}
+//! }
+//!
+//! impl NavigationModel for DemoShell {
+//!     fn theme(&self) -> ShellTheme {
+//!         ShellTheme::default()
+//!     }
+//!
+//!     fn props(&self) -> SidebarProps {
+//!         SidebarProps {
+//!             title: Some("Navegación".into()),
+//!             sections: vec![SidebarSection {
+//!                 id: "main".into(),
+//!                 title: "General".into(),
+//!                 items: vec![SidebarItem {
+//!                     id: "chat".into(),
+//!                     label: "Chat".into(),
+//!                     description: None,
+//!                     icon: Some("💬".into()),
+//!                     badge: None,
+//!                     selected: true,
+//!                 }],
+//!             }],
+//!             collapse_button_tooltip: Some("Ocultar navegación".into()),
+//!         }
+//!     }
+//!
+//!     fn on_item_selected(&mut self, _item_id: &str) {}
+//! }
+//!
+//! impl ResourcePanelModel for DemoShell {
+//!     fn theme(&self) -> ShellTheme {
+//!         ShellTheme::default()
+//!     }
+//!
+//!     fn props(&self) -> ResourcePanelProps {
+//!         ResourcePanelProps {
+//!             title: Some("Recursos".into()),
+//!             sections: vec![ResourceSectionProps {
+//!                 id: "favorites".into(),
+//!                 title: "Favoritos".into(),
+//!                 description: None,
+//!                 items: Vec::new(),
+//!             }],
+//!             collapse_button_tooltip: Some("Ocultar recursos".into()),
+//!         }
+//!     }
+//!
+//!     fn on_item_selected(&mut self, _item_id: &str) {}
+//! }
+//!
+//! impl MainContentModel for DemoShell {
+//!     fn theme(&self) -> ShellTheme {
+//!         ShellTheme::default()
+//!     }
+//!
+//!     fn props(&self) -> MainContentProps {
+//!         MainContentProps {
+//!             title: Some("Panel principal".into()),
+//!             subtitle: Some("El contenido se inyecta como closure".into()),
+//!             actions: vec![MainContentAction::new("refresh", "Actualizar")],
+//!             tabs: vec![MainContentTab {
+//!                 id: "chat".into(),
+//!                 label: "Chat".into(),
+//!                 icon: None,
+//!             }],
+//!             active_tab: Some("chat".into()),
+//!         }
+//!     }
+//!
+//!     fn on_action(&mut self, _action_id: &str) {}
+//!
+//!     fn on_tab_selected(&mut self, _tab_id: &str) {}
+//!
+//!     fn show_content(&mut self, ui: &mut egui::Ui) {
+//!         ui.label("Contenido renderizado desde el consumidor");
+//!     }
+//! }
+//!
+//! impl AppShell for DemoShell {
+//!     fn init(&mut self, _cc: &eframe::CreationContext<'_>) {}
+//!
+//!     fn update(&mut self, ctx: &egui::Context) {
+//!         draw_header(ctx, &self.layout, self);
+//!         let mut layout = self.layout.clone();
+//!         draw_sidebar(ctx, &mut layout, self);
+//!         draw_resource_panel(ctx, &mut layout, self);
+//!         draw_main_content(ctx, &layout, self);
+//!     }
+//! }
+//! ```

--- a/templates/vscode_shell/src/layout.rs
+++ b/templates/vscode_shell/src/layout.rs
@@ -1,0 +1,108 @@
+use eframe::egui::{self, Color32, Margin, Stroke};
+
+/// Conjunto mínimo de tokens de estilo utilizados por los componentes del shell.
+#[derive(Clone, Debug)]
+pub struct ShellTheme {
+    pub root_background: Color32,
+    pub surface_background: Color32,
+    pub header_background: Color32,
+    pub border: Color32,
+    pub text_primary: Color32,
+    pub text_muted: Color32,
+    pub accent: Color32,
+    pub accent_soft: Color32,
+}
+
+impl Default for ShellTheme {
+    fn default() -> Self {
+        Self {
+            root_background: Color32::from_rgb(24, 26, 30),
+            surface_background: Color32::from_rgb(32, 34, 38),
+            header_background: Color32::from_rgb(40, 42, 48),
+            border: Color32::from_rgba_unmultiplied(70, 72, 78, 160),
+            text_primary: Color32::from_rgb(232, 233, 239),
+            text_muted: Color32::from_rgb(172, 176, 184),
+            accent: Color32::from_rgb(65, 148, 245),
+            accent_soft: Color32::from_rgb(48, 86, 128),
+        }
+    }
+}
+
+/// Controla la visibilidad y el ancho de los paneles principales del layout.
+#[derive(Clone, Debug)]
+pub struct LayoutConfig {
+    pub show_header: bool,
+    pub show_navigation: bool,
+    pub show_resource_panel: bool,
+    pub navigation_width: f32,
+    pub resource_width: f32,
+    navigation_collapsed: bool,
+    resource_collapsed: bool,
+    navigation_signal: Option<bool>,
+    resource_signal: Option<bool>,
+}
+
+impl Default for LayoutConfig {
+    fn default() -> Self {
+        Self {
+            show_header: true,
+            show_navigation: true,
+            show_resource_panel: true,
+            navigation_width: 280.0,
+            resource_width: 320.0,
+            navigation_collapsed: false,
+            resource_collapsed: false,
+            navigation_signal: None,
+            resource_signal: None,
+        }
+    }
+}
+
+impl LayoutConfig {
+    pub fn navigation_collapsed(&self) -> bool {
+        self.navigation_collapsed
+    }
+
+    pub fn resource_collapsed(&self) -> bool {
+        self.resource_collapsed
+    }
+
+    pub fn set_navigation_collapsed(&mut self, collapsed: bool) {
+        self.navigation_collapsed = collapsed;
+    }
+
+    pub fn set_resource_collapsed(&mut self, collapsed: bool) {
+        self.resource_collapsed = collapsed;
+    }
+
+    pub fn emit_navigation_signal(&mut self, collapsed: bool) {
+        self.navigation_collapsed = collapsed;
+        self.navigation_signal = Some(collapsed);
+    }
+
+    pub fn emit_resource_signal(&mut self, collapsed: bool) {
+        self.resource_collapsed = collapsed;
+        self.resource_signal = Some(collapsed);
+    }
+
+    pub fn take_navigation_signal(&mut self) -> Option<bool> {
+        self.navigation_signal.take()
+    }
+
+    pub fn take_resource_signal(&mut self) -> Option<bool> {
+        self.resource_signal.take()
+    }
+}
+
+/// Envoltorio utilitario que pinta un panel principal centralizado.
+pub(crate) fn main_surface_frame(theme: &ShellTheme) -> egui::Frame {
+    egui::Frame::none()
+        .fill(theme.surface_background)
+        .stroke(Stroke::new(1.0, theme.border))
+        .inner_margin(Margin {
+            left: 18.0,
+            right: 18.0,
+            top: 18.0,
+            bottom: 14.0,
+        })
+}

--- a/templates/vscode_shell/src/lib.rs
+++ b/templates/vscode_shell/src/lib.rs
@@ -1,6 +1,10 @@
 use eframe::egui;
 use eframe::{App, CreationContext, Frame, NativeOptions};
 
+pub mod components;
+pub mod examples;
+pub mod layout;
+
 /// Trait que abstrae el estado y comportamiento de una shell basada en egui.
 pub trait AppShell: 'static {
     /// Inicializa el estado con el contexto de creación de eframe.


### PR DESCRIPTION
## Summary
- extract the header, sidebar, resource panel and main content shells into reusable components inside the `vscode_shell` template crate
- add a `LayoutConfig` and lightweight model traits so the runtime state injects props and reacts to callbacks without leaking `AppState`
- adapt the application to the new components, bridge the existing theme, and document usage with a README update and runnable examples

## Testing
- cargo check

------
https://chatgpt.com/codex/tasks/task_e_68da57d90d988333a4bed8a808f87202