### PR TITLE
Refactor main content to use workbench view registry

### DIFF
--- a/src/state/automation.rs
+++ b/src/state/automation.rs
@@ -1,5 +1,5 @@
 use super::{
-    feature::{CommandRegistry, FeatureModule},
+    feature::{CommandRegistry, FeatureModule, WorkbenchRegistry},
     AutomationWorkflowBoard, CronBoardState, EventAutomationState, ExternalIntegrationsState,
     LogEntry, NavigationNode, NavigationRegistry, NavigationTarget, ScheduledReminder,
 };
@@ -84,5 +84,11 @@ impl FeatureModule for AutomationState {
             super::CustomCommandAction::ShowSystemDiagnostics,
             super::CustomCommandAction::ShowUsageStatistics,
         ]);
+    }
+
+    fn register_workbench_views(&self, registry: &mut WorkbenchRegistry) {
+        crate::ui::chat::register_cron_workbench_view(registry);
+        crate::ui::chat::register_activity_workbench_view(registry);
+        crate::ui::chat::register_debug_workbench_view(registry);
     }
 }

--- a/src/state/chat.rs
+++ b/src/state/chat.rs
@@ -1,7 +1,7 @@
 use std::sync::mpsc::{self, Receiver, Sender};
 
 use super::{
-    feature::{CommandRegistry, FeatureModule},
+    feature::{CommandRegistry, FeatureModule, WorkbenchRegistry},
     navigation::NavigationNode,
     ChatMessage, ChatRoutingState, CustomCommand, CustomCommandAction, LocalInstallMessage,
     MainView, NavigationRegistry, NavigationTarget, PendingLocalInstall, PendingProviderCall,
@@ -79,6 +79,10 @@ impl FeatureModule for ChatState {
 
     fn register_commands(&self, registry: &mut CommandRegistry) {
         registry.extend(self.available_actions());
+    }
+
+    fn register_workbench_views(&self, registry: &mut WorkbenchRegistry) {
+        crate::ui::chat::register_chat_workbench_view(registry);
     }
 }
 

--- a/src/state/feature.rs
+++ b/src/state/feature.rs
@@ -1,4 +1,7 @@
-use super::{CustomCommandAction, NavigationRegistry};
+use std::collections::HashMap;
+
+use super::{CustomCommandAction, MainView, NavigationRegistry};
+use crate::ui::workbench::WorkbenchView;
 
 /// Registra comandos personalizados aportados por los módulos de estado.
 #[derive(Default)]
@@ -26,8 +29,27 @@ impl CommandRegistry {
     }
 }
 
+pub struct WorkbenchRegistry<'a> {
+    views: &'a mut HashMap<MainView, Box<dyn WorkbenchView>>,
+}
+
+impl<'a> WorkbenchRegistry<'a> {
+    pub fn new(views: &'a mut HashMap<MainView, Box<dyn WorkbenchView>>) -> Self {
+        Self { views }
+    }
+
+    pub fn register_view<V>(&mut self, view: MainView, view_impl: V)
+    where
+        V: WorkbenchView + 'static,
+    {
+        self.views.insert(view, Box::new(view_impl));
+    }
+}
+
 pub trait FeatureModule {
     fn register_navigation(&self, _registry: &mut NavigationRegistry) {}
 
     fn register_commands(&self, _registry: &mut CommandRegistry) {}
+
+    fn register_workbench_views(&self, _registry: &mut WorkbenchRegistry) {}
 }

--- a/src/state/resources.rs
+++ b/src/state/resources.rs
@@ -1,7 +1,7 @@
 use std::collections::BTreeMap;
 
 use super::{
-    feature::{CommandRegistry, FeatureModule},
+    feature::{CommandRegistry, FeatureModule, WorkbenchRegistry},
     navigation::{NavigationNode, NavigationTarget},
     AnthropicModel, LocalLibraryState, LocalModelCard, LocalModelIdentifier, LocalModelProvider,
     LocalProviderState, NavigationRegistry, PersonalizationResourcesState, ProjectResourceCard,
@@ -268,5 +268,9 @@ impl FeatureModule for ResourceState {
             super::CustomCommandAction::ShowJarvisStatus,
             super::CustomCommandAction::ShowActiveProviders,
         ]);
