### PR TITLE
Refactor app state into modular substructures

### DIFF
--- a/src/state/automation.rs
+++ b/src/state/automation.rs
@@ -1,0 +1,88 @@
+use super::{
+    feature::{CommandRegistry, FeatureModule},
+    AutomationWorkflowBoard, CronBoardState, EventAutomationState, ExternalIntegrationsState,
+    LogEntry, NavigationNode, NavigationRegistry, NavigationTarget, ScheduledReminder,
+};
+use crate::config::AppConfig;
+
+pub struct AutomationState {
+    pub cron_board: CronBoardState,
+    pub workflows: AutomationWorkflowBoard,
+    pub scheduled_reminders: Vec<ScheduledReminder>,
+    pub event_automation: EventAutomationState,
+    pub external_integrations: ExternalIntegrationsState,
+    pub activity_logs: Vec<LogEntry>,
+}
+
+impl AutomationState {
+    pub fn from_config(_config: &AppConfig) -> Self {
+        Self {
+            cron_board: CronBoardState::with_tasks(super::default_scheduled_tasks()),
+            workflows: AutomationWorkflowBoard::with_workflows(
+                super::default_automation_workflows(),
+            ),
+            scheduled_reminders: super::default_scheduled_reminders(),
+            event_automation: EventAutomationState::default(),
+            external_integrations: ExternalIntegrationsState::default(),
+            activity_logs: super::default_logs(),
+        }
+    }
+
+    pub fn push_activity(&mut self, entry: LogEntry) {
+        self.activity_logs.push(entry);
+        const MAX_ACTIVITY_LOGS: usize = 200;
+        if self.activity_logs.len() > MAX_ACTIVITY_LOGS {
+            let overflow = self.activity_logs.len() - MAX_ACTIVITY_LOGS;
+            self.activity_logs.drain(0..overflow);
+        }
+    }
+}
+
+impl FeatureModule for AutomationState {
+    fn register_navigation(&self, registry: &mut NavigationRegistry) {
+        let nodes = [
+            (
+                NavigationTarget::main(super::MainView::CronScheduler),
+                "Cron",
+                "⏱️",
+                "Programa y supervisa tareas automáticas.",
+                1,
+            ),
+            (
+                NavigationTarget::main(super::MainView::ActivityFeed),
+                "Actividad",
+                "📈",
+                "Consulta los eventos recientes del sistema.",
+                2,
+            ),
+            (
+                NavigationTarget::main(super::MainView::DebugConsole),
+                "Debug",
+                "🪲",
+                "Accede a diagnósticos y registros de depuración.",
+                3,
+            ),
+        ];
+
+        for (target, label, icon, description, order) in nodes {
+            registry.register_node(NavigationNode {
+                id: target.id(),
+                label: label.to_string(),
+                description: Some(description.to_string()),
+                icon: Some(icon.to_string()),
+                badge: None,
+                target,
+                order,
+                section_id: super::SECTION_PRIMARY.to_string(),
+            });
+        }
+    }
+
+    fn register_commands(&self, registry: &mut CommandRegistry) {
+        registry.extend([
+            super::CustomCommandAction::ShowSystemStatus,
+            super::CustomCommandAction::ShowSystemDiagnostics,
+            super::CustomCommandAction::ShowUsageStatistics,
+        ]);
+    }
+}

