### PR TITLE
Tag Jarvis replies and simplify preferences

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -93,8 +93,6 @@ pub struct JarvisConfig {
     pub active_model: Option<String>,
     #[serde(default = "JarvisConfig::default_alias")]
     pub chat_alias: String,
-    #[serde(default)]
-    pub respond_without_alias: bool,
 }
 
 impl Default for JarvisConfig {
@@ -106,7 +104,6 @@ impl Default for JarvisConfig {
             installed_models: Vec::new(),
             active_model: None,
             chat_alias: Self::default_alias(),
-            respond_without_alias: false,
         }
     }
 }

--- a/src/state/chat.rs
+++ b/src/state/chat.rs
@@ -57,7 +57,7 @@ impl ChatState {
         };
 
         let routing_hint = state.routing.status.clone().unwrap_or_else(|| {
-            "Menciona @claude, @openai o @groq para enrutar tus mensajes.".to_string()
+            "Menciona @claude, @openai o @groq para enrutar tus mensajes. Jarvis responderá automáticamente etiquetando sus respuestas con @jarvis.".to_string()
         });
         state.routing.update_status(Some(routing_hint.clone()));
         state

--- a/src/state/resources.rs
+++ b/src/state/resources.rs
@@ -22,7 +22,6 @@ pub struct ResourceState {
     pub jarvis_active_model: Option<LocalModelIdentifier>,
     pub jarvis_runtime: Option<JarvisRuntime>,
     pub jarvis_alias: String,
-    pub jarvis_respond_without_alias: bool,
     pub claude_default_model: String,
     pub claude_alias: String,
     pub anthropic_test_status: Option<String>,
@@ -111,7 +110,6 @@ impl ResourceState {
             } else {
                 config.jarvis.chat_alias.clone()
             },
-            jarvis_respond_without_alias: config.jarvis.respond_without_alias,
             claude_default_model: if config.anthropic.default_model.is_empty() {
                 "claude-3-opus-20240229".to_string()
             } else {


### PR DESCRIPTION
## Summary
- remove the legacy "responder sin mención" toggle from configuration, resource state, and the local preferences view
- always forward residual chat text to Jarvis and tag his replies with @jarvis so the renderer can display and copy the mention consistently
- document the automatic Jarvis replies in the initial routing hint and update chat rendering helpers to avoid duplicated mentions

## Testing
- cargo check

------
https://chatgpt.com/codex/tasks/task_e_68dad2d76234833384b05e9e704edb83