+    }
+
+    fn register_workbench_views(&self, registry: &mut WorkbenchRegistry) {
+        crate::ui::chat::register_resource_workbench_view(registry);
     }
 }

--- a/src/ui/mod.rs
+++ b/src/ui/mod.rs
@@ -10,6 +10,7 @@ pub mod resource_sidebar;
 pub mod sidebar;
 pub mod tabs;
 pub mod theme;
+pub mod workbench;
 
 pub fn draw_ui(ctx: &egui::Context, state: &mut AppState) {
     if state.update_async_tasks() {

--- a/src/ui/workbench.rs
+++ b/src/ui/workbench.rs
@@ -1,0 +1,78 @@
+use crate::state::AppState;
+use eframe::egui;
+use vscode_shell::components::{MainContentAction, MainContentTab};
+
+/// Metadatos básicos que describen una vista registrada en el workbench.
+pub struct WorkbenchMetadata {
+    pub title: Option<String>,
+    pub subtitle: Option<String>,
+}
+
+impl WorkbenchMetadata {
+    pub fn new(title: impl Into<Option<String>>, subtitle: impl Into<Option<String>>) -> Self {
+        Self {
+            title: title.into(),
+            subtitle: subtitle.into(),
+        }
+    }
+}
+
+/// Describe el contrato mínimo que debe cumplir una vista para integrarse en el workbench.
+pub trait WorkbenchView {
+    /// Devuelve el título y subtítulo que se mostrarán en el encabezado del contenedor.
+    fn metadata(&self, state: &AppState) -> WorkbenchMetadata;
+
+    /// Lista de acciones disponibles para la vista actual.
+    fn actions(&self, state: &AppState) -> Vec<MainContentAction> {
+        default_layout_actions(state)
+    }
+
+    /// Define las pestañas visibles en el encabezado.
+    fn tabs(&self, _state: &AppState) -> Vec<MainContentTab> {
+        Vec::new()
+    }
+
+    /// Identificador de la pestaña activa, si aplica.
+    fn active_tab(&self, _state: &AppState) -> Option<String> {
+        None
+    }
+
+    /// Maneja la selección de una pestaña. Retorna `true` si fue atendida.
+    fn on_tab_selected(&self, _state: &mut AppState, _tab_id: &str) -> bool {
+        false
+    }
+
+    /// Maneja una acción del encabezado. Retorna `true` si fue atendida.
+    fn on_action(&self, _state: &mut AppState, _action_id: &str) -> bool {
+        false
+    }
+
+    /// Renderiza el contenido principal de la vista.
+    fn render(&self, ui: &mut egui::Ui, state: &mut AppState);
+}
+
+/// Genera las acciones de visibilidad de paneles comunes a todas las vistas.
+pub fn default_layout_actions(state: &AppState) -> Vec<MainContentAction> {
+    vec![
+        MainContentAction {
+            id: "toggle-navigation".into(),
+            label: if state.layout.navigation_collapsed() {
+                "Mostrar navegación".into()
+            } else {
+                "Ocultar navegación".into()
+            },
+            icon: Some("📂".into()),
+            enabled: true,
+        },
+        MainContentAction {
+            id: "toggle-resources".into(),
+            label: if state.layout.resource_collapsed() {
+                "Mostrar recursos".into()
+            } else {
+                "Ocultar recursos".into()
+            },
+            icon: Some("📚".into()),
+            enabled: true,
+        },
+    ]
+}


### PR DESCRIPTION
## Summary
- add a WorkbenchView trait and default layout actions to encapsulate workbench metadata and rendering
- store registered workbench views in AppState with module-driven registration and extension hooks
- refactor the main content panel to delegate metadata, actions, tabs, and rendering to registered views

## Testing
- cargo check

------
https://chatgpt.com/codex/tasks/task_e_68da8bd5f0248333825dc785dd17566d