--- a/src/state/chat.rs
+++ b/src/state/chat.rs
@@ -1,0 +1,99 @@
+use std::sync::mpsc::{self, Receiver, Sender};
+
+use super::{
+    feature::{CommandRegistry, FeatureModule},
+    navigation::NavigationNode,
+    ChatMessage, ChatRoutingState, CustomCommand, CustomCommandAction, LocalInstallMessage,
+    MainView, NavigationRegistry, NavigationTarget, PendingLocalInstall, PendingProviderCall,
+    ProviderResponse, SECTION_PRIMARY,
+};
+use crate::config::AppConfig;
+
+pub struct ChatState {
+    pub input: String,
+    pub messages: Vec<ChatMessage>,
+    pub custom_commands: Vec<CustomCommand>,
+    pub new_command: String,
+    pub new_command_action: CustomCommandAction,
+    pub command_feedback: Option<String>,
+    pub show_functions_modal: bool,
+    pub routing: ChatRoutingState,
+    pub pending_copy_conversation: bool,
+    pub provider_response_rx: Receiver<ProviderResponse>,
+    pub provider_response_tx: Sender<ProviderResponse>,
+    pub local_install_rx: Receiver<LocalInstallMessage>,
+    pub local_install_tx: Sender<LocalInstallMessage>,
+    pub pending_local_installs: Vec<PendingLocalInstall>,
+    pub pending_provider_calls: Vec<PendingProviderCall>,
+    pub next_provider_call_id: u64,
+}
+
+impl ChatState {
+    pub fn from_config(config: &AppConfig) -> Self {
+        let (provider_response_tx, provider_response_rx) = mpsc::channel();
+        let (local_install_tx, local_install_rx) = mpsc::channel();
+
+        Self {
+            input: String::new(),
+            messages: vec![ChatMessage::default()],
+            custom_commands: if config.custom_commands.is_empty() {
+                super::default_custom_commands()
+            } else {
+                config.custom_commands.clone()
+            },
+            new_command: String::new(),
+            new_command_action: CustomCommandAction::ShowCurrentTime,
+            command_feedback: None,
+            show_functions_modal: false,
+            routing: ChatRoutingState::default(),
+            pending_copy_conversation: false,
+            provider_response_rx,
+            provider_response_tx,
+            local_install_rx,
+            local_install_tx,
+            pending_local_installs: Vec::new(),
+            pending_provider_calls: Vec::new(),
+            next_provider_call_id: 0,
+        }
+    }
+
+    pub fn available_actions(&self) -> impl Iterator<Item = CustomCommandAction> + '_ {
+        DEFAULT_CUSTOM_ACTIONS.iter().copied()
+    }
+}
+
+impl FeatureModule for ChatState {
+    fn register_navigation(&self, registry: &mut NavigationRegistry) {
+        let target = NavigationTarget::main(MainView::ChatMultimodal);
+        registry.register_node(NavigationNode {
+            id: target.id(),
+            label: "Chat multimodal".into(),
+            description: Some("Conversa con JungleMonkAI en modo multimodal.".into()),
+            icon: Some("💬".into()),
+            badge: None,
+            target,
+            order: 0,
+            section_id: SECTION_PRIMARY.to_string(),
+        });
+    }
+
+    fn register_commands(&self, registry: &mut CommandRegistry) {
+        registry.extend(self.available_actions());
+    }
+}
+
+pub const DEFAULT_CUSTOM_ACTIONS: &[CustomCommandAction] = &[
+    CustomCommandAction::ShowCurrentTime,
+    CustomCommandAction::ShowSystemStatus,
+    CustomCommandAction::ShowSystemDiagnostics,
+    CustomCommandAction::ShowUsageStatistics,
+    CustomCommandAction::ListActiveProjects,
+    CustomCommandAction::ListConfiguredProfiles,
+    CustomCommandAction::ShowCacheConfiguration,
+    CustomCommandAction::ListAvailableModels,
+    CustomCommandAction::ShowGithubSummary,
+    CustomCommandAction::ShowMemorySettings,
+    CustomCommandAction::ShowActiveProviders,
+    CustomCommandAction::ShowJarvisStatus,
+    CustomCommandAction::ShowCommandHelp,
+];

--- a/src/state/feature.rs
+++ b/src/state/feature.rs
@@ -1,0 +1,33 @@
+use super::{CustomCommandAction, NavigationRegistry};
+
+/// Registra comandos personalizados aportados por los módulos de estado.
+#[derive(Default)]
+pub struct CommandRegistry {
+    actions: Vec<CustomCommandAction>,
+}
+
+impl CommandRegistry {
+    pub fn new() -> Self {
+        Self {
+            actions: Vec::new(),
+        }
+    }
+
+    pub fn extend(&mut self, actions: impl IntoIterator<Item = CustomCommandAction>) {
+        for action in actions {
+            if !self.actions.contains(&action) {
+                self.actions.push(action);
+            }
+        }
+    }
+
+    pub fn actions(&self) -> &[CustomCommandAction] {
+        &self.actions
+    }
+}
+
+pub trait FeatureModule {
+    fn register_navigation(&self, _registry: &mut NavigationRegistry) {}
+
+    fn register_commands(&self, _registry: &mut CommandRegistry) {}
+}

