### PR TITLE
Populate automation defaults and surface routing status

### DIFF
--- a/src/state/chat.rs
+++ b/src/state/chat.rs
@@ -33,7 +33,7 @@ impl ChatState {
         let (provider_response_tx, provider_response_rx) = mpsc::channel();
         let (local_install_tx, local_install_rx) = mpsc::channel();
 
-        Self {
+        let mut state = Self {
             input: String::new(),
             messages: vec![ChatMessage::default()],
             custom_commands: if config.custom_commands.is_empty() {
@@ -54,11 +54,29 @@ impl ChatState {
             pending_local_installs: Vec::new(),
             pending_provider_calls: Vec::new(),
             next_provider_call_id: 0,
-        }
+        };
+
+        let initial_provider = state
+            .routing
+            .message_override
+            .unwrap_or(state.routing.active_thread_provider);
+        state.messages.push(ChatMessage::system(format!(
+            "Canal predeterminado configurado en {}.",
+            initial_provider.display_name()
+        )));
+
+        state
     }
 
     pub fn available_actions(&self) -> impl Iterator<Item = CustomCommandAction> + '_ {
         DEFAULT_CUSTOM_ACTIONS.iter().copied()
+    }
+
+    pub fn current_route_display(&self) -> &'static str {
+        self.routing
+            .message_override
+            .unwrap_or(self.routing.active_thread_provider)
+            .display_name()
     }
 }
 


### PR DESCRIPTION
## Summary
- populate automation defaults using the bundled listeners and integrations data
- log a setup summary for automation and surface the active chat routing provider in navigation
- register the preferences workbench via initializer and expose the current routing label from chat state

## Testing
- `cargo check`


------
https://chatgpt.com/codex/tasks/task_e_68da9b58bee88333b5dafd64dd8c3ae1