### PR TITLE
Refactor chat routing to parse alias mentions and show provider metadata

### DIFF
--- a/src/state/chat.rs
+++ b/src/state/chat.rs
@@ -56,14 +56,13 @@ impl ChatState {
             next_provider_call_id: 0,
         };
 
-        let initial_provider = state
-            .routing
-            .message_override
-            .unwrap_or(state.routing.active_thread_provider);
-        state.messages.push(ChatMessage::system(format!(
-            "Canal predeterminado configurado en {}.",
-            initial_provider.display_name()
-        )));
+        let routing_hint = state.routing.status.clone().unwrap_or_else(|| {
+            "Menciona @claude, @openai o @groq para enrutar tus mensajes.".to_string()
+        });
+        state.routing.update_status(Some(routing_hint.clone()));
+        state
+            .messages
+            .push(ChatMessage::system(routing_hint.clone()));
 
         state
     }
@@ -72,11 +71,11 @@ impl ChatState {
         DEFAULT_CUSTOM_ACTIONS.iter().copied()
     }
 
-    pub fn current_route_display(&self) -> &'static str {
+    pub fn current_route_display(&self) -> String {
         self.routing
-            .message_override
-            .unwrap_or(self.routing.active_thread_provider)
-            .display_name()
+            .status
+            .clone()
+            .unwrap_or_else(|| "Rutas disponibles mediante menciones".to_string())
     }
 }
 


### PR DESCRIPTION
## Summary
- remove the active provider toggle and repurpose the routing state to surface alias-based guidance and navigation labels
- track the originating provider on pending and resolved chat messages while parsing @alias mentions to fan out invocations and return the residual text
- refresh the chat UI to show passive routing status, render provider headers from message metadata, and only forward leftover text to Jarvis

## Testing
- cargo fmt
- cargo check

------
https://chatgpt.com/codex/tasks/task_e_68dabf1a222c8333830cd790f8da6281