--- a/src/state/resources.rs
+++ b/src/state/resources.rs
@@ -1,0 +1,272 @@
+use std::collections::BTreeMap;
+
+use super::{
+    feature::{CommandRegistry, FeatureModule},
+    navigation::{NavigationNode, NavigationTarget},
+    AnthropicModel, LocalLibraryState, LocalModelCard, LocalModelIdentifier, LocalModelProvider,
+    LocalProviderState, NavigationRegistry, PersonalizationResourcesState, ProjectResourceCard,
+    ProjectResourceKind, RemoteCatalogState, RemoteProviderKind,
+};
+use crate::config::AppConfig;
+use crate::state::{InstalledLocalModel, JarvisRuntime};
+
+pub struct ResourceState {
+    pub selected_resource: Option<super::ResourceSection>,
+    pub local_provider_states: BTreeMap<LocalModelProvider, LocalProviderState>,
+    pub jarvis_model_path: String,
+    pub jarvis_install_dir: String,
+    pub jarvis_auto_start: bool,
+    pub jarvis_status: Option<String>,
+    pub installed_local_models: Vec<InstalledLocalModel>,
+    pub jarvis_selected_provider: LocalModelProvider,
+    pub jarvis_active_model: Option<LocalModelIdentifier>,
+    pub jarvis_runtime: Option<JarvisRuntime>,
+    pub jarvis_alias: String,
+    pub jarvis_respond_without_alias: bool,
+    pub claude_default_model: String,
+    pub claude_alias: String,
+    pub anthropic_test_status: Option<String>,
+    pub claude_available_models: Vec<AnthropicModel>,
+    pub claude_models_status: Option<String>,
+    pub openai_default_model: String,
+    pub openai_alias: String,
+    pub openai_test_status: Option<String>,
+    pub groq_default_model: String,
+    pub groq_alias: String,
+    pub groq_test_status: Option<String>,
+    pub remote_catalog: RemoteCatalogState,
+    pub local_library: LocalLibraryState,
+    pub personalization_resources: PersonalizationResourcesState,
+    pub personalization_feedback: Option<String>,
+    pub project_resources: Vec<ProjectResourceCard>,
+}
+
+impl ResourceState {
+    pub fn from_config(config: &AppConfig, profiles: &[String], projects: &[String]) -> Self {
+        let mut local_provider_states: BTreeMap<LocalModelProvider, LocalProviderState> =
+            BTreeMap::new();
+        for provider in LocalModelProvider::ALL {
+            let mut provider_state = LocalProviderState::from_config(provider, config);
+            if provider == LocalModelProvider::HuggingFace
+                && provider_state.search_query.trim().is_empty()
+            {
+                provider_state.models = vec![
+                    LocalModelCard::placeholder(
+                        LocalModelProvider::HuggingFace,
+                        "sentence-transformers/all-MiniLM-L6-v2",
+                    ),
+                    LocalModelCard::placeholder(
+                        LocalModelProvider::HuggingFace,
+                        "openai/whisper-small",
+                    ),
+                    LocalModelCard::placeholder(
+                        LocalModelProvider::HuggingFace,
+                        "stabilityai/stable-diffusion-xl",
+                    ),
+                ];
+            }
+            local_provider_states.insert(provider, provider_state);
+        }
+
+        let mut installed_local_models: Vec<InstalledLocalModel> = config
+            .jarvis
+            .installed_models
+            .iter()
+            .map(InstalledLocalModel::from_config)
+            .collect();
+        installed_local_models.sort_by(|a, b| b.installed_at.cmp(&a.installed_at));
+
+        let jarvis_active_model = config
+            .jarvis
+            .active_model
+            .as_ref()
+            .map(|value| LocalModelIdentifier::parse(value))
+            .or_else(|| {
+                installed_local_models
+                    .first()
+                    .map(|model| model.identifier.clone())
+            });
+
+        let jarvis_selected_provider = jarvis_active_model
+            .as_ref()
+            .map(|model| model.provider)
+            .unwrap_or(LocalModelProvider::HuggingFace);
+
+        let personalization_resources =
+            PersonalizationResourcesState::from_sources(profiles, projects, &Vec::new());
+
+        Self {
+            selected_resource: None,
+            local_provider_states,
+            jarvis_model_path: config.jarvis.model_path.clone(),
+            jarvis_install_dir: config.jarvis.install_dir.clone(),
+            jarvis_auto_start: config.jarvis.auto_start,
+            jarvis_status: None,
+            installed_local_models,
+            jarvis_selected_provider,
+            jarvis_active_model,
+            jarvis_runtime: None,
+            jarvis_alias: if config.jarvis.chat_alias.trim().is_empty() {
+                "jarvis".to_string()
+            } else {
+                config.jarvis.chat_alias.clone()
+            },
+            jarvis_respond_without_alias: config.jarvis.respond_without_alias,
+            claude_default_model: if config.anthropic.default_model.is_empty() {
+                "claude-3-opus-20240229".to_string()
+            } else {
+                config.anthropic.default_model.clone()
+            },
+            claude_alias: if config.anthropic.alias.is_empty() {
+                "claude".to_string()
+            } else {
+                config.anthropic.alias.clone()
+            },
+            anthropic_test_status: None,
+            claude_available_models: Vec::new(),
+            claude_models_status: None,
+            openai_default_model: if config.openai.default_model.is_empty() {
+                "gpt-4.1-mini".to_string()
+            } else {
+                config.openai.default_model.clone()
+            },
+            openai_alias: if config.openai.alias.is_empty() {
+                "gpt".to_string()
+            } else {
+                config.openai.alias.clone()
+            },
+            openai_test_status: None,
+            groq_default_model: if config.groq.default_model.is_empty() {
+                "llama3-70b-8192".to_string()
+            } else {
+                config.groq.default_model.clone()
+            },
+            groq_alias: if config.groq.alias.is_empty() {
+                "groq".to_string()
+            } else {
+                config.groq.alias.clone()
+            },
+            groq_test_status: None,
+            remote_catalog: RemoteCatalogState::default(),
+            local_library: LocalLibraryState::default(),
+            personalization_resources,
+            personalization_feedback: None,
+            project_resources: super::default_project_resources(),
+        }
+    }
+
+    pub fn ensure_library_selection(&mut self) {
+        if self.local_library.selection.is_none() {
+            self.local_library.selection = self.jarvis_active_model.clone();
+        }
+    }
+
+    pub fn project_resources_by_kind(&self, kind: ProjectResourceKind) -> Vec<ProjectResourceCard> {
+        self.project_resources
+            .iter()
+            .filter(|card| card.kind == kind)
+            .cloned()
+            .collect()
+    }
+}
+
+impl FeatureModule for ResourceState {
+    fn register_navigation(&self, registry: &mut NavigationRegistry) {
+        let remote_providers = [
+            RemoteProviderKind::Anthropic,
+            RemoteProviderKind::OpenAi,
+            RemoteProviderKind::Groq,
+        ];
+
+        for (index, provider) in remote_providers.into_iter().enumerate() {
+            let section = super::ResourceSection::RemoteCatalog(provider);
+            let metadata = section.metadata();
+            let label = metadata
+                .breadcrumb
+                .last()
+                .copied()
+                .unwrap_or(metadata.title);
+            let target = NavigationTarget::resource(section);
+            registry.register_node(NavigationNode {
+                id: target.id(),
+                label: label.to_string(),
+                description: Some(metadata.description.to_string()),
+                icon: Some("☁️".into()),
+                badge: None,
+                target,
+                order: index as u32,
+                section_id: super::SECTION_RESOURCES_REMOTE.to_string(),
+            });
+        }
+
+        for (index, provider) in LocalModelProvider::ALL.iter().enumerate() {
+            let section = super::ResourceSection::LocalCatalog(*provider);
+            let metadata = section.metadata();
+            let label = metadata
+                .breadcrumb
+                .last()
+                .copied()
+                .unwrap_or(metadata.title);
+            let target = NavigationTarget::resource(section);
+            registry.register_node(NavigationNode {
+                id: target.id(),
+                label: label.to_string(),
+                description: Some(metadata.description.to_string()),
+                icon: Some("💾".into()),
+                badge: None,
+                target,
+                order: index as u32,
+                section_id: super::SECTION_RESOURCES_LOCAL.to_string(),
+            });
+        }
+
+        let installed_nodes = [
+            (
+                super::ResourceSection::InstalledLocal,
+                "📦",
+                "Modelos y recursos ya disponibles en Jarvis",
+                0u32,
+            ),
+            (
+                super::ResourceSection::ConnectedProjects,
+                "🗂️",
+                "Proyectos conectados y su estado de sincronización",
+                1u32,
+            ),
+            (
+                super::ResourceSection::GithubRepositories,
+                "📁",
+                "Repositorios disponibles desde GitHub",
+                2u32,
+            ),
+        ];
+
+        for (section, icon, description, order) in installed_nodes {
+            let metadata = section.metadata();
+            let label = metadata
+                .breadcrumb
+                .last()
+                .copied()
+                .unwrap_or(metadata.title);
+            let target = NavigationTarget::resource(section);
+            registry.register_node(NavigationNode {
+                id: target.id(),
+                label: label.to_string(),
+                description: Some(description.into()),
+                icon: Some(icon.into()),
+                badge: None,
+                target,
+                order,
+                section_id: super::SECTION_RESOURCES_INSTALLED.to_string(),
+            });
+        }
+    }
+
+    fn register_commands(&self, registry: &mut CommandRegistry) {
+        registry.extend([
+            super::CustomCommandAction::ListAvailableModels,
+            super::CustomCommandAction::ShowJarvisStatus,
+            super::CustomCommandAction::ShowActiveProviders,
+        ]);
+    }
+}

--- a/src/ui/header.rs
+++ b/src/ui/header.rs
@@ -126,7 +126,7 @@ impl HeaderModel for AppHeader<'_> {
     fn on_action(&mut self, action_id: &str) {
         match action_id {
             "open_settings" => self.state.show_settings_modal = true,
-            "open_functions" => self.state.show_functions_modal = true,
+            "open_functions" => self.state.chat.show_functions_modal = true,
             _ => {}
         }
     }

--- a/src/ui/logs.rs
+++ b/src/ui/logs.rs
@@ -110,7 +110,7 @@ fn draw_logs_table(ui: &mut egui::Ui, state: &AppState) {
             });
         })
         .body(|mut body| {
-            for (index, entry) in state.activity_logs.iter().enumerate() {
+            for (index, entry) in state.automation.activity_logs.iter().enumerate() {
                 let bg = if index % 2 == 0 { row_even } else { row_odd };
                 body.row(32.0, |mut row| {
                     row.col(|ui| {

--- a/src/ui/modals.rs
+++ b/src/ui/modals.rs
@@ -1,4 +1,4 @@
-use crate::state::{AppState, AVAILABLE_CUSTOM_ACTIONS};
+use crate::state::AppState;
 use eframe::egui;
 
 pub fn draw_settings_modal(ctx: &egui::Context, state: &mut AppState) {
@@ -24,11 +24,11 @@ pub fn draw_settings_modal(ctx: &egui::Context, state: &mut AppState) {
 }
 
 pub fn draw_functions_modal(ctx: &egui::Context, state: &mut AppState) {
-    if !state.show_functions_modal {
+    if !state.chat.show_functions_modal {
         return;
     }
 
-    let mut is_open = state.show_functions_modal;
+    let mut is_open = state.chat.show_functions_modal;
     egui::Window::new("Available Functions")
         .collapsible(false)
         .resizable(true)
@@ -62,7 +62,8 @@ pub fn draw_functions_modal(ctx: &egui::Context, state: &mut AppState) {
                     ui.heading("Funciones personalizables");
                     ui.add_space(6.0);
 
-                    for action in AVAILABLE_CUSTOM_ACTIONS {
+                    for action in state.command_registry.actions() {
+                        let action = *action;
                         let doc = action.documentation();
                         ui.group(|ui| {
                             ui.strong(doc.signature);
@@ -90,7 +91,7 @@ pub fn draw_functions_modal(ctx: &egui::Context, state: &mut AppState) {
                 });
         });
 
-    state.show_functions_modal = is_open;
+    state.chat.show_functions_modal = is_open;
 }
 
 fn builtin_documentation() -> Vec<(&'static str, &'static str, &'static [&'static str])> {


### PR DESCRIPTION
## Summary
- split the monolithic app state into chat, automation, and resource modules that implement a shared `FeatureModule` trait and expose a centralized `CommandRegistry`
- refactor `AppState` initialization, persistence, and helper flows to delegate to the new sub-structures while rebuilding navigation and command registries from module hooks
- update chat, resource sidebar, modals, header, and logs UI code to consume the nested state layout and module-provided command metadata

## Testing
- `cargo check`


------
https://chatgpt.com/codex/tasks/task_e_68da7e01cee0833390da01d6465030d4